### PR TITLE
Fix QI-Styling-Configuration

### DIFF
--- a/public/pages/Configuration/Configuration.tsx
+++ b/public/pages/Configuration/Configuration.tsx
@@ -216,7 +216,6 @@ const Configuration = ({
     return windowVal >= 1 && windowVal <= 24;
   })();
 
-  const textPadding = { lineHeight: '22px', padding: '5px 0px' };
   const formRowPadding = { padding: '0px 0px 20px' };
   const enabledSymb = <EuiHealth color="primary">Enabled</EuiHealth>;
   const disabledSymb = <EuiHealth color="default">Disabled</EuiHealth>;
@@ -242,7 +241,7 @@ const Configuration = ({
             <EuiForm>
               <EuiFlexItem>
                 <EuiTitle size="s">
-                    <h2>Top n queries monitoring configuration settings</h2>
+                  <h2>Top n queries monitoring configuration settings</h2>
                 </EuiTitle>
               </EuiFlexItem>
               <EuiFlexItem>
@@ -301,7 +300,8 @@ const Configuration = ({
                           listItems={[
                             {
                               title: <h3>Value of N (count)</h3>,
-                              description: 'Specify the value of N. N is the number of queries to be collected within the window size.',
+                              description:
+                                'Specify the value of N. N is the number of queries to be collected within the window size.',
                             },
                           ]}
                         />
@@ -327,7 +327,8 @@ const Configuration = ({
                           listItems={[
                             {
                               title: <h3>Window size</h3>,
-                              description: ' The duration during which the Top N queries are collected.',
+                              description:
+                                ' The duration during which the Top N queries are collected.',
                             },
                           ]}
                         />
@@ -365,7 +366,7 @@ const Configuration = ({
           <EuiPanel paddingSize="m" grow={false}>
             <EuiFlexItem>
               <EuiTitle size="s">
-                  <h2>Statuses for configuration metrics</h2>
+                <h2>Statuses for configuration metrics</h2>
               </EuiTitle>
             </EuiFlexItem>
             <EuiFlexItem>
@@ -406,7 +407,7 @@ const Configuration = ({
             <EuiForm>
               <EuiFlexItem>
                 <EuiTitle size="s">
-                    <h2>Top n queries grouping configuration settings</h2>
+                  <h2>Top n queries grouping configuration settings</h2>
                 </EuiTitle>
               </EuiFlexItem>
               <EuiFlexItem>
@@ -442,7 +443,7 @@ const Configuration = ({
           <EuiPanel paddingSize="m" grow={false}>
             <EuiFlexItem>
               <EuiTitle size="s">
-                  <h2>Statuses for group by</h2>
+                <h2>Statuses for group by</h2>
               </EuiTitle>
             </EuiFlexItem>
             <EuiFlexItem>
@@ -465,7 +466,7 @@ const Configuration = ({
             <EuiForm>
               <EuiFlexItem>
                 <EuiTitle size="s">
-                    <h2>Query Insights export and data retention settings</h2>
+                  <h2>Query Insights export and data retention settings</h2>
                 </EuiTitle>
               </EuiFlexItem>
               <EuiFlexItem>
@@ -523,7 +524,7 @@ const Configuration = ({
           <EuiPanel paddingSize="m" grow={false}>
             <EuiFlexItem>
               <EuiTitle size="s">
-                  <h2>Statuses for data retention</h2>
+                <h2>Statuses for data retention</h2>
               </EuiTitle>
             </EuiFlexItem>
             <EuiFlexItem>

--- a/public/pages/Configuration/Configuration.tsx
+++ b/public/pages/Configuration/Configuration.tsx
@@ -21,6 +21,7 @@ import {
   EuiSwitch,
   EuiText,
   EuiTitle,
+  EuiDescriptionList,
 } from '@elastic/eui';
 import { useHistory, useLocation } from 'react-router-dom';
 import { AppMountParameters, CoreStart } from 'opensearch-dashboards/public';
@@ -241,20 +242,21 @@ const Configuration = ({
             <EuiForm>
               <EuiFlexItem>
                 <EuiTitle size="s">
-                  <EuiText size="s">
                     <h2>Top n queries monitoring configuration settings</h2>
-                  </EuiText>
                 </EuiTitle>
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiFlexGrid columns={2} gutterSize="s" style={{ padding: '15px 0px' }}>
                   <EuiFlexItem>
-                    <EuiText size="xs">
-                      <h3>Metric Type</h3>
-                    </EuiText>
-                    <EuiText size="xs" style={textPadding}>
-                      Specify the metric type to set settings for.
-                    </EuiText>
+                    <EuiDescriptionList
+                      compressed={true}
+                      listItems={[
+                        {
+                          title: <h3>Metric Type</h3>,
+                          description: 'Specify the metric type to set settings for.',
+                        },
+                      ]}
+                    />
                   </EuiFlexItem>
                   <EuiFlexItem>
                     <EuiFormRow style={formRowPadding}>
@@ -268,12 +270,15 @@ const Configuration = ({
                     </EuiFormRow>
                   </EuiFlexItem>
                   <EuiFlexItem>
-                    <EuiText size="xs">
-                      <h3>Enabled</h3>
-                    </EuiText>
-                    <EuiText size="xs" style={textPadding}>
-                      {`Enable/disable top N query monitoring by ${metric}.`}
-                    </EuiText>
+                    <EuiDescriptionList
+                      compressed={true}
+                      listItems={[
+                        {
+                          title: <h3>Enabled</h3>,
+                          description: 'Enable/disable top N query monitoring by ${metric}.',
+                        },
+                      ]}
+                    />
                   </EuiFlexItem>
                   <EuiFlexItem>
                     <EuiFormRow style={formRowPadding}>
@@ -291,13 +296,15 @@ const Configuration = ({
                   {isEnabled ? (
                     <>
                       <EuiFlexItem>
-                        <EuiText size="xs">
-                          <h3>Value of N (count)</h3>
-                        </EuiText>
-                        <EuiText size="xs" style={textPadding}>
-                          Specify the value of N. N is the number of queries to be collected within
-                          the window size.
-                        </EuiText>
+                        <EuiDescriptionList
+                          compressed={true}
+                          listItems={[
+                            {
+                              title: <h3>Value of N (count)</h3>,
+                              description: 'Specify the value of N. N is the number of queries to be collected within the window size.',
+                            },
+                          ]}
+                        />
                       </EuiFlexItem>
                       <EuiFlexItem>
                         <EuiFormRow
@@ -315,12 +322,15 @@ const Configuration = ({
                         </EuiFormRow>
                       </EuiFlexItem>
                       <EuiFlexItem>
-                        <EuiText size="xs">
-                          <h3>Window size</h3>
-                        </EuiText>
-                        <EuiText size="xs" style={textPadding}>
-                          The duration during which the Top N queries are collected.
-                        </EuiText>
+                        <EuiDescriptionList
+                          compressed={true}
+                          listItems={[
+                            {
+                              title: <h3>Window size</h3>,
+                              description: ' The duration during which the Top N queries are collected.',
+                            },
+                          ]}
+                        />
                       </EuiFlexItem>
                       <EuiFlexItem>
                         <EuiFormRow
@@ -355,15 +365,13 @@ const Configuration = ({
           <EuiPanel paddingSize="m" grow={false}>
             <EuiFlexItem>
               <EuiTitle size="s">
-                <EuiText size="s">
                   <h2>Statuses for configuration metrics</h2>
-                </EuiText>
               </EuiTitle>
             </EuiFlexItem>
             <EuiFlexItem>
               <EuiFlexGroup>
                 <EuiFlexItem>
-                  <EuiText size="m">Latency</EuiText>
+                  <EuiText size="s">Latency</EuiText>
                 </EuiFlexItem>
                 <EuiFlexItem>
                   <EuiSpacer size="xs" />
@@ -372,7 +380,7 @@ const Configuration = ({
               </EuiFlexGroup>
               <EuiFlexGroup>
                 <EuiFlexItem>
-                  <EuiText size="m">CPU Usage</EuiText>
+                  <EuiText size="s">CPU Usage</EuiText>
                 </EuiFlexItem>
                 <EuiFlexItem>
                   <EuiSpacer size="xs" />
@@ -381,7 +389,7 @@ const Configuration = ({
               </EuiFlexGroup>
               <EuiFlexGroup>
                 <EuiFlexItem>
-                  <EuiText size="m">Memory</EuiText>
+                  <EuiText size="s">Memory</EuiText>
                 </EuiFlexItem>
                 <EuiFlexItem>
                   <EuiSpacer size="xs" />
@@ -398,20 +406,21 @@ const Configuration = ({
             <EuiForm>
               <EuiFlexItem>
                 <EuiTitle size="s">
-                  <EuiText size="s">
                     <h2>Top n queries grouping configuration settings</h2>
-                  </EuiText>
                 </EuiTitle>
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiFlexGrid columns={2} gutterSize="s" style={{ padding: '15px 0px' }}>
                   <EuiFlexItem>
-                    <EuiText size="xs">
-                      <h3>Group By</h3>
-                    </EuiText>
-                    <EuiText size="xs" style={textPadding}>
-                      Specify the group by type.
-                    </EuiText>
+                    <EuiDescriptionList
+                      compressed={true}
+                      listItems={[
+                        {
+                          title: <h3>Group By</h3>,
+                          description: ' Specify the group by type.',
+                        },
+                      ]}
+                    />
                   </EuiFlexItem>
                   <EuiFlexItem>
                     <EuiFormRow style={formRowPadding}>
@@ -433,15 +442,13 @@ const Configuration = ({
           <EuiPanel paddingSize="m" grow={false}>
             <EuiFlexItem>
               <EuiTitle size="s">
-                <EuiText size="s">
                   <h2>Statuses for group by</h2>
-                </EuiText>
               </EuiTitle>
             </EuiFlexItem>
             <EuiFlexItem>
               <EuiFlexGroup>
                 <EuiFlexItem>
-                  <EuiText size="m">Group By</EuiText>
+                  <EuiText size="s">Group By</EuiText>
                 </EuiFlexItem>
                 <EuiFlexItem>
                   <EuiSpacer size="xs" />
@@ -458,20 +465,21 @@ const Configuration = ({
             <EuiForm>
               <EuiFlexItem>
                 <EuiTitle size="s">
-                  <EuiText size="s">
                     <h2>Query Insights export and data retention settings</h2>
-                  </EuiText>
                 </EuiTitle>
               </EuiFlexItem>
               <EuiFlexItem>
                 <EuiFlexGrid columns={2} gutterSize="s" style={{ padding: '15px 0px' }}>
                   <EuiFlexItem>
-                    <EuiText size="xs">
-                      <h3>Exporter</h3>
-                    </EuiText>
-                    <EuiText size="xs" style={textPadding}>
-                      Configure a sink for exporting Query Insights data.
-                    </EuiText>
+                    <EuiDescriptionList
+                      compressed={true}
+                      listItems={[
+                        {
+                          title: <h3>Exporter</h3>,
+                          description: ' Configure a sink for exporting Query Insights data.',
+                        },
+                      ]}
+                    />
                   </EuiFlexItem>
                   <EuiFlexItem>
                     <EuiFormRow style={formRowPadding}>
@@ -485,12 +493,15 @@ const Configuration = ({
                     </EuiFormRow>
                   </EuiFlexItem>
                   <EuiFlexItem>
-                    <EuiText size="xs">
-                      <h3>Delete After (days)</h3>
-                    </EuiText>
-                    <EuiText size="xs" style={textPadding}>
-                      Number of days to retain Query Insights data.
-                    </EuiText>
+                    <EuiDescriptionList
+                      compressed={true}
+                      listItems={[
+                        {
+                          title: <h3>Delete After (days)</h3>,
+                          description: ' Number of days to retain Query Insights data.',
+                        },
+                      ]}
+                    />
                   </EuiFlexItem>
                   <EuiFlexItem>
                     <EuiFormRow style={formRowPadding}>
@@ -512,15 +523,13 @@ const Configuration = ({
           <EuiPanel paddingSize="m" grow={false}>
             <EuiFlexItem>
               <EuiTitle size="s">
-                <EuiText size="s">
                   <h2>Statuses for data retention</h2>
-                </EuiText>
               </EuiTitle>
             </EuiFlexItem>
             <EuiFlexItem>
               <EuiFlexGroup>
                 <EuiFlexItem>
-                  <EuiText size="m">Exporter</EuiText>
+                  <EuiText size="s">Exporter</EuiText>
                 </EuiFlexItem>
                 <EuiFlexItem>
                   <EuiSpacer size="xs" />

--- a/public/pages/Configuration/__snapshots__/Configuration.test.tsx.snap
+++ b/public/pages/Configuration/__snapshots__/Configuration.test.tsx.snap
@@ -18,13 +18,11 @@ exports[`Configuration Component renders with default settings: should match def
             <div
               class="euiFlexItem"
             >
-              <div
-                class="euiText euiText--small euiTitle euiTitle--small"
+              <h2
+                class="euiTitle euiTitle--small"
               >
-                <h2>
-                  Top n queries monitoring configuration settings
-                </h2>
-              </div>
+                Top n queries monitoring configuration settings
+              </h2>
             </div>
             <div
               class="euiFlexItem"
@@ -36,19 +34,22 @@ exports[`Configuration Component renders with default settings: should match def
                 <div
                   class="euiFlexItem"
                 >
-                  <div
-                    class="euiText euiText--extraSmall"
+                  <dl
+                    class="euiDescriptionList euiDescriptionList--row euiDescriptionList--compressed"
                   >
-                    <h3>
-                      Metric Type
-                    </h3>
-                  </div>
-                  <div
-                    class="euiText euiText--extraSmall"
-                    style="line-height: 22px; padding: 5px 0px;"
-                  >
-                    Specify the metric type to set settings for.
-                  </div>
+                    <dt
+                      class="euiDescriptionList__title"
+                    >
+                      <h3>
+                        Metric Type
+                      </h3>
+                    </dt>
+                    <dd
+                      class="euiDescriptionList__description"
+                    >
+                      Specify the metric type to set settings for.
+                    </dd>
+                  </dl>
                 </div>
                 <div
                   class="euiFlexItem"
@@ -118,19 +119,22 @@ exports[`Configuration Component renders with default settings: should match def
                 <div
                   class="euiFlexItem"
                 >
-                  <div
-                    class="euiText euiText--extraSmall"
+                  <dl
+                    class="euiDescriptionList euiDescriptionList--row euiDescriptionList--compressed"
                   >
-                    <h3>
-                      Enabled
-                    </h3>
-                  </div>
-                  <div
-                    class="euiText euiText--extraSmall"
-                    style="line-height: 22px; padding: 5px 0px;"
-                  >
-                    Enable/disable top N query monitoring by latency.
-                  </div>
+                    <dt
+                      class="euiDescriptionList__title"
+                    >
+                      <h3>
+                        Enabled
+                      </h3>
+                    </dt>
+                    <dd
+                      class="euiDescriptionList__description"
+                    >
+                      Enable/disable top N query monitoring by \${metric}.
+                    </dd>
+                  </dl>
                 </div>
                 <div
                   class="euiFlexItem"
@@ -214,19 +218,22 @@ exports[`Configuration Component renders with default settings: should match def
                 <div
                   class="euiFlexItem"
                 >
-                  <div
-                    class="euiText euiText--extraSmall"
+                  <dl
+                    class="euiDescriptionList euiDescriptionList--row euiDescriptionList--compressed"
                   >
-                    <h3>
-                      Value of N (count)
-                    </h3>
-                  </div>
-                  <div
-                    class="euiText euiText--extraSmall"
-                    style="line-height: 22px; padding: 5px 0px;"
-                  >
-                    Specify the value of N. N is the number of queries to be collected within the window size.
-                  </div>
+                    <dt
+                      class="euiDescriptionList__title"
+                    >
+                      <h3>
+                        Value of N (count)
+                      </h3>
+                    </dt>
+                    <dd
+                      class="euiDescriptionList__description"
+                    >
+                      Specify the value of N. N is the number of queries to be collected within the window size.
+                    </dd>
+                  </dl>
                 </div>
                 <div
                   class="euiFlexItem"
@@ -279,19 +286,22 @@ exports[`Configuration Component renders with default settings: should match def
                 <div
                   class="euiFlexItem"
                 >
-                  <div
-                    class="euiText euiText--extraSmall"
+                  <dl
+                    class="euiDescriptionList euiDescriptionList--row euiDescriptionList--compressed"
                   >
-                    <h3>
-                      Window size
-                    </h3>
-                  </div>
-                  <div
-                    class="euiText euiText--extraSmall"
-                    style="line-height: 22px; padding: 5px 0px;"
-                  >
-                    The duration during which the Top N queries are collected.
-                  </div>
+                    <dt
+                      class="euiDescriptionList__title"
+                    >
+                      <h3>
+                        Window size
+                      </h3>
+                    </dt>
+                    <dd
+                      class="euiDescriptionList__description"
+                    >
+                       The duration during which the Top N queries are collected.
+                    </dd>
+                  </dl>
                 </div>
                 <div
                   class="euiFlexItem"
@@ -454,13 +464,11 @@ exports[`Configuration Component renders with default settings: should match def
           <div
             class="euiFlexItem"
           >
-            <div
-              class="euiText euiText--small euiTitle euiTitle--small"
+            <h2
+              class="euiTitle euiTitle--small"
             >
-              <h2>
-                Statuses for configuration metrics
-              </h2>
-            </div>
+              Statuses for configuration metrics
+            </h2>
           </div>
           <div
             class="euiFlexItem"
@@ -472,7 +480,7 @@ exports[`Configuration Component renders with default settings: should match def
                 class="euiFlexItem"
               >
                 <div
-                  class="euiText euiText--medium"
+                  class="euiText euiText--small"
                 >
                   Latency
                 </div>
@@ -523,7 +531,7 @@ exports[`Configuration Component renders with default settings: should match def
                 class="euiFlexItem"
               >
                 <div
-                  class="euiText euiText--medium"
+                  class="euiText euiText--small"
                 >
                   CPU Usage
                 </div>
@@ -574,7 +582,7 @@ exports[`Configuration Component renders with default settings: should match def
                 class="euiFlexItem"
               >
                 <div
-                  class="euiText euiText--medium"
+                  class="euiText euiText--small"
                 >
                   Memory
                 </div>
@@ -637,13 +645,11 @@ exports[`Configuration Component renders with default settings: should match def
             <div
               class="euiFlexItem"
             >
-              <div
-                class="euiText euiText--small euiTitle euiTitle--small"
+              <h2
+                class="euiTitle euiTitle--small"
               >
-                <h2>
-                  Top n queries grouping configuration settings
-                </h2>
-              </div>
+                Top n queries grouping configuration settings
+              </h2>
             </div>
             <div
               class="euiFlexItem"
@@ -655,19 +661,22 @@ exports[`Configuration Component renders with default settings: should match def
                 <div
                   class="euiFlexItem"
                 >
-                  <div
-                    class="euiText euiText--extraSmall"
+                  <dl
+                    class="euiDescriptionList euiDescriptionList--row euiDescriptionList--compressed"
                   >
-                    <h3>
-                      Group By
-                    </h3>
-                  </div>
-                  <div
-                    class="euiText euiText--extraSmall"
-                    style="line-height: 22px; padding: 5px 0px;"
-                  >
-                    Specify the group by type.
-                  </div>
+                    <dt
+                      class="euiDescriptionList__title"
+                    >
+                      <h3>
+                        Group By
+                      </h3>
+                    </dt>
+                    <dd
+                      class="euiDescriptionList__description"
+                    >
+                       Specify the group by type.
+                    </dd>
+                  </dl>
                 </div>
                 <div
                   class="euiFlexItem"
@@ -743,13 +752,11 @@ exports[`Configuration Component renders with default settings: should match def
           <div
             class="euiFlexItem"
           >
-            <div
-              class="euiText euiText--small euiTitle euiTitle--small"
+            <h2
+              class="euiTitle euiTitle--small"
             >
-              <h2>
-                Statuses for group by
-              </h2>
-            </div>
+              Statuses for group by
+            </h2>
           </div>
           <div
             class="euiFlexItem"
@@ -761,7 +768,7 @@ exports[`Configuration Component renders with default settings: should match def
                 class="euiFlexItem"
               >
                 <div
-                  class="euiText euiText--medium"
+                  class="euiText euiText--small"
                 >
                   Group By
                 </div>
@@ -824,13 +831,11 @@ exports[`Configuration Component renders with default settings: should match def
             <div
               class="euiFlexItem"
             >
-              <div
-                class="euiText euiText--small euiTitle euiTitle--small"
+              <h2
+                class="euiTitle euiTitle--small"
               >
-                <h2>
-                  Query Insights export and data retention settings
-                </h2>
-              </div>
+                Query Insights export and data retention settings
+              </h2>
             </div>
             <div
               class="euiFlexItem"
@@ -842,19 +847,22 @@ exports[`Configuration Component renders with default settings: should match def
                 <div
                   class="euiFlexItem"
                 >
-                  <div
-                    class="euiText euiText--extraSmall"
+                  <dl
+                    class="euiDescriptionList euiDescriptionList--row euiDescriptionList--compressed"
                   >
-                    <h3>
-                      Exporter
-                    </h3>
-                  </div>
-                  <div
-                    class="euiText euiText--extraSmall"
-                    style="line-height: 22px; padding: 5px 0px;"
-                  >
-                    Configure a sink for exporting Query Insights data.
-                  </div>
+                    <dt
+                      class="euiDescriptionList__title"
+                    >
+                      <h3>
+                        Exporter
+                      </h3>
+                    </dt>
+                    <dd
+                      class="euiDescriptionList__description"
+                    >
+                       Configure a sink for exporting Query Insights data.
+                    </dd>
+                  </dl>
                 </div>
                 <div
                   class="euiFlexItem"
@@ -919,19 +927,22 @@ exports[`Configuration Component renders with default settings: should match def
                 <div
                   class="euiFlexItem"
                 >
-                  <div
-                    class="euiText euiText--extraSmall"
+                  <dl
+                    class="euiDescriptionList euiDescriptionList--row euiDescriptionList--compressed"
                   >
-                    <h3>
-                      Delete After (days)
-                    </h3>
-                  </div>
-                  <div
-                    class="euiText euiText--extraSmall"
-                    style="line-height: 22px; padding: 5px 0px;"
-                  >
-                    Number of days to retain Query Insights data.
-                  </div>
+                    <dt
+                      class="euiDescriptionList__title"
+                    >
+                      <h3>
+                        Delete After (days)
+                      </h3>
+                    </dt>
+                    <dd
+                      class="euiDescriptionList__description"
+                    >
+                       Number of days to retain Query Insights data.
+                    </dd>
+                  </dl>
                 </div>
                 <div
                   class="euiFlexItem"
@@ -977,13 +988,11 @@ exports[`Configuration Component renders with default settings: should match def
           <div
             class="euiFlexItem"
           >
-            <div
-              class="euiText euiText--small euiTitle euiTitle--small"
+            <h2
+              class="euiTitle euiTitle--small"
             >
-              <h2>
-                Statuses for data retention
-              </h2>
-            </div>
+              Statuses for data retention
+            </h2>
           </div>
           <div
             class="euiFlexItem"
@@ -995,7 +1004,7 @@ exports[`Configuration Component renders with default settings: should match def
                 class="euiFlexItem"
               >
                 <div
-                  class="euiText euiText--medium"
+                  class="euiText euiText--small"
                 >
                   Exporter
                 </div>
@@ -1065,13 +1074,11 @@ exports[`Configuration Component updates state when toggling metrics and enables
             <div
               class="euiFlexItem"
             >
-              <div
-                class="euiText euiText--small euiTitle euiTitle--small"
+              <h2
+                class="euiTitle euiTitle--small"
               >
-                <h2>
-                  Top n queries monitoring configuration settings
-                </h2>
-              </div>
+                Top n queries monitoring configuration settings
+              </h2>
             </div>
             <div
               class="euiFlexItem"
@@ -1083,19 +1090,22 @@ exports[`Configuration Component updates state when toggling metrics and enables
                 <div
                   class="euiFlexItem"
                 >
-                  <div
-                    class="euiText euiText--extraSmall"
+                  <dl
+                    class="euiDescriptionList euiDescriptionList--row euiDescriptionList--compressed"
                   >
-                    <h3>
-                      Metric Type
-                    </h3>
-                  </div>
-                  <div
-                    class="euiText euiText--extraSmall"
-                    style="line-height: 22px; padding: 5px 0px;"
-                  >
-                    Specify the metric type to set settings for.
-                  </div>
+                    <dt
+                      class="euiDescriptionList__title"
+                    >
+                      <h3>
+                        Metric Type
+                      </h3>
+                    </dt>
+                    <dd
+                      class="euiDescriptionList__description"
+                    >
+                      Specify the metric type to set settings for.
+                    </dd>
+                  </dl>
                 </div>
                 <div
                   class="euiFlexItem"
@@ -1166,19 +1176,22 @@ exports[`Configuration Component updates state when toggling metrics and enables
                 <div
                   class="euiFlexItem"
                 >
-                  <div
-                    class="euiText euiText--extraSmall"
+                  <dl
+                    class="euiDescriptionList euiDescriptionList--row euiDescriptionList--compressed"
                   >
-                    <h3>
-                      Enabled
-                    </h3>
-                  </div>
-                  <div
-                    class="euiText euiText--extraSmall"
-                    style="line-height: 22px; padding: 5px 0px;"
-                  >
-                    Enable/disable top N query monitoring by cpu.
-                  </div>
+                    <dt
+                      class="euiDescriptionList__title"
+                    >
+                      <h3>
+                        Enabled
+                      </h3>
+                    </dt>
+                    <dd
+                      class="euiDescriptionList__description"
+                    >
+                      Enable/disable top N query monitoring by \${metric}.
+                    </dd>
+                  </dl>
                 </div>
                 <div
                   class="euiFlexItem"
@@ -1263,19 +1276,22 @@ exports[`Configuration Component updates state when toggling metrics and enables
                 <div
                   class="euiFlexItem"
                 >
-                  <div
-                    class="euiText euiText--extraSmall"
+                  <dl
+                    class="euiDescriptionList euiDescriptionList--row euiDescriptionList--compressed"
                   >
-                    <h3>
-                      Value of N (count)
-                    </h3>
-                  </div>
-                  <div
-                    class="euiText euiText--extraSmall"
-                    style="line-height: 22px; padding: 5px 0px;"
-                  >
-                    Specify the value of N. N is the number of queries to be collected within the window size.
-                  </div>
+                    <dt
+                      class="euiDescriptionList__title"
+                    >
+                      <h3>
+                        Value of N (count)
+                      </h3>
+                    </dt>
+                    <dd
+                      class="euiDescriptionList__description"
+                    >
+                      Specify the value of N. N is the number of queries to be collected within the window size.
+                    </dd>
+                  </dl>
                 </div>
                 <div
                   class="euiFlexItem"
@@ -1328,19 +1344,22 @@ exports[`Configuration Component updates state when toggling metrics and enables
                 <div
                   class="euiFlexItem"
                 >
-                  <div
-                    class="euiText euiText--extraSmall"
+                  <dl
+                    class="euiDescriptionList euiDescriptionList--row euiDescriptionList--compressed"
                   >
-                    <h3>
-                      Window size
-                    </h3>
-                  </div>
-                  <div
-                    class="euiText euiText--extraSmall"
-                    style="line-height: 22px; padding: 5px 0px;"
-                  >
-                    The duration during which the Top N queries are collected.
-                  </div>
+                    <dt
+                      class="euiDescriptionList__title"
+                    >
+                      <h3>
+                        Window size
+                      </h3>
+                    </dt>
+                    <dd
+                      class="euiDescriptionList__description"
+                    >
+                       The duration during which the Top N queries are collected.
+                    </dd>
+                  </dl>
                 </div>
                 <div
                   class="euiFlexItem"
@@ -1464,13 +1483,11 @@ exports[`Configuration Component updates state when toggling metrics and enables
           <div
             class="euiFlexItem"
           >
-            <div
-              class="euiText euiText--small euiTitle euiTitle--small"
+            <h2
+              class="euiTitle euiTitle--small"
             >
-              <h2>
-                Statuses for configuration metrics
-              </h2>
-            </div>
+              Statuses for configuration metrics
+            </h2>
           </div>
           <div
             class="euiFlexItem"
@@ -1482,7 +1499,7 @@ exports[`Configuration Component updates state when toggling metrics and enables
                 class="euiFlexItem"
               >
                 <div
-                  class="euiText euiText--medium"
+                  class="euiText euiText--small"
                 >
                   Latency
                 </div>
@@ -1535,7 +1552,7 @@ exports[`Configuration Component updates state when toggling metrics and enables
                 class="euiFlexItem"
               >
                 <div
-                  class="euiText euiText--medium"
+                  class="euiText euiText--small"
                 >
                   CPU Usage
                 </div>
@@ -1588,7 +1605,7 @@ exports[`Configuration Component updates state when toggling metrics and enables
                 class="euiFlexItem"
               >
                 <div
-                  class="euiText euiText--medium"
+                  class="euiText euiText--small"
                 >
                   Memory
                 </div>
@@ -1653,13 +1670,11 @@ exports[`Configuration Component updates state when toggling metrics and enables
             <div
               class="euiFlexItem"
             >
-              <div
-                class="euiText euiText--small euiTitle euiTitle--small"
+              <h2
+                class="euiTitle euiTitle--small"
               >
-                <h2>
-                  Top n queries grouping configuration settings
-                </h2>
-              </div>
+                Top n queries grouping configuration settings
+              </h2>
             </div>
             <div
               class="euiFlexItem"
@@ -1671,19 +1686,22 @@ exports[`Configuration Component updates state when toggling metrics and enables
                 <div
                   class="euiFlexItem"
                 >
-                  <div
-                    class="euiText euiText--extraSmall"
+                  <dl
+                    class="euiDescriptionList euiDescriptionList--row euiDescriptionList--compressed"
                   >
-                    <h3>
-                      Group By
-                    </h3>
-                  </div>
-                  <div
-                    class="euiText euiText--extraSmall"
-                    style="line-height: 22px; padding: 5px 0px;"
-                  >
-                    Specify the group by type.
-                  </div>
+                    <dt
+                      class="euiDescriptionList__title"
+                    >
+                      <h3>
+                        Group By
+                      </h3>
+                    </dt>
+                    <dd
+                      class="euiDescriptionList__description"
+                    >
+                       Specify the group by type.
+                    </dd>
+                  </dl>
                 </div>
                 <div
                   class="euiFlexItem"
@@ -1760,13 +1778,11 @@ exports[`Configuration Component updates state when toggling metrics and enables
           <div
             class="euiFlexItem"
           >
-            <div
-              class="euiText euiText--small euiTitle euiTitle--small"
+            <h2
+              class="euiTitle euiTitle--small"
             >
-              <h2>
-                Statuses for group by
-              </h2>
-            </div>
+              Statuses for group by
+            </h2>
           </div>
           <div
             class="euiFlexItem"
@@ -1778,7 +1794,7 @@ exports[`Configuration Component updates state when toggling metrics and enables
                 class="euiFlexItem"
               >
                 <div
-                  class="euiText euiText--medium"
+                  class="euiText euiText--small"
                 >
                   Group By
                 </div>
@@ -1843,13 +1859,11 @@ exports[`Configuration Component updates state when toggling metrics and enables
             <div
               class="euiFlexItem"
             >
-              <div
-                class="euiText euiText--small euiTitle euiTitle--small"
+              <h2
+                class="euiTitle euiTitle--small"
               >
-                <h2>
-                  Query Insights export and data retention settings
-                </h2>
-              </div>
+                Query Insights export and data retention settings
+              </h2>
             </div>
             <div
               class="euiFlexItem"
@@ -1861,19 +1875,22 @@ exports[`Configuration Component updates state when toggling metrics and enables
                 <div
                   class="euiFlexItem"
                 >
-                  <div
-                    class="euiText euiText--extraSmall"
+                  <dl
+                    class="euiDescriptionList euiDescriptionList--row euiDescriptionList--compressed"
                   >
-                    <h3>
-                      Exporter
-                    </h3>
-                  </div>
-                  <div
-                    class="euiText euiText--extraSmall"
-                    style="line-height: 22px; padding: 5px 0px;"
-                  >
-                    Configure a sink for exporting Query Insights data.
-                  </div>
+                    <dt
+                      class="euiDescriptionList__title"
+                    >
+                      <h3>
+                        Exporter
+                      </h3>
+                    </dt>
+                    <dd
+                      class="euiDescriptionList__description"
+                    >
+                       Configure a sink for exporting Query Insights data.
+                    </dd>
+                  </dl>
                 </div>
                 <div
                   class="euiFlexItem"
@@ -1939,19 +1956,22 @@ exports[`Configuration Component updates state when toggling metrics and enables
                 <div
                   class="euiFlexItem"
                 >
-                  <div
-                    class="euiText euiText--extraSmall"
+                  <dl
+                    class="euiDescriptionList euiDescriptionList--row euiDescriptionList--compressed"
                   >
-                    <h3>
-                      Delete After (days)
-                    </h3>
-                  </div>
-                  <div
-                    class="euiText euiText--extraSmall"
-                    style="line-height: 22px; padding: 5px 0px;"
-                  >
-                    Number of days to retain Query Insights data.
-                  </div>
+                    <dt
+                      class="euiDescriptionList__title"
+                    >
+                      <h3>
+                        Delete After (days)
+                      </h3>
+                    </dt>
+                    <dd
+                      class="euiDescriptionList__description"
+                    >
+                       Number of days to retain Query Insights data.
+                    </dd>
+                  </dl>
                 </div>
                 <div
                   class="euiFlexItem"
@@ -1997,13 +2017,11 @@ exports[`Configuration Component updates state when toggling metrics and enables
           <div
             class="euiFlexItem"
           >
-            <div
-              class="euiText euiText--small euiTitle euiTitle--small"
+            <h2
+              class="euiTitle euiTitle--small"
             >
-              <h2>
-                Statuses for data retention
-              </h2>
-            </div>
+              Statuses for data retention
+            </h2>
           </div>
           <div
             class="euiFlexItem"
@@ -2015,7 +2033,7 @@ exports[`Configuration Component updates state when toggling metrics and enables
                 class="euiFlexItem"
               >
                 <div
-                  class="euiText euiText--medium"
+                  class="euiText euiText--small"
                 >
                   Exporter
                 </div>


### PR DESCRIPTION
<img width="1728" alt="Screenshot 2025-01-29 at 1 02 37 PM" src="https://github.com/user-attachments/assets/96bad631-0cef-400f-9f90-7cb8275cc1ed" />
<img width="1728" alt="Screenshot 2025-01-29 at 3 09 37 PM" src="https://github.com/user-attachments/assets/611ebfb0-7717-4a07-a7c6-e293513b942d" />

### Description
This change introduces improvements to the configuration page by enhancing the UI and aligning it with the latest design guidelines. The main updates include:
- Ensuring the use of semantic header tags for accessibility.
- Adjusting text sizes for regular and heading text to match the type ramp specifications.
- Implementing consistent padding and layout for a clean and responsive design.
- Using `EuiFlexGroup`, `EuiPanel`, and other components to structure the content in a modular, maintainable manner.


### Changed Made

EuiDescriptionList Integration:
- Used to display configuration settings with their descriptions.
- Helps maintain a clear and concise UI.
- Configurations like "Enabled" and their respective descriptions (e.g., "Enable/disable top N query monitoring") are displayed in a compact and organized manner.
Compressed Layout:
- Utilized the compressed={true} prop to minimize the vertical space between items, ensuring the UI stays compact and avoids unnecessary scrolling.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
