### PR TITLE
Version decoupling and tests for MDS

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -6,5 +6,7 @@
   "ui": true,
   "requiredPlugins": ["navigation"],
   "optionalPlugins": ["dataSource",
-    "dataSourceManagement"]
+    "dataSourceManagement"],
+  "supportedOSDataSourceVersions": ">=2.19.0",
+  "requiredOSDataSourcePlugins": ["query-insights"]
 }

--- a/public/components/DataSourcePicker.tsx
+++ b/public/components/DataSourcePicker.tsx
@@ -11,6 +11,7 @@ import {
 } from 'src/plugins/data_source_management/public';
 import { AppMountParameters, CoreStart } from '../../../../src/core/public';
 import { QueryInsightsDashboardsPluginStartDependencies } from '../types';
+import { getDataSourceEnabledUrl, isDataSourceCompatible } from '../utils/datasource-utils';
 
 export interface DataSourceMenuProps {
   dataSourceManagement?: DataSourceManagementPluginSetup;
@@ -22,23 +23,6 @@ export interface DataSourceMenuProps {
   onManageDataSource: () => void;
   onSelectedDataSource: () => void;
   dataSourcePickerReadOnly: boolean;
-}
-
-export function getDataSourceEnabledUrl(dataSource: DataSourceOption) {
-  const url = new URL(window.location.href);
-  url.searchParams.set('dataSource', JSON.stringify(dataSource));
-  return url;
-}
-
-export function getDataSourceFromUrl(): DataSourceOption {
-  const urlParams = new URLSearchParams(window.location.search);
-  const dataSourceParam = (urlParams && urlParams.get('dataSource')) || '{}';
-  // following block is needed if the dataSource param is set to non-JSON value, say 'undefined'
-  try {
-    return JSON.parse(dataSourceParam);
-  } catch (e) {
-    return JSON.parse('{}'); // Return an empty object or some default value if parsing fails
-  }
 }
 
 export const QueryInsightsDataSourceMenu = React.memo(
@@ -78,6 +62,7 @@ export const QueryInsightsDataSourceMenu = React.memo(
             selectedDataSource.id || selectedDataSource.label ? [selectedDataSource] : undefined,
           onSelectedDataSources: wrapSetDataSourceWithUpdateUrl,
           fullWidth: true,
+          dataSourceFilter: isDataSourceCompatible,
         }}
       />
     ) : null;

--- a/public/pages/QueryDetails/QueryDetails.tsx
+++ b/public/pages/QueryDetails/QueryDetails.tsx
@@ -27,10 +27,9 @@ import { SearchQueryRecord } from '../../../types/types';
 import { PageHeader } from '../../components/PageHeader';
 import { QueryInsightsDashboardsPluginStartDependencies } from '../../types';
 import { retrieveQueryById } from '../Utils/QueryUtils';
-import {
-  getDataSourceFromUrl,
-  QueryInsightsDataSourceMenu,
-} from '../../components/DataSourcePicker';
+import { QueryInsightsDataSourceMenu } from '../../components/DataSourcePicker';
+
+import { getDataSourceFromUrl } from '../../utils/datasource-utils';
 
 const QueryDetails = ({
   core,

--- a/public/pages/QueryGroupDetails/QueryGroupDetails.tsx
+++ b/public/pages/QueryGroupDetails/QueryGroupDetails.tsx
@@ -30,10 +30,8 @@ import { QueryInsightsDashboardsPluginStartDependencies } from '../../types';
 import { PageHeader } from '../../components/PageHeader';
 import { SearchQueryRecord } from '../../../types/types';
 import { retrieveQueryById } from '../Utils/QueryUtils';
-import {
-  getDataSourceFromUrl,
-  QueryInsightsDataSourceMenu,
-} from '../../components/DataSourcePicker';
+import { QueryInsightsDataSourceMenu } from '../../components/DataSourcePicker';
+import { getDataSourceFromUrl } from '../../utils/datasource-utils';
 
 export const QueryGroupDetails = ({
   core,

--- a/public/pages/TopNQueries/TopNQueries.tsx
+++ b/public/pages/TopNQueries/TopNQueries.tsx
@@ -32,7 +32,7 @@ import {
   getMergedStringSettings,
   getTimeAndUnitFromString,
 } from '../Utils/MetricUtils';
-import { getDataSourceFromUrl } from '../../components/DataSourcePicker';
+import { getDataSourceFromUrl } from '../../utils/datasource-utils';
 import { EXPORTER_TYPE } from '../Utils/Constants';
 
 export const QUERY_INSIGHTS = '/queryInsights';

--- a/public/utils/datasource-utils.test.ts
+++ b/public/utils/datasource-utils.test.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { getDataSourceFromUrl, isDataSourceCompatible } from './datasource-utils';
+
+describe('Tests datasource utils', () => {
+  it('Tests getting the datasource from the url', () => {
+    const mockSearchNoDataSourceId = '?foo=bar&baz=qux';
+    Object.defineProperty(window, 'location', {
+      value: { search: mockSearchNoDataSourceId },
+      writable: true,
+    });
+    expect(getDataSourceFromUrl()).toEqual({});
+    const mockSearchDataSourceIdNotfirst =
+      '?foo=bar&baz=qux&dataSource=%7B"id"%3A"94ffa650-f11a-11ee-a585-793f7b098e1a"%2C"label"%3A"9202"%7D';
+    Object.defineProperty(window, 'location', {
+      value: { search: mockSearchDataSourceIdNotfirst },
+      writable: true,
+    });
+    expect(getDataSourceFromUrl()).toEqual({
+      id: '94ffa650-f11a-11ee-a585-793f7b098e1a',
+      label: '9202',
+    });
+    const mockSearchDataSourceIdFirst =
+      '?dataSource=%7B"id"%3A"94ffa650-f11a-11ee-a585-793f7b098e1a"%2C"label"%3A"9202"%7D';
+    Object.defineProperty(window, 'location', {
+      value: { search: mockSearchDataSourceIdFirst },
+      writable: true,
+    });
+    expect(getDataSourceFromUrl()).toEqual({
+      id: '94ffa650-f11a-11ee-a585-793f7b098e1a',
+      label: '9202',
+    });
+  });
+
+  it('Tests getting the datasource from the url with undefined dataSource', () => {
+    const mockSearchUndefinedDataSource = '?dataSource=undefined';
+    Object.defineProperty(window, 'location', {
+      value: { search: mockSearchUndefinedDataSource },
+      writable: true,
+    });
+    expect(getDataSourceFromUrl()).toEqual({});
+  });
+
+  describe('isDataSourceCompatible', () => {
+    it('should return true for compatible data sources', () => {
+      expect(
+        isDataSourceCompatible({
+          attributes: {
+            installedPlugins: ['query-insights'],
+            dataSourceVersion: '2.19.0',
+            title: '',
+            endpoint: '',
+            auth: {
+              type: '',
+              credentials: undefined,
+            },
+          },
+          id: '',
+          type: '',
+          references: [],
+        })
+      ).toBe(true);
+      expect(
+        isDataSourceCompatible({
+          attributes: {
+            installedPlugins: ['query-insights'],
+            dataSourceVersion: '3.0.0',
+            title: '',
+            endpoint: '',
+            auth: {
+              type: '',
+              credentials: undefined,
+            },
+          },
+          id: '',
+          type: '',
+          references: [],
+        })
+      ).toBe(true);
+    });
+
+    it('should return false for un-compatible data sources', () => {
+      expect(
+        isDataSourceCompatible({
+          attributes: {
+            installedPlugins: [],
+            dataSourceVersion: '2.13.0',
+            title: '',
+            endpoint: '',
+            auth: {
+              type: '',
+              credentials: undefined,
+            },
+          },
+          id: '',
+          type: '',
+          references: [],
+        })
+      ).toBe(false);
+      expect(
+        isDataSourceCompatible({
+          attributes: {
+            installedPlugins: ['query-insights'],
+            dataSourceVersion: '2.13.0',
+            title: '',
+            endpoint: '',
+            auth: {
+              type: '',
+              credentials: undefined,
+            },
+          },
+          id: '',
+          type: '',
+          references: [],
+        })
+      ).toBe(false);
+      expect(
+        isDataSourceCompatible({
+          attributes: {
+            title: '',
+            endpoint: '',
+            dataSourceVersion: '',
+            auth: {
+              type: '',
+              credentials: undefined,
+            },
+          },
+          id: '',
+          type: '',
+          references: [],
+        })
+      ).toBe(false);
+      expect(
+        isDataSourceCompatible({
+          attributes: {
+            installedPlugins: ['random'],
+            dataSourceVersion: '1.0.0-beta1',
+            title: '',
+            endpoint: '',
+            auth: {
+              type: '',
+              credentials: undefined,
+            },
+          },
+          id: '',
+          type: '',
+          references: [],
+        })
+      ).toBe(false);
+    });
+  });
+});

--- a/public/utils/datasource-utils.ts
+++ b/public/utils/datasource-utils.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import semver from 'semver';
+import { DataSourceOption } from 'src/plugins/data_source_management/public';
+import pluginManifest from '../../opensearch_dashboards.json';
+import type { SavedObject } from '../../../../src/core/public';
+import type { DataSourceAttributes } from '../../../../src/plugins/data_source/common/data_sources';
+
+export function getDataSourceEnabledUrl(dataSource: DataSourceOption) {
+  const url = new URL(window.location.href);
+  url.searchParams.set('dataSource', JSON.stringify(dataSource));
+  return url;
+}
+
+export function getDataSourceFromUrl(): DataSourceOption {
+  const urlParams = new URLSearchParams(window.location.search);
+  const dataSourceParam = (urlParams && urlParams.get('dataSource')) || '{}';
+  // following block is needed if the dataSource param is set to non-JSON value, say 'undefined'
+  try {
+    return JSON.parse(dataSourceParam);
+  } catch (e) {
+    return JSON.parse('{}'); // Return an empty object or some default value if parsing fails
+  }
+}
+
+export const isDataSourceCompatible = (dataSource: SavedObject<DataSourceAttributes>) => {
+  if (
+    'requiredOSDataSourcePlugins' in pluginManifest &&
+    !pluginManifest.requiredOSDataSourcePlugins.every((plugin) =>
+      dataSource.attributes.installedPlugins?.includes(plugin)
+    )
+  ) {
+    return false;
+  }
+
+  // filter out data sources which is NOT in the support range of plugin
+  if (
+    'supportedOSDataSourceVersions' in pluginManifest &&
+    !semver.satisfies(
+      dataSource.attributes.dataSourceVersion,
+      pluginManifest.supportedOSDataSourceVersions
+    )
+  ) {
+    return false;
+  }
+  return true;
+};


### PR DESCRIPTION
### Description
Support cersion decoupling and added unit tests for MDS
- Add a cluster `dstest` with expected version
- Add another cluster with lower version
- Only `dstest` is shown on the selector
<img width="1127" alt="image" src="https://github.com/user-attachments/assets/e1b44f81-b1f9-4257-9503-cfa05d7c5585" />


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
