### PR TITLE
fix sorting on top n queries table

### DIFF
--- a/common/utils/MetricUtils.ts
+++ b/common/utils/MetricUtils.ts
@@ -14,9 +14,16 @@ export function calculateMetric(
   defaultMsg: string = 'N/A'
 ): string {
   if (value !== undefined && count !== undefined) {
-    return `${(value / count / factor).toFixed(2)} ${unit}`;
+    return `${calculateMetricNumber(value, count, factor).toFixed(2)} ${unit}`;
   }
   return defaultMsg;
+}
+
+export function calculateMetricNumber(value?: number, count?: number, factor: number = 1): number {
+  if (value !== undefined && count !== undefined && count !== 0 && factor !== 0) {
+    return value / count / factor;
+  }
+  return 0;
 }
 
 export function getTimeUnitFromAbbreviation(timeUnit: string): string {

--- a/public/components/__snapshots__/app.test.tsx.snap
+++ b/public/components/__snapshots__/app.test.tsx.snap
@@ -570,7 +570,7 @@ exports[`<QueryInsightsDashboardsApp /> spec renders the component 1`] = `
                   aria-live="polite"
                   aria-sort="none"
                   class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_measurements_4"
+                  data-test-subj="tableHeaderCell_measurements.latency_4"
                   role="columnheader"
                   scope="col"
                 >
@@ -595,7 +595,7 @@ exports[`<QueryInsightsDashboardsApp /> spec renders the component 1`] = `
                   aria-live="polite"
                   aria-sort="none"
                   class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_measurements_5"
+                  data-test-subj="tableHeaderCell_measurements.cpu_5"
                   role="columnheader"
                   scope="col"
                 >
@@ -620,7 +620,7 @@ exports[`<QueryInsightsDashboardsApp /> spec renders the component 1`] = `
                   aria-live="polite"
                   aria-sort="none"
                   class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_measurements_6"
+                  data-test-subj="tableHeaderCell_measurements.memory_6"
                   role="columnheader"
                   scope="col"
                 >

--- a/public/pages/QueryInsights/QueryInsights.tsx
+++ b/public/pages/QueryInsights/QueryInsights.tsx
@@ -23,13 +23,16 @@ import {
   TOTAL_SHARDS,
   TYPE,
 } from '../../../common/constants';
-import { calculateMetric } from '../../../common/utils/MetricUtils';
+import { calculateMetric, calculateMetricNumber } from '../../../common/utils/MetricUtils';
 import { parseDateString } from '../../../common/utils/DateUtils';
 import { QueryInsightsDataSourceMenu } from '../../components/DataSourcePicker';
 import { QueryInsightsDashboardsPluginStartDependencies } from '../../types';
 
 const TIMESTAMP_FIELD = 'timestamp';
 const MEASUREMENTS_FIELD = 'measurements';
+const LATENCY_FIELD = 'measurements.latency';
+const CPU_FIELD = 'measurements.cpu';
+const MEMORY_FIELD = 'measurements.memory';
 const INDICES_FIELD = 'indices';
 const SEARCH_TYPE_FIELD = 'search_type';
 const NODE_ID_FIELD = 'node_id';
@@ -174,48 +177,51 @@ const QueryInsights = ({
       truncateText: true,
     },
     {
-      field: MEASUREMENTS_FIELD,
+      field: LATENCY_FIELD,
       name: LATENCY,
-      render: (measurements: SearchQueryRecord['measurements']) => {
-        return calculateMetric(
-          measurements?.latency?.number,
-          measurements?.latency?.count,
-          'ms',
-          1,
-          METRIC_DEFAULT_MSG
+      render: (latency: SearchQueryRecord['measurements']['latency']) => {
+        return calculateMetric(latency?.number, latency?.count, 'ms', 1, METRIC_DEFAULT_MSG);
+      },
+      sortable: (query: SearchQueryRecord) => {
+        return calculateMetricNumber(
+          query.measurements?.latency?.number,
+          query.measurements?.latency?.count
         );
       },
-      sortable: true,
       truncateText: true,
     },
     {
-      field: MEASUREMENTS_FIELD,
+      field: CPU_FIELD,
       name: CPU_TIME,
-      render: (measurements: SearchQueryRecord['measurements']) => {
+      render: (cpu: SearchQueryRecord['measurements']['cpu']) => {
         return calculateMetric(
-          measurements?.cpu?.number,
-          measurements?.cpu?.count,
+          cpu?.number,
+          cpu?.count,
           'ms',
           1000000, // Divide by 1,000,000 for CPU time
           METRIC_DEFAULT_MSG
         );
       },
-      sortable: true,
+      sortable: (query: SearchQueryRecord) => {
+        return calculateMetricNumber(
+          query.measurements?.cpu?.number,
+          query.measurements?.cpu?.count
+        );
+      },
       truncateText: true,
     },
     {
-      field: MEASUREMENTS_FIELD,
+      field: MEMORY_FIELD,
       name: MEMORY_USAGE,
-      render: (measurements: SearchQueryRecord['measurements']) => {
-        return calculateMetric(
-          measurements?.memory?.number,
-          measurements?.memory?.count,
-          'B',
-          1,
-          METRIC_DEFAULT_MSG
+      render: (memory: SearchQueryRecord['measurements']['memory']) => {
+        return calculateMetric(memory?.number, memory?.count, 'B', 1, METRIC_DEFAULT_MSG);
+      },
+      sortable: (query: SearchQueryRecord) => {
+        return calculateMetricNumber(
+          query.measurements?.memory?.number,
+          query.measurements?.memory?.count
         );
       },
-      sortable: true,
       truncateText: true,
     },
     {
@@ -379,6 +385,9 @@ const QueryInsights = ({
           defaultFields: [
             TIMESTAMP_FIELD,
             MEASUREMENTS_FIELD,
+            LATENCY_FIELD,
+            CPU_FIELD,
+            MEMORY_FIELD,
             INDICES_FIELD,
             SEARCH_TYPE_FIELD,
             NODE_ID_FIELD,

--- a/public/pages/QueryInsights/__snapshots__/QueryInsights.test.tsx.snap
+++ b/public/pages/QueryInsights/__snapshots__/QueryInsights.test.tsx.snap
@@ -527,7 +527,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                 aria-live="polite"
                 aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_measurements_4"
+                data-test-subj="tableHeaderCell_measurements.latency_4"
                 role="columnheader"
                 scope="col"
               >
@@ -552,7 +552,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                 aria-live="polite"
                 aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_measurements_5"
+                data-test-subj="tableHeaderCell_measurements.cpu_5"
                 role="columnheader"
                 scope="col"
               >
@@ -577,7 +577,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                 aria-live="polite"
                 aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_measurements_6"
+                data-test-subj="tableHeaderCell_measurements.memory_6"
                 role="columnheader"
                 scope="col"
               >


### PR DESCRIPTION
### Description
The sorting on top queries is not working, fixed it by using correct fields and number type as sort key

### Testing
<img width="1218" alt="image" src="https://github.com/user-attachments/assets/ed95ce3e-3a3b-4a6c-9825-59917751c8db" />
<img width="1218" alt="image" src="https://github.com/user-attachments/assets/4a1b2f7d-015a-4bb3-a745-b48b5f4ac10e" />
<img width="1204" alt="image" src="https://github.com/user-attachments/assets/d87fa150-d473-4c85-abfe-81b5cd508195" />
<img width="1206" alt="image" src="https://github.com/user-attachments/assets/cfada031-6786-4d0d-9e57-59b23156a465" />
<img width="1207" alt="image" src="https://github.com/user-attachments/assets/8adfd8c3-502a-45dd-af86-c3d5b6f03701" />
<img width="1215" alt="image" src="https://github.com/user-attachments/assets/ced0d8b0-61f4-4a95-b3e9-b2cfba5378b8" />



### Issues Resolved
Closes https://github.com/opensearch-project/query-insights-dashboards/issues/97

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
