### PR TITLE
Make sure API configuration changes are reflected on the UI

### DIFF
--- a/public/pages/Configuration/Configuration.tsx
+++ b/public/pages/Configuration/Configuration.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useCallback, useState, useEffect } from 'react';
+import React, { useMemo, useCallback, useState, useEffect } from 'react';
 import {
   EuiBottomBar,
   EuiButton,
@@ -66,19 +66,14 @@ const Configuration = ({
   const [windowSize, setWindowSize] = useState(latencySettings.currWindowSize);
   const [time, setTime] = useState(latencySettings.currTimeUnit);
 
-  const [metricSettingsMap, setMetricSettingsMap] = useState({
-    latency: latencySettings,
-    cpu: cpuSettings,
-    memory: memorySettings,
-  });
-
-  useEffect(() => {
-    setMetricSettingsMap({
+  const metricSettingsMap = useMemo(
+    () => ({
       latency: latencySettings,
       cpu: cpuSettings,
       memory: memorySettings,
-    });
-  }, [latencySettings, cpuSettings, memorySettings]);
+    }),
+    [latencySettings, cpuSettings, memorySettings]
+  );
 
   const newOrReset = useCallback(() => {
     const currMetric = metricSettingsMap[metric];
@@ -90,7 +85,7 @@ const Configuration = ({
 
   useEffect(() => {
     newOrReset();
-  }, [newOrReset, metricSettingsMap]);
+  }, [newOrReset]);
 
   useEffect(() => {
     core.chrome.setBreadcrumbs([

--- a/public/pages/Configuration/Configuration.tsx
+++ b/public/pages/Configuration/Configuration.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useMemo, useCallback, useState, useEffect } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import {
   EuiBottomBar,
   EuiButton,
@@ -66,14 +66,19 @@ const Configuration = ({
   const [windowSize, setWindowSize] = useState(latencySettings.currWindowSize);
   const [time, setTime] = useState(latencySettings.currTimeUnit);
 
-  const metricSettingsMap = useMemo(
-    () => ({
+  const [metricSettingsMap, setMetricSettingsMap] = useState({
+    latency: latencySettings,
+    cpu: cpuSettings,
+    memory: memorySettings,
+  });
+
+  useEffect(() => {
+    setMetricSettingsMap({
       latency: latencySettings,
       cpu: cpuSettings,
       memory: memorySettings,
-    }),
-    [latencySettings, cpuSettings, memorySettings]
-  );
+    });
+  }, [latencySettings, cpuSettings, memorySettings]);
 
   const newOrReset = useCallback(() => {
     const currMetric = metricSettingsMap[metric];
@@ -85,7 +90,7 @@ const Configuration = ({
 
   useEffect(() => {
     newOrReset();
-  }, [newOrReset]);
+  }, [newOrReset, metricSettingsMap]);
 
   useEffect(() => {
     core.chrome.setBreadcrumbs([

--- a/public/pages/TopNQueries/TopNQueries.tsx
+++ b/public/pages/TopNQueries/TopNQueries.tsx
@@ -183,7 +183,9 @@ const TopNQueries = ({
           const { latency, cpu, memory } =
             resp?.response?.persistent?.search?.insights?.top_queries || {};
           if (latency !== undefined && latency.enabled === 'true') {
-            const [time, timeUnits] = latency.window_size.match(/\D+|\d+/g);
+            const [time, timeUnits] = latency.window_size
+              ? latency.window_size.match(/\D+|\d+/g)
+              : ['1', 'm'];
             setMetricSettings('latency', {
               isEnabled: true,
               currTopN: latency.top_n_size,
@@ -192,7 +194,9 @@ const TopNQueries = ({
             });
           }
           if (cpu !== undefined && cpu.enabled === 'true') {
-            const [time, timeUnits] = cpu.window_size.match(/\D+|\d+/g);
+            const [time, timeUnits] = cpu.window_size
+              ? cpu.window_size.match(/\D+|\d+/g)
+              : ['1', 'm'];
             setMetricSettings('cpu', {
               isEnabled: true,
               currTopN: cpu.top_n_size,
@@ -201,7 +205,9 @@ const TopNQueries = ({
             });
           }
           if (memory !== undefined && memory.enabled === 'true') {
-            const [time, timeUnits] = memory.window_size.match(/\D+|\d+/g);
+            const [time, timeUnits] = memory.window_size
+              ? memory.window_size.match(/\D+|\d+/g)
+              : ['1', 'm'];
             setMetricSettings('memory', {
               isEnabled: true,
               currTopN: memory.top_n_size,


### PR DESCRIPTION
### Description
**This is a bug fix where the API configuration changes are not reflected on the UI on page refresh.**

If window_size is not passed while enabling a metric_type the error causes the configuration changes to not display on the UI for the specific type.

```
TopNQueries.tsx:174 Failed to retrieve settings: TypeError: Cannot read properties of undefined (reading 'match')
    at TopNQueries.tsx:165:1
```

Fixed by checking for `window_size` before trying to parse it. If `window_size` does not exist, use the default value `1m`.

### Testing
Tested on local by deploying OS with query insights and OSD with query insights dashboards. Verified that updating the settings via API is now reflected when we refresh the UI page.

### Issues Resolved
Closes: #27 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
