### PR TITLE
Fix Bug: Include Transient Settings in Fetch Logic 

### DIFF
--- a/public/pages/TopNQueries/TopNQueries.tsx
+++ b/public/pages/TopNQueries/TopNQueries.tsx
@@ -181,7 +181,7 @@ const TopNQueries = ({
         try {
           const resp = await core.http.get('/api/settings');
           const { latency, cpu, memory } =
-            resp?.response?.persistent?.search?.insights?.top_queries || {};
+            resp?.response?.persistent?.search?.insights?.top_queries || resp?.response?.transient?.search?.insights?.top_queries || {};
           if (latency !== undefined && latency.enabled === 'true') {
             const [time, timeUnits] = latency.window_size
               ? latency.window_size.match(/\D+|\d+/g)


### PR DESCRIPTION
### Description
When fetching settings via the code in the following file:
[TopNQueries.tsx - Line 185](https://github.com/opensearch-project/query-insights-dashboards/blob/main/public/pages/TopNQueries/TopNQueries.tsx#L185), the logic seems to only account for persistent settings.

Bug Link: https://github.com/opensearch-project/query-insights-dashboards/issues/29

Issue: Transient settings are ignored.
Concern: Should transient settings be included, or is it mandatory for these settings to be marked as persistent?

### Issues Resolved

What Changed: Transient settings  accounted in addition to persistent settings, unless explicitly intended otherwise.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
