### PR TITLE
Fix all filters on the main page

### DIFF
--- a/public/pages/QueryInsights/QueryInsights.tsx
+++ b/public/pages/QueryInsights/QueryInsights.tsx
@@ -306,7 +306,7 @@ const QueryInsights = ({
               type: 'field_value_selection',
               field: GROUP_BY_FIELD,
               name: TYPE,
-              multiSelect: true,
+              multiSelect: 'or',
               options: [
                 {
                   value: 'NONE',
@@ -325,7 +325,7 @@ const QueryInsights = ({
               type: 'field_value_selection',
               field: INDICES_FIELD,
               name: INDICES,
-              multiSelect: true,
+              multiSelect: 'or',
               options: filterDuplicates(
                 queries.map((query) => {
                   const values = Array.from(new Set(query[INDICES_FIELD].flat()));
@@ -341,7 +341,7 @@ const QueryInsights = ({
               type: 'field_value_selection',
               field: SEARCH_TYPE_FIELD,
               name: SEARCH_TYPE,
-              multiSelect: false,
+              multiSelect: 'or',
               options: filterDuplicates(
                 queries.map((query) => ({
                   value: query[SEARCH_TYPE_FIELD],
@@ -354,7 +354,7 @@ const QueryInsights = ({
               type: 'field_value_selection',
               field: NODE_ID_FIELD,
               name: NODE_ID,
-              multiSelect: true,
+              multiSelect: 'or',
               options: filterDuplicates(
                 queries.map((query) => ({
                   value: query[NODE_ID_FIELD],


### PR DESCRIPTION
### Description
_Describe what this change achieves._
All the filter types of the query insights dashboards main page do not work properly when selecting multiple values.

Example: if we select type=query and type=group it shows an empty table.

This PR fixes the above.

![image](https://github.com/user-attachments/assets/43cf91e4-eacf-4145-865a-8881aed8e1e0)


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 
closes: https://github.com/opensearch-project/query-insights-dashboards/issues/77

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
