### PR TITLE
Fix bugs in UI and refactor types and interfaces

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const TIMESTAMP = 'Timestamp';
+export const LATENCY = 'Latency';
+export const CPU_TIME = 'CPU Time';
+export const MEMORY_USAGE = 'Memory Usage';
+export const INDICES = 'Indices';
+export const SEARCH_TYPE = 'Search type';
+export const NODE_ID = 'Coordinator node ID';
+export const TOTAL_SHARDS = 'Total shards';

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@testing-library/dom": "^8.11.3",
     "@testing-library/user-event": "^14.4.3",
     "@types/react-dom": "^16.9.8",
+    "@types/object-hash": "^3.0.0",
     "@types/react-router-dom": "^5.3.2",
     "cypress": "9.5.4",
     "cypress-real-events": "1.7.6",

--- a/public/components/__snapshots__/app.test.tsx.snap
+++ b/public/components/__snapshots__/app.test.tsx.snap
@@ -452,7 +452,7 @@ exports[`<QueryInsightsDashboardsApp /> spec renders the component 1`] = `
                   aria-live="polite"
                   aria-sort="none"
                   class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_latency_1"
+                  data-test-subj="tableHeaderCell_measurements_1"
                   role="columnheader"
                   scope="col"
                 >
@@ -477,7 +477,7 @@ exports[`<QueryInsightsDashboardsApp /> spec renders the component 1`] = `
                   aria-live="polite"
                   aria-sort="none"
                   class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_cpu_2"
+                  data-test-subj="tableHeaderCell_measurements_2"
                   role="columnheader"
                   scope="col"
                 >
@@ -491,9 +491,9 @@ exports[`<QueryInsightsDashboardsApp /> spec renders the component 1`] = `
                     >
                       <span
                         class="euiTableCellContent__text"
-                        title="CPU usage"
+                        title="CPU Time"
                       >
-                        CPU usage
+                        CPU Time
                       </span>
                     </span>
                   </button>
@@ -502,7 +502,7 @@ exports[`<QueryInsightsDashboardsApp /> spec renders the component 1`] = `
                   aria-live="polite"
                   aria-sort="none"
                   class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_memory_3"
+                  data-test-subj="tableHeaderCell_measurements_3"
                   role="columnheader"
                   scope="col"
                 >
@@ -516,9 +516,9 @@ exports[`<QueryInsightsDashboardsApp /> spec renders the component 1`] = `
                     >
                       <span
                         class="euiTableCellContent__text"
-                        title="Memory"
+                        title="Memory Usage"
                       >
-                        Memory
+                        Memory Usage
                       </span>
                     </span>
                   </button>

--- a/public/pages/Configuration/Configuration.tsx
+++ b/public/pages/Configuration/Configuration.tsx
@@ -23,7 +23,7 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 import { useHistory, useLocation } from 'react-router-dom';
-import { CoreStart } from '../../../../../src/core/public';
+import { CoreStart } from 'opensearch-dashboards/public';
 import { QUERY_INSIGHTS, MetricSettings } from '../TopNQueries/TopNQueries';
 
 const Configuration = ({

--- a/public/pages/QueryDetails/Components/QuerySummary.tsx
+++ b/public/pages/QueryDetails/Components/QuerySummary.tsx
@@ -5,13 +5,36 @@
 
 import React from 'react';
 import { EuiFlexGrid, EuiFlexItem, EuiHorizontalRule, EuiPanel, EuiText } from '@elastic/eui';
+import { SearchQueryRecord } from '../../../../types/types';
+import {
+  CPU_TIME,
+  INDICES,
+  LATENCY,
+  MEMORY_USAGE,
+  NODE_ID,
+  SEARCH_TYPE,
+  TIMESTAMP,
+  TOTAL_SHARDS,
+} from '../../../../common/constants';
 
-const QuerySummary = ({ query }: { query: any }) => {
+// Panel component for displaying query detail values
+const PanelItem = ({ label, value }: { label: string; value: string | number }) => (
+  <EuiFlexItem>
+    <EuiText size="xs">
+      <h4>{label}</h4>
+    </EuiText>
+    <EuiText size="xs">{value}</EuiText>
+  </EuiFlexItem>
+);
+
+const QuerySummary = ({ query }: { query: SearchQueryRecord }) => {
   const convertTime = (unixTime: number) => {
     const date = new Date(unixTime);
     const loc = date.toDateString().split(' ');
     return `${loc[1]} ${loc[2]}, ${loc[3]} @ ${date.toLocaleTimeString('en-US')}`;
   };
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const { timestamp, measurements, indices, search_type, node_id, total_shards } = query;
   return (
     <EuiPanel>
       <EuiText size="xs">
@@ -19,54 +42,21 @@ const QuerySummary = ({ query }: { query: any }) => {
       </EuiText>
       <EuiHorizontalRule margin="m" />
       <EuiFlexGrid columns={4}>
-        <EuiFlexItem>
-          <EuiText size="xs">
-            <h4>Timestamp</h4>
-          </EuiText>
-          <EuiText size="xs">{convertTime(query.timestamp)}</EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiText size="xs">
-            <h4>Latency</h4>
-          </EuiText>
-          <EuiText size="xs">{`${query.latency} ms`}</EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiText size="xs">
-            <h4>CPU Usage</h4>
-          </EuiText>
-          <EuiText size="xs">{`${query.cpu} ns`}</EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiText size="xs">
-            <h4>Memory</h4>
-          </EuiText>
-          <EuiText size="xs">{`${query.memory} B`}</EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiText size="xs">
-            <h4>Indexes</h4>
-          </EuiText>
-          <EuiText size="xs">{query.indices.toString()}</EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiText size="xs">
-            <h4>Search type</h4>
-          </EuiText>
-          <EuiText size="xs">{query.search_type.replaceAll('_', ' ')}</EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiText size="xs">
-            <h4>Coordinator node ID</h4>
-          </EuiText>
-          <EuiText size="xs">{query.node_id}</EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiText size="xs">
-            <h4>Total shards</h4>
-          </EuiText>
-          <EuiText size="xs">{query.total_shards}</EuiText>
-        </EuiFlexItem>
+        <PanelItem label={TIMESTAMP} value={convertTime(timestamp)} />
+        <PanelItem label={LATENCY} value={`${measurements.latency?.number ?? 'N/A'} ms`} />
+        <PanelItem
+          label={CPU_TIME}
+          value={
+            measurements.cpu?.number !== undefined
+              ? `${measurements.cpu.number / 1000000} ms`
+              : 'N/A'
+          }
+        />
+        <PanelItem label={MEMORY_USAGE} value={`${measurements.memory?.number ?? 'N/A'} B`} />
+        <PanelItem label={INDICES} value={indices.toString()} />
+        <PanelItem label={SEARCH_TYPE} value={search_type.replaceAll('_', ' ')} />
+        <PanelItem label={NODE_ID} value={node_id} />
+        <PanelItem label={TOTAL_SHARDS} value={total_shards} />
       </EuiFlexGrid>
     </EuiPanel>
   );

--- a/public/pages/QueryDetails/QueryDetails.tsx
+++ b/public/pages/QueryDetails/QueryDetails.tsx
@@ -19,7 +19,7 @@ import {
 } from '@elastic/eui';
 import hash from 'object-hash';
 import { useParams, useHistory, useLocation } from 'react-router-dom';
-import { CoreStart } from '../../../../../src/core/public';
+import { CoreStart } from 'opensearch-dashboards/public';
 import QuerySummary from './Components/QuerySummary';
 import { QUERY_INSIGHTS } from '../TopNQueries/TopNQueries';
 

--- a/public/pages/TopNQueries/TopNQueries.tsx
+++ b/public/pages/TopNQueries/TopNQueries.tsx
@@ -11,6 +11,7 @@ import { CoreStart } from 'opensearch-dashboards/public';
 import QueryInsights from '../QueryInsights/QueryInsights';
 import Configuration from '../Configuration/Configuration';
 import QueryDetails from '../QueryDetails/QueryDetails';
+import { SearchQueryRecord } from '../../../types/types';
 
 export const QUERY_INSIGHTS = '/queryInsights';
 export const CONFIGURATION = '/configuration';
@@ -66,7 +67,7 @@ const TopNQueries = ({ core }: { core: CoreStart }) => {
     }
   };
 
-  const [queries, setQueries] = useState<any[]>([]);
+  const [queries, setQueries] = useState<SearchQueryRecord[]>([]);
 
   const tabs: Array<{ id: string; name: string; route: string }> = [
     {
@@ -114,7 +115,11 @@ const TopNQueries = ({ core }: { core: CoreStart }) => {
       };
       const fetchMetric = async (endpoint: string) => {
         try {
-          const response = await core.http.get(endpoint, params);
+          // TODO: #13 refactor the interface definitions for requests and responses
+          const response: { response: { top_queries: SearchQueryRecord[] } } = await core.http.get(
+            endpoint,
+            params
+          );
           return {
             response: {
               top_queries: Array.isArray(response?.response?.top_queries)
@@ -142,7 +147,7 @@ const TopNQueries = ({ core }: { core: CoreStart }) => {
           ...respCpu.response.top_queries,
           ...respMemory.response.top_queries,
         ];
-        const noDuplicates = Array.from(
+        const noDuplicates: SearchQueryRecord[] = Array.from(
           new Set(newQueries.map((item) => JSON.stringify(item)))
         ).map((item) => JSON.parse(item));
         setQueries(noDuplicates);

--- a/types/types.ts
+++ b/types/types.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ISearchSource } from 'src/plugins/data/public';
+
+export interface SearchQueryRecord {
+  timestamp: number;
+  measurements: {
+    latency?: Measurement;
+    cpu?: Measurement;
+    memory?: Measurement;
+  };
+  total_shards: number;
+  node_id: string;
+  source: ISearchSource;
+  labels: Record<string, string>;
+  search_type: string;
+  indices: string[];
+  phase_latency_map: PhaseLatencyMap;
+  task_resource_usages: Task[];
+}
+
+export interface Measurement {
+  number: number;
+  count: number;
+  aggregationType: string;
+}
+
+export interface PhaseLatencyMap {
+  expand?: number;
+  query?: number;
+  fetch?: number;
+}
+
+export interface TaskResourceUsage {
+  cpu_time_in_nanos: number;
+  memory_in_bytes: number;
+}
+export interface Task {
+  action: string;
+  taskId: number;
+  parentTaskId: number;
+  nodeId: string;
+  taskResourceUsage: TaskResourceUsage;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -841,6 +841,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.63.tgz#1788fa8da838dbb5f9ea994b834278205db6ca2b"
   integrity sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==
 
+"@types/object-hash@^3.0.0":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/object-hash/-/object-hash-3.0.6.tgz#25c052428199d374ef723b7b0ed44b5bfe1b3029"
+  integrity sha512-fOBV8C1FIu2ELinoILQ+ApxcUKz4ngq+IWUYrxSGjXzzjUALijilampwkMgEtJ+h2njAW3pi853QpzNVCHB73w==
+
 "@types/parse-json@^4.0.0":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.2.tgz#5950e50960793055845e956c427fc2b0d70c5239"


### PR DESCRIPTION
### Description
This PR fix the bugs in the stats render function caused by the grouping changes. More specifically:
- Read measurement from the new data type, e.g.`measurements.latency?.number`.
- Refactor the constants used in multiple places.
- Refactor some column names.
- Use strict types for the records.

### Issues Resolved
Related to https://github.com/opensearch-project/query-insights-dashboards/issues/11

### Results
- Enabled Top Queries by latency and CPU and inject document.
- Make search requests
- On the Overview page, the stats are displayed correctly
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/f697129d-4ff0-4702-bcb3-48a4cb1f6225">

- On the details oage, the stats are displayed correctly
<img width="1907" alt="image" src="https://github.com/user-attachments/assets/45470dba-ccd9-4013-bf1f-2e6fba620cf6">



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
