### PR TITLE
fix bugs on configuration pages and refactor code

### DIFF
--- a/cypress/e2e/3_configurations.cy.js
+++ b/cypress/e2e/3_configurations.cy.js
@@ -83,7 +83,7 @@ describe('Query Insights Configurations Page', () => {
   it('should allow updating the value of N (count)', () => {
     cy.get('button[role="switch"]').first().click();
     // Locate the input for N
-    cy.get('input[type="number"]').should('have.attr', 'value', ''); // Default empty
+    cy.get('input[type="number"]').should('have.attr', 'value', '3'); // Default 3
     // Change the value to 50
     cy.get('input[type="number"]').first().clear().type('50').should('have.value', '50');
     // Validate invalid input
@@ -97,7 +97,7 @@ describe('Query Insights Configurations Page', () => {
   it('should allow selecting a window size and unit', () => {
     cy.get('button[role="switch"]').first().click();
     // Validate default values
-    cy.get('select#timeUnit').should('have.value', 'HOURS'); // Default unit is "Minute(s)"
+    cy.get('select#timeUnit').should('have.value', 'MINUTES'); // Default unit is "Minute(s)"
     // Test valid time unit selection
     cy.get('select#timeUnit').select('HOURS').should('have.value', 'HOURS');
     cy.get('select#timeUnit').select('MINUTES').should('have.value', 'MINUTES');

--- a/public/pages/Configuration/Configuration.tsx
+++ b/public/pages/Configuration/Configuration.tsx
@@ -25,7 +25,12 @@ import {
 import { useHistory, useLocation } from 'react-router-dom';
 import { CoreStart } from 'opensearch-dashboards/public';
 import { QUERY_INSIGHTS, MetricSettings, GroupBySettings } from '../TopNQueries/TopNQueries';
-import { METRIC_TYPES, TIME_UNITS, MINUTES_OPTIONS, GROUP_BY_OPTIONS } from '../Utils/Constants';
+import {
+  METRIC_TYPES_TEXT,
+  TIME_UNITS_TEXT,
+  MINUTES_OPTIONS,
+  GROUP_BY_OPTIONS,
+} from '../Utils/Constants';
 
 const Configuration = ({
   latencySettings,
@@ -141,7 +146,7 @@ const Configuration = ({
     />
   );
 
-  const WindowChoice = time === TIME_UNITS[0].value ? MinutesBox : HoursBox;
+  const WindowChoice = time === TIME_UNITS_TEXT[0].value ? MinutesBox : HoursBox;
 
   const isChanged =
     isEnabled !== metricSettingsMap[metric].isEnabled ||
@@ -153,7 +158,7 @@ const Configuration = ({
   const isValid = (() => {
     const nVal = parseInt(topNSize, 10);
     if (nVal < 1 || nVal > 100) return false;
-    if (time === TIME_UNITS[0].value) return true;
+    if (time === TIME_UNITS_TEXT[0].value) return true;
     const windowVal = parseInt(windowSize, 10);
     return windowVal >= 1 && windowVal <= 24;
   })();
@@ -191,7 +196,7 @@ const Configuration = ({
                       <EuiSelect
                         id="metricType"
                         required={true}
-                        options={METRIC_TYPES}
+                        options={METRIC_TYPES_TEXT}
                         value={metric}
                         onChange={onMetricChange}
                       />
@@ -261,7 +266,7 @@ const Configuration = ({
                               <EuiSelect
                                 id="timeUnit"
                                 required={isEnabled}
-                                options={TIME_UNITS}
+                                options={TIME_UNITS_TEXT}
                                 value={time}
                                 onChange={onTimeChange}
                               />

--- a/public/pages/Utils/Constants.ts
+++ b/public/pages/Utils/Constants.ts
@@ -2,14 +2,19 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+export const MetricType = {
+  LATENCY: 'latency',
+  CPU: 'cpu',
+  MEMORY: 'memory',
+};
 
-export const METRIC_TYPES = [
-  { value: 'latency', text: 'Latency' },
-  { value: 'cpu', text: 'CPU' },
-  { value: 'memory', text: 'Memory' },
+export const METRIC_TYPES_TEXT = [
+  { value: MetricType.LATENCY, text: 'Latency' },
+  { value: MetricType.CPU, text: 'CPU' },
+  { value: MetricType.MEMORY, text: 'Memory' },
 ];
 
-export const TIME_UNITS = [
+export const TIME_UNITS_TEXT = [
   { value: 'MINUTES', text: 'Minute(s)' },
   { value: 'HOURS', text: 'Hour(s)' },
 ];
@@ -25,3 +30,17 @@ export const GROUP_BY_OPTIONS = [
   { value: 'none', text: 'None' },
   { value: 'similarity', text: 'Similarity' },
 ];
+
+export const TIME_UNIT = {
+  MINUTES: 'MINUTES',
+  HOURS: 'HOURS',
+};
+
+export const TIME_UNIT_ABBREVIATION = {
+  MINUTES: 'm',
+  HOURS: 'h',
+};
+
+export const DEFAULT_TOP_N_SIZE = '3';
+export const DEFAULT_WINDOW_SIZE = '1';
+export const DEFAULT_TIME_UNIT = TIME_UNIT.MINUTES;

--- a/public/pages/Utils/MetricUtils.ts
+++ b/public/pages/Utils/MetricUtils.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { DEFAULT_TIME_UNIT, DEFAULT_WINDOW_SIZE, TIME_UNIT_ABBREVIATION } from './Constants';
+
 export function calculateMetric(
   value?: number,
   count?: number,
@@ -13,4 +15,25 @@ export function calculateMetric(
     return (value / count / factor).toFixed(2);
   }
   return defaultMsg;
+}
+
+export function getTimeUnitFromAbbreviation(timeUnit: string): string {
+  for (const [key, value] of Object.entries(TIME_UNIT_ABBREVIATION)) {
+    if (value === timeUnit) {
+      return key;
+    }
+  }
+  return DEFAULT_TIME_UNIT; // Return default time unit if no match is found
+}
+
+export function getTimeAndUnitFromString(time: string | undefined | null): string[] {
+  const defaultWindowSize = [DEFAULT_WINDOW_SIZE, TIME_UNIT_ABBREVIATION.MINUTES];
+  if (!time) {
+    return defaultWindowSize;
+  }
+  const timeAndUnit = time.match(/\D+|\d+/g);
+  if (!timeAndUnit || timeAndUnit.length !== 2) {
+    return defaultWindowSize;
+  }
+  return [timeAndUnit[0], getTimeUnitFromAbbreviation(timeAndUnit[1])];
 }

--- a/public/types.ts
+++ b/public/types.ts
@@ -11,6 +11,12 @@ export interface QueryInsightsDashboardsPluginSetup {
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface QueryInsightsDashboardsPluginStart {}
 
+export interface MetricSettingsResponse {
+  enabled?: string; // Could be 'true' or 'false'
+  window_size?: string; // E.g., '15m', '1h'
+  top_n_size?: string;
+}
+
 export interface AppPluginStartDependencies {
   navigation: NavigationPublicPluginStart;
 }


### PR DESCRIPTION
### Description
Currently when we fetch the settings from backend, there are 2 defects:
- We are not considering any transient settings
- When obtaining window size / top n sizes from settings, if a metric is enabled but no default settings are set, we are setting "undefined" value to a state, which makes the setState function fail - In this case, if there are values in the settings for other metrics, the old values will be used.

This PR resolved both of the issues by assigning default values when reading settings data from backend. Also make sure we pick up the transient settings as well

### Issues Resolved
https://github.com/opensearch-project/query-insights-dashboards/issues/31
https://github.com/opensearch-project/query-insights-dashboards/issues/29

### Results
- Run a clean OpenSearch Cluster
- Start OSD with query insights plugin
- insert configurations
```
curl -X PUT 'localhost:9200/_cluster/settings' -H 'Content-Type: application/json' -d'
{
    "persistent" : {
         "search.insights.top_queries.latency.enabled" : true,
        "search.insights.top_queries.cpu.enabled" : true,
        "search.insights.top_queries.memory.enabled" : true,
        "search.insights.top_queries.group_by" : "none",
        "search.insights.top_queries.latency.window_size" : "1m",
        "search.insights.top_queries.latency.top_n_size" : 5
    }
}'
```
- check configuration page, the latency setting is correctly picked up
<img width="1908" alt="image" src="https://github.com/user-attachments/assets/db8a8b77-8537-4fbb-9f65-464f6376be76" />

- Check CPU setting, the default values matches what's on the backend
<img width="1906" alt="image" src="https://github.com/user-attachments/assets/32acbe68-eec3-4593-a3bd-1a76c55ca42a" />
- Check Memory setting, the default values matches what's on the backend
<img width="1917" alt="image" src="https://github.com/user-attachments/assets/7567db8c-0db9-424b-9723-05f8e279843c" />

- Override with transient settings to disable top queries by latency
```
curl -X PUT 'localhost:9200/_cluster/settings' -H 'Content-Type: application/json' -d'
{
    "transient" : {
        "search.insights.top_queries.latency.enabled" : "false"
    }
}'
```
- Refresh the page and the transient settings are picked up
<img width="1919" alt="image" src="https://github.com/user-attachments/assets/42a726a8-7dae-404c-a8fe-98c266142c0e" />

- Override with transient settings to enable grouping
```
curl -X PUT 'localhost:9200/_cluster/settings' -H 'Content-Type: application/json' -d'
{
    "transient" : {
        "search.insights.top_queries.group_by" : "similarity"
    }
}'
```

- Refresh the page and the transient settings are picked up for group by
<img width="958" alt="image" src="https://github.com/user-attachments/assets/73b8355d-978e-4ad3-8d9c-a7450864d348" />



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
