### PR TITLE
fix default strings across pages

### DIFF
--- a/public/pages/QueryDetails/Components/QuerySummary.tsx
+++ b/public/pages/QueryDetails/Components/QuerySummary.tsx
@@ -46,27 +46,15 @@ const QuerySummary = ({ query }: { query: SearchQueryRecord }) => {
         <PanelItem label={TIMESTAMP} value={convertTime(timestamp)} />
         <PanelItem
           label={LATENCY}
-          value={
-            calculateMetric(measurements.latency?.number, measurements.latency?.count) === 'N/A'
-              ? 'N/A'
-              : `${calculateMetric(measurements.latency?.number, measurements.latency?.count)} ms`
-          }
+          value={calculateMetric(measurements.latency?.number, measurements.latency?.count, 'ms')}
         />
         <PanelItem
           label={CPU_TIME}
-          value={
-            calculateMetric(measurements.cpu?.number, measurements.cpu?.count, 1000000) === 'N/A'
-              ? 'N/A'
-              : `${calculateMetric(measurements.cpu?.number, measurements.cpu?.count, 1000000)} ms`
-          }
+          value={calculateMetric(measurements.cpu?.number, measurements.cpu?.count, 'ms', 1000000)}
         />
         <PanelItem
           label={MEMORY_USAGE}
-          value={
-            calculateMetric(measurements.memory?.number, measurements.memory?.count) === 'N/A'
-              ? 'N/A'
-              : `${calculateMetric(measurements.memory?.number, measurements.memory?.count)} B`
-          }
+          value={calculateMetric(measurements.memory?.number, measurements.memory?.count, 'B')}
         />
         <PanelItem label={INDICES} value={indices.toString()} />
         <PanelItem label={SEARCH_TYPE} value={search_type.replaceAll('_', ' ')} />

--- a/public/pages/QueryGroupDetails/Components/QueryGroupAggregateSummary.tsx
+++ b/public/pages/QueryGroupDetails/Components/QueryGroupAggregateSummary.tsx
@@ -40,31 +40,20 @@ export const QueryGroupAggregateSummary = ({ query }: { query: any }) => {
         <PanelItem label={ID} value={id} />
         <PanelItem
           label={AVERAGE_LATENCY}
-          value={
-            calculateMetric(measurements.latency?.number, measurements.latency?.count, 1) === 'N/A'
-              ? 'N/A'
-              : `${calculateMetric(
-                  measurements.latency?.number,
-                  measurements.latency?.count,
-                  1
-                )} ms`
-          }
+          value={calculateMetric(
+            measurements.latency?.number,
+            measurements.latency?.count,
+            'ms',
+            1
+          )}
         />
         <PanelItem
           label={AVERAGE_CPU_TIME}
-          value={
-            calculateMetric(measurements.cpu?.number, measurements.cpu?.count, 1000000) === 'N/A'
-              ? 'N/A'
-              : `${calculateMetric(measurements.cpu?.number, measurements.cpu?.count, 1000000)} ms`
-          }
+          value={calculateMetric(measurements.cpu?.number, measurements.cpu?.count, 'ms', 1000000)}
         />
         <PanelItem
           label={AVERAGE_MEMORY_USAGE}
-          value={
-            calculateMetric(measurements.memory?.number, measurements.memory?.count, 1) === 'N/A'
-              ? 'N/A'
-              : `${calculateMetric(measurements.memory?.number, measurements.memory?.count, 1)} B`
-          }
+          value={calculateMetric(measurements.memory?.number, measurements.memory?.count, 'B', 1)}
         />
         <PanelItem label={GROUP_BY} value={groupBy !== undefined ? `${groupBy}` : 'N/A'} />
       </EuiFlexGrid>

--- a/public/pages/QueryInsights/QueryInsights.tsx
+++ b/public/pages/QueryInsights/QueryInsights.tsx
@@ -12,12 +12,12 @@ import { QUERY_INSIGHTS } from '../TopNQueries/TopNQueries';
 import { SearchQueryRecord } from '../../../types/types';
 import {
   CPU_TIME,
+  ID,
   INDICES,
   LATENCY,
   MEMORY_USAGE,
   NODE_ID,
   QUERY_COUNT,
-  ID,
   SEARCH_TYPE,
   TIMESTAMP,
   TOTAL_SHARDS,
@@ -160,13 +160,13 @@ const QueryInsights = ({
       field: MEASUREMENTS_FIELD,
       name: LATENCY,
       render: (measurements: SearchQueryRecord['measurements']) => {
-        const result = calculateMetric(
+        return calculateMetric(
           measurements?.latency?.number,
           measurements?.latency?.count,
+          'ms',
           1,
           METRIC_DEFAULT_MSG
         );
-        return `${result} ms`;
       },
       sortable: true,
       truncateText: true,
@@ -175,13 +175,13 @@ const QueryInsights = ({
       field: MEASUREMENTS_FIELD,
       name: CPU_TIME,
       render: (measurements: SearchQueryRecord['measurements']) => {
-        const result = calculateMetric(
+        return calculateMetric(
           measurements?.cpu?.number,
           measurements?.cpu?.count,
+          'ms',
           1000000, // Divide by 1,000,000 for CPU time
           METRIC_DEFAULT_MSG
         );
-        return `${result} ms`;
       },
       sortable: true,
       truncateText: true,
@@ -190,13 +190,13 @@ const QueryInsights = ({
       field: MEASUREMENTS_FIELD,
       name: MEMORY_USAGE,
       render: (measurements: SearchQueryRecord['measurements']) => {
-        const result = calculateMetric(
+        return calculateMetric(
           measurements?.memory?.number,
           measurements?.memory?.count,
+          'B',
           1,
           METRIC_DEFAULT_MSG
         );
-        return `${result} B`;
       },
       sortable: true,
       truncateText: true,

--- a/public/pages/QueryInsights/__snapshots__/QueryInsights.test.tsx.snap
+++ b/public/pages/QueryInsights/__snapshots__/QueryInsights.test.tsx.snap
@@ -827,7 +827,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                 <div
                   class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
                 >
-                  Not enabled B
+                  Not enabled
                 </div>
               </td>
               <td

--- a/public/pages/Utils/MetricUtils.ts
+++ b/public/pages/Utils/MetricUtils.ts
@@ -6,11 +6,12 @@
 export function calculateMetric(
   value?: number,
   count?: number,
+  unit: string = '',
   factor: number = 1,
   defaultMsg: string = 'N/A'
 ): string {
   if (value !== undefined && count !== undefined) {
-    return (value / count / factor).toFixed(2);
+    return `${(value / count / factor).toFixed(2)} ${unit}`;
   }
   return defaultMsg;
 }


### PR DESCRIPTION
### Description
Refactor the calculateMetric to take unit string

### Issues Resolved
https://github.com/opensearch-project/query-insights-dashboards/issues/50

### tests
- enable all metrics but CPU
- send search requests
- on overview page
<img width="1912" alt="image" src="https://github.com/user-attachments/assets/b03c5a79-bbd1-441f-b1c0-d5007e0ea31d" />

- on details page
<img width="1912" alt="image" src="https://github.com/user-attachments/assets/2f4721a1-4c8a-48c7-af9f-fc4e9c90abc4" />

- enable grouping
- send search requests
- On overview page
<img width="1891" alt="image" src="https://github.com/user-attachments/assets/c0247595-919b-4f87-aa63-5b56901b12e6" />
- on details page
<img width="1868" alt="image" src="https://github.com/user-attachments/assets/350b8f5a-3eb1-4f63-9cc2-2440f85dd12b" />



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
