### PR TITLE
Add configuration section for exporter and delete_after

### DIFF
--- a/cypress/e2e/2_query_details.cy.js
+++ b/cypress/e2e/2_query_details.cy.js
@@ -28,7 +28,10 @@ describe('Top Queries Details Page', () => {
     // waiting for the query insights queue to drain
     cy.wait(10000);
     cy.navigateToOverview();
+    cy.get('.euiTableRow').first().find('button').first().trigger('mouseover');
+    cy.wait(1000);
     cy.get('.euiTableRow').first().find('button').first().click(); // Navigate to details
+    cy.wait(1000);
   });
 
   it('should display correct details on the query details page', () => {

--- a/cypress/e2e/3_configurations.cy.js
+++ b/cypress/e2e/3_configurations.cy.js
@@ -36,7 +36,8 @@ describe('Query Insights Configurations Page', () => {
     cy.contains('button', 'Top N queries').should('be.visible');
     cy.contains('button', 'Configuration').should('have.class', 'euiTab-isSelected');
     // Validate the panels
-    cy.get('.euiPanel').should('have.length', 6); // 6 panels: Settings, Status, Group Settings, Group Status
+    // 6 panels: Settings, Status, Group Settings, Group Status, Delete After Settings, Delete After Status
+    cy.get('.euiPanel').should('have.length', 6);
   });
 
   /**

--- a/cypress/e2e/3_configurations.cy.js
+++ b/cypress/e2e/3_configurations.cy.js
@@ -36,7 +36,7 @@ describe('Query Insights Configurations Page', () => {
     cy.contains('button', 'Top N queries').should('be.visible');
     cy.contains('button', 'Configuration').should('have.class', 'euiTab-isSelected');
     // Validate the panels
-    cy.get('.euiPanel').should('have.length', 4); // 4 panels: Settings, Status, Group Settings, Group Status
+    cy.get('.euiPanel').should('have.length', 6); // 6 panels: Settings, Status, Group Settings, Group Status
   });
 
   /**

--- a/cypress/e2e/4_group_details.cy.js
+++ b/cypress/e2e/4_group_details.cy.js
@@ -23,7 +23,10 @@ describe('Query Group Details Page', () => {
     // waiting for the query insights queue to drain
     cy.wait(10000);
     cy.navigateToOverview();
+    cy.get('.euiTableRow').first().find('button').first().trigger('mouseover');
+    cy.wait(1000);
     cy.get('.euiTableRow').first().find('button').first().click(); // Navigate to details
+    cy.wait(1000);
   });
 
   it('should display correct details on the group details page', () => {

--- a/public/components/DataSourcePicker.tsx
+++ b/public/components/DataSourcePicker.tsx
@@ -13,7 +13,7 @@ import { AppMountParameters, CoreStart } from '../../../../src/core/public';
 import { QueryInsightsDashboardsPluginStartDependencies } from '../types';
 
 export interface DataSourceMenuProps {
-  dataSourceManagement: DataSourceManagementPluginSetup;
+  dataSourceManagement?: DataSourceManagementPluginSetup;
   depsStart: QueryInsightsDashboardsPluginStartDependencies;
   coreStart: CoreStart;
   params: AppMountParameters;

--- a/public/pages/Configuration/Configuration.test.tsx
+++ b/public/pages/Configuration/Configuration.test.tsx
@@ -22,18 +22,21 @@ const defaultLatencySettings = {
   currTopN: '5',
   currWindowSize: '10',
   currTimeUnit: 'MINUTES',
+  exporterType: 'local_index',
 };
 const defaultCpuSettings = {
   isEnabled: false,
   currTopN: '10',
   currWindowSize: '1',
   currTimeUnit: 'HOURS',
+  exporterType: 'local_index',
 };
 const defaultMemorySettings = {
   isEnabled: false,
   currTopN: '15',
   currWindowSize: '2',
   currTimeUnit: 'HOURS',
+  exporterType: 'local_index',
 };
 
 const groupBySettings = {
@@ -52,6 +55,10 @@ const mockDataSourceContext = {
   setDataSource: jest.fn(),
 };
 
+const deleteAfterDaysSettings = {
+  deleteAfterDays: '179',
+};
+
 const renderConfiguration = (overrides = {}) =>
   render(
     <MemoryRouter>
@@ -62,6 +69,7 @@ const renderConfiguration = (overrides = {}) =>
           memorySettings={defaultMemorySettings}
           groupBySettings={groupBySettings}
           configInfo={mockConfigInfo}
+          deleteAfterDaysSettings={deleteAfterDaysSettings}
           core={mockCoreStart}
           depsStart={{ navigation: {} }}
           params={{} as any}
@@ -72,7 +80,7 @@ const renderConfiguration = (overrides = {}) =>
   );
 
 const getWindowSizeConfigurations = () => screen.getAllByRole('combobox');
-const getTopNSizeConfiguration = () => screen.getByRole('spinbutton');
+const getTopNSizeConfiguration = () => screen.getAllByRole('spinbutton');
 const getEnableToggle = () => screen.getByRole('switch');
 
 describe('Configuration Component', () => {
@@ -108,7 +116,7 @@ describe('Configuration Component', () => {
 
   it('validates topNSize and windowSize inputs and disables Save button for invalid input', () => {
     renderConfiguration();
-    fireEvent.change(getTopNSizeConfiguration(), { target: { value: '101' } });
+    fireEvent.change(getTopNSizeConfiguration()[0], { target: { value: '101' } });
     expect(screen.queryByText('Save')).not.toBeInTheDocument();
     fireEvent.change(getWindowSizeConfigurations()[1], { target: { value: '999' } });
     expect(screen.queryByText('Save')).not.toBeInTheDocument();
@@ -116,7 +124,7 @@ describe('Configuration Component', () => {
 
   it('calls configInfo and navigates on Save button click', async () => {
     renderConfiguration();
-    fireEvent.change(getTopNSizeConfiguration(), { target: { value: '7' } });
+    fireEvent.change(getTopNSizeConfiguration()[0], { target: { value: '7' } });
     fireEvent.click(screen.getByText('Save'));
     await waitFor(() => {
       expect(mockConfigInfo).toHaveBeenCalledWith(
@@ -126,15 +134,17 @@ describe('Configuration Component', () => {
         '7',
         '10',
         'MINUTES',
-        'SIMILARITY'
+        'local_index',
+        'SIMILARITY',
+        '179'
       );
     });
   });
 
   it('resets state on Cancel button click', async () => {
     renderConfiguration();
-    fireEvent.change(getTopNSizeConfiguration(), { target: { value: '7' } });
+    fireEvent.change(getTopNSizeConfiguration()[0], { target: { value: '7' } });
     fireEvent.click(screen.getByText('Cancel'));
-    expect(getTopNSizeConfiguration()).toHaveValue(5); // Resets to initial value
+    expect(getTopNSizeConfiguration()[0]).toHaveValue(5); // Resets to initial value
   });
 });

--- a/public/pages/Configuration/Configuration.test.tsx
+++ b/public/pages/Configuration/Configuration.test.tsx
@@ -69,7 +69,7 @@ const renderConfiguration = (overrides = {}) =>
           memorySettings={defaultMemorySettings}
           groupBySettings={groupBySettings}
           configInfo={mockConfigInfo}
-          deleteAfterDaysSettings={deleteAfterDaysSettings}
+          dataRetentionSettings={deleteAfterDaysSettings}
           core={mockCoreStart}
           depsStart={{ navigation: {} }}
           params={{} as any}

--- a/public/pages/Configuration/Configuration.test.tsx
+++ b/public/pages/Configuration/Configuration.test.tsx
@@ -22,25 +22,27 @@ const defaultLatencySettings = {
   currTopN: '5',
   currWindowSize: '10',
   currTimeUnit: 'MINUTES',
-  exporterType: 'local_index',
 };
 const defaultCpuSettings = {
   isEnabled: false,
   currTopN: '10',
   currWindowSize: '1',
   currTimeUnit: 'HOURS',
-  exporterType: 'local_index',
 };
 const defaultMemorySettings = {
   isEnabled: false,
   currTopN: '15',
   currWindowSize: '2',
   currTimeUnit: 'HOURS',
-  exporterType: 'local_index',
 };
 
 const groupBySettings = {
   groupBy: 'SIMILARITY',
+};
+
+const dataRetentionSettings = {
+  exporterType: 'local_index',
+  deleteAfterDays: '179',
 };
 
 const dataSourceMenuMock = jest.fn(() => <div>Mock DataSourceMenu</div>);
@@ -55,10 +57,6 @@ const mockDataSourceContext = {
   setDataSource: jest.fn(),
 };
 
-const deleteAfterDaysSettings = {
-  deleteAfterDays: '179',
-};
-
 const renderConfiguration = (overrides = {}) =>
   render(
     <MemoryRouter>
@@ -69,7 +67,7 @@ const renderConfiguration = (overrides = {}) =>
           memorySettings={defaultMemorySettings}
           groupBySettings={groupBySettings}
           configInfo={mockConfigInfo}
-          dataRetentionSettings={deleteAfterDaysSettings}
+          dataRetentionSettings={dataRetentionSettings}
           core={mockCoreStart}
           depsStart={{ navigation: {} }}
           params={{} as any}

--- a/public/pages/Configuration/Configuration.tsx
+++ b/public/pages/Configuration/Configuration.tsx
@@ -29,6 +29,7 @@ import {
   QUERY_INSIGHTS,
   MetricSettings,
   GroupBySettings,
+  DeleteAfterDaysSettings,
   DataSourceContext,
 } from '../TopNQueries/TopNQueries';
 import {
@@ -36,6 +37,7 @@ import {
   TIME_UNITS_TEXT,
   MINUTES_OPTIONS,
   GROUP_BY_OPTIONS,
+  EXPORTER_TYPES_LIST,
 } from '../Utils/Constants';
 import { QueryInsightsDataSourceMenu } from '../../components/DataSourcePicker';
 import { QueryInsightsDashboardsPluginStartDependencies } from '../../types';

--- a/public/pages/Configuration/__snapshots__/Configuration.test.tsx.snap
+++ b/public/pages/Configuration/__snapshots__/Configuration.test.tsx.snap
@@ -440,6 +440,83 @@ exports[`Configuration Component renders with default settings: should match def
                     </div>
                   </div>
                 </div>
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiText euiText--extraSmall"
+                  >
+                    <h3>
+                      Exporter
+                    </h3>
+                  </div>
+                  <div
+                    class="euiText euiText--extraSmall"
+                    style="line-height: 22px; padding: 5px 0px;"
+                  >
+                    Configure exporter for latency.
+                  </div>
+                </div>
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiFormRow"
+                    id="random_html_id-row"
+                    style="padding: 0px 0px 20px;"
+                  >
+                    <div
+                      class="euiFormRow__fieldWrapper"
+                    >
+                      <div
+                        class="euiFormControlLayout"
+                      >
+                        <div
+                          class="euiFormControlLayout__childrenWrapper"
+                        >
+                          <select
+                            class="euiSelect"
+                            id="random_html_id"
+                            required=""
+                          >
+                            <option
+                              value="local_index"
+                            >
+                              Local Index
+                            </option>
+                            <option
+                              value="none"
+                            >
+                              None
+                            </option>
+                          </select>
+                          <div
+                            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                          >
+                            <span
+                              class="euiFormControlLayoutCustomIcon"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -800,6 +877,163 @@ exports[`Configuration Component renders with default settings: should match def
                       class="euiFlexItem euiFlexItem--flexGrowZero"
                     >
                       Disabled
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+    >
+      <div
+        class="euiFlexItem euiFlexItem--flexGrow6"
+      >
+        <div
+          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+        >
+          <div
+            class="euiForm"
+          >
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiText euiText--small euiTitle euiTitle--small"
+              >
+                <h2>
+                  Query Insights data retention settings
+                </h2>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFlexGrid euiFlexGrid--gutterSmall euiFlexGrid--halves euiFlexGrid--responsive"
+                style="padding: 15px 0px;"
+              >
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiText euiText--extraSmall"
+                  >
+                    <h3>
+                      Delete After (days)
+                    </h3>
+                  </div>
+                  <div
+                    class="euiText euiText--extraSmall"
+                    style="line-height: 22px; padding: 5px 0px;"
+                  >
+                    Delete the Query Insights data after certain days.
+                  </div>
+                </div>
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiFormRow"
+                    id="random_html_id-row"
+                    style="padding: 0px 0px 20px;"
+                  >
+                    <div
+                      class="euiFormRow__fieldWrapper"
+                    >
+                      <div
+                        class="euiFormControlLayout"
+                      >
+                        <div
+                          class="euiFormControlLayout__childrenWrapper"
+                        >
+                          <input
+                            class="euiFieldNumber"
+                            id="random_html_id"
+                            max="180"
+                            min="1"
+                            type="number"
+                            value="179"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiFlexItem euiFlexItem--flexGrow2"
+      >
+        <div
+          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPanel--flexGrowZero"
+        >
+          <div
+            class="euiFlexItem"
+          >
+            <div
+              class="euiText euiText--small euiTitle euiTitle--small"
+            >
+              <h2>
+                Statuses for data retention settings
+              </h2>
+            </div>
+          </div>
+          <div
+            class="euiFlexItem"
+          >
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+            >
+              <div
+                class="euiFlexItem"
+              >
+                <div
+                  class="euiText euiText--medium"
+                >
+                  Delete After
+                </div>
+              </div>
+              <div
+                class="euiFlexItem"
+              >
+                <div
+                  class="euiSpacer euiSpacer--xs"
+                />
+                <div
+                  class="euiHealth euiHealth--textSizeS"
+                >
+                  <div
+                    class="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                  >
+                    <div
+                      class="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--medium euiIcon--primary euiIcon-isLoading"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                        />
+                      </svg>
+                    </div>
+                    <div
+                      class="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      Enabled
                     </div>
                   </div>
                 </div>
@@ -1216,6 +1450,84 @@ exports[`Configuration Component updates state when toggling metrics and enables
                     </div>
                   </div>
                 </div>
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiText euiText--extraSmall"
+                  >
+                    <h3>
+                      Exporter
+                    </h3>
+                  </div>
+                  <div
+                    class="euiText euiText--extraSmall"
+                    style="line-height: 22px; padding: 5px 0px;"
+                  >
+                    Configure exporter for cpu.
+                  </div>
+                </div>
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiFormRow"
+                    id="random_html_id-row"
+                    style="padding: 0px 0px 20px;"
+                  >
+                    <div
+                      class="euiFormRow__fieldWrapper"
+                    >
+                      <div
+                        class="euiFormControlLayout"
+                      >
+                        <div
+                          class="euiFormControlLayout__childrenWrapper"
+                        >
+                          <select
+                            class="euiSelect"
+                            id="random_html_id"
+                            required=""
+                          >
+                            <option
+                              value="local_index"
+                            >
+                              Local Index
+                            </option>
+                            <option
+                              value="none"
+                            >
+                              None
+                            </option>
+                          </select>
+                          <div
+                            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                          >
+                            <span
+                              class="euiFormControlLayoutCustomIcon"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                  fill-rule="non-zero"
+                                />
+                              </svg>
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -1585,6 +1897,165 @@ exports[`Configuration Component updates state when toggling metrics and enables
                       class="euiFlexItem euiFlexItem--flexGrowZero"
                     >
                       Disabled
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+    >
+      <div
+        class="euiFlexItem euiFlexItem--flexGrow6"
+      >
+        <div
+          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+        >
+          <div
+            class="euiForm"
+          >
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiText euiText--small euiTitle euiTitle--small"
+              >
+                <h2>
+                  Query Insights data retention settings
+                </h2>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFlexGrid euiFlexGrid--gutterSmall euiFlexGrid--halves euiFlexGrid--responsive"
+                style="padding: 15px 0px;"
+              >
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiText euiText--extraSmall"
+                  >
+                    <h3>
+                      Delete After (days)
+                    </h3>
+                  </div>
+                  <div
+                    class="euiText euiText--extraSmall"
+                    style="line-height: 22px; padding: 5px 0px;"
+                  >
+                    Delete the Query Insights data after certain days.
+                  </div>
+                </div>
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiFormRow"
+                    id="random_html_id-row"
+                    style="padding: 0px 0px 20px;"
+                  >
+                    <div
+                      class="euiFormRow__fieldWrapper"
+                    >
+                      <div
+                        class="euiFormControlLayout"
+                      >
+                        <div
+                          class="euiFormControlLayout__childrenWrapper"
+                        >
+                          <input
+                            class="euiFieldNumber"
+                            id="random_html_id"
+                            max="180"
+                            min="1"
+                            type="number"
+                            value="179"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiFlexItem euiFlexItem--flexGrow2"
+      >
+        <div
+          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPanel--flexGrowZero"
+        >
+          <div
+            class="euiFlexItem"
+          >
+            <div
+              class="euiText euiText--small euiTitle euiTitle--small"
+            >
+              <h2>
+                Statuses for data retention settings
+              </h2>
+            </div>
+          </div>
+          <div
+            class="euiFlexItem"
+          >
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+            >
+              <div
+                class="euiFlexItem"
+              >
+                <div
+                  class="euiText euiText--medium"
+                >
+                  Delete After
+                </div>
+              </div>
+              <div
+                class="euiFlexItem"
+              >
+                <div
+                  class="euiSpacer euiSpacer--xs"
+                />
+                <div
+                  class="euiHealth euiHealth--textSizeS"
+                >
+                  <div
+                    class="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                  >
+                    <div
+                      class="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--medium euiIcon--primary"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="8"
+                          cy="8"
+                          r="4"
+                        />
+                      </svg>
+                    </div>
+                    <div
+                      class="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      Enabled
                     </div>
                   </div>
                 </div>

--- a/public/pages/Configuration/__snapshots__/Configuration.test.tsx.snap
+++ b/public/pages/Configuration/__snapshots__/Configuration.test.tsx.snap
@@ -440,83 +440,6 @@ exports[`Configuration Component renders with default settings: should match def
                     </div>
                   </div>
                 </div>
-                <div
-                  class="euiFlexItem"
-                >
-                  <div
-                    class="euiText euiText--extraSmall"
-                  >
-                    <h3>
-                      Exporter
-                    </h3>
-                  </div>
-                  <div
-                    class="euiText euiText--extraSmall"
-                    style="line-height: 22px; padding: 5px 0px;"
-                  >
-                    Configure exporter for latency.
-                  </div>
-                </div>
-                <div
-                  class="euiFlexItem"
-                >
-                  <div
-                    class="euiFormRow"
-                    id="random_html_id-row"
-                    style="padding: 0px 0px 20px;"
-                  >
-                    <div
-                      class="euiFormRow__fieldWrapper"
-                    >
-                      <div
-                        class="euiFormControlLayout"
-                      >
-                        <div
-                          class="euiFormControlLayout__childrenWrapper"
-                        >
-                          <select
-                            class="euiSelect"
-                            id="random_html_id"
-                            required=""
-                          >
-                            <option
-                              value="local_index"
-                            >
-                              Local Index
-                            </option>
-                            <option
-                              value="none"
-                            >
-                              None
-                            </option>
-                          </select>
-                          <div
-                            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                          >
-                            <span
-                              class="euiFormControlLayoutCustomIcon"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                focusable="false"
-                                height="16"
-                                role="img"
-                                viewBox="0 0 16 16"
-                                width="16"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
-                                />
-                              </svg>
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
               </div>
             </div>
           </div>
@@ -905,7 +828,7 @@ exports[`Configuration Component renders with default settings: should match def
                 class="euiText euiText--small euiTitle euiTitle--small"
               >
                 <h2>
-                  Query Insights data retention settings
+                  Query Insights export and data retention settings
                 </h2>
               </div>
             </div>
@@ -923,6 +846,83 @@ exports[`Configuration Component renders with default settings: should match def
                     class="euiText euiText--extraSmall"
                   >
                     <h3>
+                      Exporter
+                    </h3>
+                  </div>
+                  <div
+                    class="euiText euiText--extraSmall"
+                    style="line-height: 22px; padding: 5px 0px;"
+                  >
+                    Configure a sink for exporting Query Insights data.
+                  </div>
+                </div>
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiFormRow"
+                    id="random_html_id-row"
+                    style="padding: 0px 0px 20px;"
+                  >
+                    <div
+                      class="euiFormRow__fieldWrapper"
+                    >
+                      <div
+                        class="euiFormControlLayout"
+                      >
+                        <div
+                          class="euiFormControlLayout__childrenWrapper"
+                        >
+                          <select
+                            class="euiSelect"
+                            id="random_html_id"
+                            required=""
+                          >
+                            <option
+                              value="local_index"
+                            >
+                              Local Index
+                            </option>
+                            <option
+                              value="none"
+                            >
+                              None
+                            </option>
+                          </select>
+                          <div
+                            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                          >
+                            <span
+                              class="euiFormControlLayoutCustomIcon"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiText euiText--extraSmall"
+                  >
+                    <h3>
                       Delete After (days)
                     </h3>
                   </div>
@@ -930,7 +930,7 @@ exports[`Configuration Component renders with default settings: should match def
                     class="euiText euiText--extraSmall"
                     style="line-height: 22px; padding: 5px 0px;"
                   >
-                    Delete the Query Insights data after certain days.
+                    Number of days to retain Query Insights data.
                   </div>
                 </div>
                 <div
@@ -981,7 +981,7 @@ exports[`Configuration Component renders with default settings: should match def
               class="euiText euiText--small euiTitle euiTitle--small"
             >
               <h2>
-                Statuses for data retention settings
+                Statuses for data retention
               </h2>
             </div>
           </div>
@@ -997,7 +997,7 @@ exports[`Configuration Component renders with default settings: should match def
                 <div
                   class="euiText euiText--medium"
                 >
-                  Delete After
+                  Exporter
                 </div>
               </div>
               <div
@@ -1450,84 +1450,6 @@ exports[`Configuration Component updates state when toggling metrics and enables
                     </div>
                   </div>
                 </div>
-                <div
-                  class="euiFlexItem"
-                >
-                  <div
-                    class="euiText euiText--extraSmall"
-                  >
-                    <h3>
-                      Exporter
-                    </h3>
-                  </div>
-                  <div
-                    class="euiText euiText--extraSmall"
-                    style="line-height: 22px; padding: 5px 0px;"
-                  >
-                    Configure exporter for cpu.
-                  </div>
-                </div>
-                <div
-                  class="euiFlexItem"
-                >
-                  <div
-                    class="euiFormRow"
-                    id="random_html_id-row"
-                    style="padding: 0px 0px 20px;"
-                  >
-                    <div
-                      class="euiFormRow__fieldWrapper"
-                    >
-                      <div
-                        class="euiFormControlLayout"
-                      >
-                        <div
-                          class="euiFormControlLayout__childrenWrapper"
-                        >
-                          <select
-                            class="euiSelect"
-                            id="random_html_id"
-                            required=""
-                          >
-                            <option
-                              value="local_index"
-                            >
-                              Local Index
-                            </option>
-                            <option
-                              value="none"
-                            >
-                              None
-                            </option>
-                          </select>
-                          <div
-                            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                          >
-                            <span
-                              class="euiFormControlLayoutCustomIcon"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                focusable="false"
-                                height="16"
-                                role="img"
-                                viewBox="0 0 16 16"
-                                width="16"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                  fill-rule="non-zero"
-                                />
-                              </svg>
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
               </div>
             </div>
           </div>
@@ -1925,7 +1847,7 @@ exports[`Configuration Component updates state when toggling metrics and enables
                 class="euiText euiText--small euiTitle euiTitle--small"
               >
                 <h2>
-                  Query Insights data retention settings
+                  Query Insights export and data retention settings
                 </h2>
               </div>
             </div>
@@ -1943,6 +1865,84 @@ exports[`Configuration Component updates state when toggling metrics and enables
                     class="euiText euiText--extraSmall"
                   >
                     <h3>
+                      Exporter
+                    </h3>
+                  </div>
+                  <div
+                    class="euiText euiText--extraSmall"
+                    style="line-height: 22px; padding: 5px 0px;"
+                  >
+                    Configure a sink for exporting Query Insights data.
+                  </div>
+                </div>
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiFormRow"
+                    id="random_html_id-row"
+                    style="padding: 0px 0px 20px;"
+                  >
+                    <div
+                      class="euiFormRow__fieldWrapper"
+                    >
+                      <div
+                        class="euiFormControlLayout"
+                      >
+                        <div
+                          class="euiFormControlLayout__childrenWrapper"
+                        >
+                          <select
+                            class="euiSelect"
+                            id="random_html_id"
+                            required=""
+                          >
+                            <option
+                              value="local_index"
+                            >
+                              Local Index
+                            </option>
+                            <option
+                              value="none"
+                            >
+                              None
+                            </option>
+                          </select>
+                          <div
+                            class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                          >
+                            <span
+                              class="euiFormControlLayoutCustomIcon"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                  fill-rule="non-zero"
+                                />
+                              </svg>
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiText euiText--extraSmall"
+                  >
+                    <h3>
                       Delete After (days)
                     </h3>
                   </div>
@@ -1950,7 +1950,7 @@ exports[`Configuration Component updates state when toggling metrics and enables
                     class="euiText euiText--extraSmall"
                     style="line-height: 22px; padding: 5px 0px;"
                   >
-                    Delete the Query Insights data after certain days.
+                    Number of days to retain Query Insights data.
                   </div>
                 </div>
                 <div
@@ -2001,7 +2001,7 @@ exports[`Configuration Component updates state when toggling metrics and enables
               class="euiText euiText--small euiTitle euiTitle--small"
             >
               <h2>
-                Statuses for data retention settings
+                Statuses for data retention
               </h2>
             </div>
           </div>
@@ -2017,7 +2017,7 @@ exports[`Configuration Component updates state when toggling metrics and enables
                 <div
                   class="euiText euiText--medium"
                 >
-                  Delete After
+                  Exporter
                 </div>
               </div>
               <div

--- a/public/pages/TopNQueries/TopNQueries.tsx
+++ b/public/pages/TopNQueries/TopNQueries.tsx
@@ -12,7 +12,7 @@ import { DataSourceOption } from 'src/plugins/data_source_management/public/comp
 import QueryInsights from '../QueryInsights/QueryInsights';
 import Configuration from '../Configuration/Configuration';
 import QueryDetails from '../QueryDetails/QueryDetails';
-import { SearchQueryRecord } from '../../../types/types';
+import { QueryInsightsSettingsResponse, SearchQueryRecord } from '../../../types/types';
 import { QueryGroupDetails } from '../QueryGroupDetails/QueryGroupDetails';
 import { QueryInsightsDashboardsPluginStartDependencies } from '../../types';
 import { PageHeader } from '../../components/PageHeader';
@@ -24,8 +24,12 @@ import {
 } from '../Utils/Constants';
 
 import { MetricSettingsResponse } from '../../types';
-import { getTimeAndUnitFromString } from '../Utils/MetricUtils';
 import { parseDateString } from '../Utils/DateUtils';
+import {
+  getMergedMetricSettings,
+  getMergedStringSettings,
+  getTimeAndUnitFromString,
+} from '../Utils/MetricUtils';
 import { getDataSourceFromUrl } from '../../components/DataSourcePicker';
 import { EXPORTER_TYPE } from '../Utils/Constants';
 
@@ -297,13 +301,17 @@ const TopNQueries = ({
               });
             }
           });
-          const groupBy = getMergedGroupBySettings(
+          const groupBy = getMergedStringSettings(
             persistentSettings?.group_by,
             transientSettings?.group_by
           );
           if (groupBy) {
             setGroupBySettings({ groupBy });
           }
+          const deleteAfterDays = getMergedStringSettings(
+            persistentSettings?.delete_after_days,
+            transientSettings?.delete_after_days
+          );
           if (deleteAfterDays) {
             setDeleteAfterDaysSettings({ deleteAfterDays });
           }

--- a/public/pages/TopNQueries/TopNQueries.tsx
+++ b/public/pages/TopNQueries/TopNQueries.tsx
@@ -12,23 +12,22 @@ import { DataSourceOption } from 'src/plugins/data_source_management/public/comp
 import QueryInsights from '../QueryInsights/QueryInsights';
 import Configuration from '../Configuration/Configuration';
 import QueryDetails from '../QueryDetails/QueryDetails';
-import { QueryInsightsSettingsResponse, SearchQueryRecord } from '../../../types/types';
+import { SearchQueryRecord } from '../../../types/types';
 import { QueryGroupDetails } from '../QueryGroupDetails/QueryGroupDetails';
 import { QueryInsightsDashboardsPluginStartDependencies } from '../../types';
 import { PageHeader } from '../../components/PageHeader';
 import {
-  DEFAULT_DELETE_AFTER_DAYS, DEFAULT_EXPORTER_TYPE,
+  DEFAULT_DELETE_AFTER_DAYS,
+  DEFAULT_EXPORTER_TYPE,
   DEFAULT_GROUP_BY,
   DEFAULT_TIME_UNIT,
   DEFAULT_TOP_N_SIZE,
   DEFAULT_WINDOW_SIZE,
-  MetricType
-} from "../Utils/Constants";
+  MetricType,
+} from '../Utils/Constants';
 
-import { MetricSettingsResponse } from '../../types';
 import { parseDateString } from '../Utils/DateUtils';
 import {
-  getExporterTypeSetting,
   getMergedMetricSettings,
   getMergedStringSettings,
   getTimeAndUnitFromString,
@@ -232,26 +231,6 @@ const TopNQueries = ({
     ) => {
       if (get) {
         try {
-          // Helper to get merged settings with transient overwriting persistent
-          const getMergedMetricSettings = (
-            persistent: MetricSettingsResponse | undefined,
-            transient: MetricSettingsResponse | undefined
-          ): MetricSettingsResponse => {
-            if (transient !== undefined) {
-              return transient;
-            }
-            return {
-              ...persistent,
-            };
-          };
-
-          const getMergedGroupBySettings = (
-            persistent: string | undefined,
-            transient: string | undefined
-          ) => {
-            return transient ?? persistent;
-          };
-
           // const resp = await core.http.get('/api/settings', {query: {dataSourceId: '738ffbd0-d8de-11ef-9d96-eff1abd421b8'}});
           const resp = await core.http.get('/api/settings', {
             query: { dataSourceId: getDataSourceFromUrl().id },

--- a/public/pages/Utils/Constants.ts
+++ b/public/pages/Utils/Constants.ts
@@ -41,10 +41,6 @@ export const TIME_UNIT_ABBREVIATION = {
   HOURS: 'h',
 };
 
-export const DEFAULT_TOP_N_SIZE = '3';
-export const DEFAULT_WINDOW_SIZE = '1';
-export const DEFAULT_TIME_UNIT = TIME_UNIT.MINUTES;
-
 export const EXPORTER_TYPE = {
   localIndex: 'local_index',
   none: 'none',
@@ -54,3 +50,10 @@ export const EXPORTER_TYPES_LIST = [
   { value: EXPORTER_TYPE.localIndex, text: 'Local Index' },
   { value: EXPORTER_TYPE.none, text: 'None' },
 ];
+
+export const DEFAULT_TOP_N_SIZE = '3';
+export const DEFAULT_WINDOW_SIZE = '1';
+export const DEFAULT_TIME_UNIT = TIME_UNIT.MINUTES;
+export const DEFAULT_GROUP_BY = 'none';
+export const DEFAULT_EXPORTER_TYPE = EXPORTER_TYPE.none;
+export const DEFAULT_DELETE_AFTER_DAYS = '7';

--- a/public/pages/Utils/Constants.ts
+++ b/public/pages/Utils/Constants.ts
@@ -44,3 +44,13 @@ export const TIME_UNIT_ABBREVIATION = {
 export const DEFAULT_TOP_N_SIZE = '3';
 export const DEFAULT_WINDOW_SIZE = '1';
 export const DEFAULT_TIME_UNIT = TIME_UNIT.MINUTES;
+
+export const EXPORTER_TYPE = {
+  localIndex: 'local_index',
+  none: 'none',
+};
+
+export const EXPORTER_TYPES_LIST = [
+  { value: EXPORTER_TYPE.localIndex, text: 'Local Index' },
+  { value: EXPORTER_TYPE.none, text: 'None' },
+];

--- a/public/pages/Utils/MetricUtils.ts
+++ b/public/pages/Utils/MetricUtils.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DEFAULT_TIME_UNIT, DEFAULT_WINDOW_SIZE, TIME_UNIT_ABBREVIATION } from './Constants';
+import { DEFAULT_TIME_UNIT, DEFAULT_WINDOW_SIZE, EXPORTER_TYPE, TIME_UNIT_ABBREVIATION } from "./Constants";
 import { MetricSettingsResponse } from '../../../types/types';
 
 export function calculateMetric(
@@ -55,7 +55,8 @@ export function getMergedMetricSettings(
 
 export function getMergedStringSettings(
   persistent: string | undefined,
-  transient: string | undefined
-): string | undefined {
-  return transient ?? persistent;
+  transient: string | undefined,
+  defaultVal: string
+): string {
+  return transient ?? persistent ?? defaultVal;
 }

--- a/public/pages/Utils/MetricUtils.ts
+++ b/public/pages/Utils/MetricUtils.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DEFAULT_TIME_UNIT, DEFAULT_WINDOW_SIZE, EXPORTER_TYPE, TIME_UNIT_ABBREVIATION } from "./Constants";
+import { DEFAULT_TIME_UNIT, DEFAULT_WINDOW_SIZE, TIME_UNIT_ABBREVIATION } from './Constants';
 import { MetricSettingsResponse } from '../../../types/types';
 
 export function calculateMetric(

--- a/public/pages/Utils/MetricUtils.ts
+++ b/public/pages/Utils/MetricUtils.ts
@@ -4,6 +4,7 @@
  */
 
 import { DEFAULT_TIME_UNIT, DEFAULT_WINDOW_SIZE, TIME_UNIT_ABBREVIATION } from './Constants';
+import { MetricSettingsResponse } from '../../../types/types';
 
 export function calculateMetric(
   value?: number,
@@ -37,4 +38,24 @@ export function getTimeAndUnitFromString(time: string | undefined | null): strin
     return defaultWindowSize;
   }
   return [timeAndUnit[0], getTimeUnitFromAbbreviation(timeAndUnit[1])];
+}
+
+// Helper to get merged settings with transient overwriting persistent
+export function getMergedMetricSettings(
+  persistent: MetricSettingsResponse | undefined,
+  transient: MetricSettingsResponse | undefined
+): MetricSettingsResponse {
+  if (transient !== undefined) {
+    return transient;
+  }
+  return {
+    ...persistent,
+  };
+}
+
+export function getMergedStringSettings(
+  persistent: string | undefined,
+  transient: string | undefined
+): string | undefined {
+  return transient ?? persistent;
 }

--- a/public/types.ts
+++ b/public/types.ts
@@ -18,12 +18,6 @@ export interface QueryInsightsDashboardsPluginSetupDependencies {
 }
 /* eslint-enable @typescript-eslint/no-empty-interface */
 
-export interface MetricSettingsResponse {
-  enabled?: string; // Could be 'true' or 'false'
-  window_size?: string; // E.g., '15m', '1h'
-  top_n_size?: string;
-}
-
 export interface AppPluginStartDependencies {
   navigation: NavigationPublicPluginStart;
   dataSource?: DataSourcePluginStart;

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -296,6 +296,8 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
     async (context, request, response) => {
       try {
         const query = request.query;
+        const client = context.queryInsights_plugin.queryInsightsClient.asScoped(request)
+          .callAsCurrentUser;
         const params = {
           body: {
             persistent: {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -304,8 +304,6 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
               [`search.insights.top_queries.${query.metric}.enabled`]: query.enabled,
               [`search.insights.top_queries.${query.metric}.top_n_size`]: query.top_n_size,
               [`search.insights.top_queries.${query.metric}.window_size`]: query.window_size,
-              [`search.insights.top_queries.${query.metric}.exporter.type`]:
-                query.exporterType === EXPORTER_TYPE.localIndex ? query.exporterType : null,
             },
           },
         };
@@ -313,8 +311,14 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
           params.body.persistent['search.insights.top_queries.group_by'] = query.group_by;
         }
         if (query.delete_after_days !== '') {
-          params.body.persistent['search.insights.top_queries.delete_after_days'] =
+          params.body.persistent['search.insights.top_queries.exporter.delete_after_days'] =
             query.delete_after_days;
+        }
+        if (query.exporterType !== '') {
+          params.body.persistent['search.insights.top_queries.exporter.type'] =
+            query.exporterType === EXPORTER_TYPE.localIndex
+              ? query.exporterType
+              : EXPORTER_TYPE.none;
         }
         if (!dataSourceEnabled || !request.query?.dataSourceId) {
           const client = context.queryInsights_plugin.queryInsightsClient.asScoped(request)

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -296,8 +296,6 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
     async (context, request, response) => {
       try {
         const query = request.query;
-        const client = context.queryInsights_plugin.queryInsightsClient.asScoped(request)
-          .callAsCurrentUser;
         const params = {
           body: {
             persistent: {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -5,6 +5,8 @@
 
 import { schema } from '@osd/config-schema';
 import { IRouter } from '../../../../src/core/server';
+import { EXPORTER_TYPE } from '../../public/pages/Utils/Constants';
+
 export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
   router.get(
     {
@@ -284,8 +286,10 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
           enabled: schema.maybe(schema.boolean({ defaultValue: false })),
           top_n_size: schema.maybe(schema.string({ defaultValue: '' })),
           window_size: schema.maybe(schema.string({ defaultValue: '' })),
+          exporterType: schema.maybe(schema.string({ defaultValue: '' })),
           group_by: schema.maybe(schema.string({ defaultValue: '' })),
           dataSourceId: schema.maybe(schema.string()),
+          delete_after_days: schema.maybe(schema.string({ defaultValue: '' })),
         }),
       },
     },
@@ -298,10 +302,18 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
               [`search.insights.top_queries.${query.metric}.enabled`]: query.enabled,
               [`search.insights.top_queries.${query.metric}.top_n_size`]: query.top_n_size,
               [`search.insights.top_queries.${query.metric}.window_size`]: query.window_size,
-              [`search.insights.top_queries.group_by`]: query.group_by,
+              [`search.insights.top_queries.${query.metric}.exporter.type`]:
+                query.exporterType === EXPORTER_TYPE.localIndex ? query.exporterType : null,
             },
           },
         };
+        if (query.group_by !== '') {
+          params.body.persistent['search.insights.top_queries.group_by'] = query.group_by;
+        }
+        if (query.delete_after_days !== '') {
+          params.body.persistent['search.insights.top_queries.delete_after_days'] =
+            query.delete_after_days;
+        }
         if (!dataSourceEnabled || !request.query?.dataSourceId) {
           const client = context.queryInsights_plugin.queryInsightsClient.asScoped(request)
             .callAsCurrentUser;

--- a/types/types.ts
+++ b/types/types.ts
@@ -52,9 +52,11 @@ export interface MetricSettingsResponse {
   enabled?: string; // Could be 'true' or 'false'
   window_size?: string; // E.g., '15m', '1h'
   top_n_size?: string;
-  exporter?: {
-    type?: string;
-  };
+}
+
+export interface ExporterSettingsResponse {
+  type?: string;
+  delete_after_days?: string;
 }
 
 export interface QueryInsightsSettingsResponse {
@@ -62,5 +64,5 @@ export interface QueryInsightsSettingsResponse {
   cpu?: MetricSettingsResponse;
   memory?: MetricSettingsResponse;
   group_by?: string;
-  delete_after_days?: string;
+  exporter?: ExporterSettingsResponse;
 }

--- a/types/types.ts
+++ b/types/types.ts
@@ -47,3 +47,20 @@ export interface Task {
   nodeId: string;
   taskResourceUsage: TaskResourceUsage;
 }
+
+export interface MetricSettingsResponse {
+  enabled?: string; // Could be 'true' or 'false'
+  window_size?: string; // E.g., '15m', '1h'
+  top_n_size?: string;
+  exporter?: {
+    type?: string;
+  };
+}
+
+export interface QueryInsightsSettingsResponse {
+  latency?: MetricSettingsResponse;
+  cpu?: MetricSettingsResponse;
+  memory?: MetricSettingsResponse;
+  group_by?: string;
+  delete_after_days?: string;
+}


### PR DESCRIPTION
### Description
This PR adds configuration panels for 
- Query Insights Exporters 
- the newly added configuration endpoint `delete_after_days` https://github.com/opensearch-project/query-insights/pull/172

- enabled
<img width="1918" alt="image" src="https://github.com/user-attachments/assets/7449855f-e9f2-42ab-84d5-0b1f8f75d94b" />


- when exporter disabled, delete_after days should also be disabled
<img width="959" alt="image" src="https://github.com/user-attachments/assets/d9b118d0-0bba-4a26-87c3-4f207a0ea0d5" />


### Issues Resolved
https://github.com/opensearch-project/query-insights-dashboards/issues/47

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
