### PR TITLE
Fix grouping cypress tests failing on build machine

### DIFF
--- a/cypress/e2e/4_group_details.cy.js
+++ b/cypress/e2e/4_group_details.cy.js
@@ -4,24 +4,22 @@
  */
 
 import sampleDocument from '../fixtures/sample_document.json';
-import { METRICS } from '../support/constants';
 
 const indexName = 'sample_index';
 
 const clearAll = () => {
   cy.deleteIndexByName(indexName);
-  cy.disableTopQueries(METRICS.LATENCY);
-  cy.disableTopQueries(METRICS.CPU);
-  cy.disableTopQueries(METRICS.MEMORY);
   cy.disableGrouping();
 };
 
 describe('Query Group Details Page', () => {
   beforeEach(() => {
     clearAll();
+    cy.wait(5000);
     cy.createIndexByName(indexName, sampleDocument);
-    cy.enableTopQueries(METRICS.LATENCY);
     cy.enableGrouping();
+    // waiting for the query insights to stablize
+    cy.wait(5000);
     cy.searchOnIndex(indexName);
     cy.searchOnIndex(indexName);
     cy.searchOnIndex(indexName);
@@ -30,6 +28,7 @@ describe('Query Group Details Page', () => {
     cy.navigateToOverview();
     cy.get('.euiTableRow').first().find('button').first().trigger('mouseover');
     cy.wait(1000);
+    // Click the first button in the 'group' row
     cy.get('.euiTableRow').first().find('button').first().click(); // Navigate to details
     cy.wait(1000);
   });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -115,9 +115,10 @@ Cypress.Commands.add('enableGrouping', () => {
         'search.insights.top_queries.latency.window_size': '1m',
         'search.insights.top_queries.cpu.window_size': '1m',
         'search.insights.top_queries.memory.window_size': '1m',
+        'search.insights.top_queries.exporter.type': 'none',
       },
     },
-    failOnStatusCode: false,
+    failOnStatusCode: true,
   });
 });
 
@@ -131,9 +132,10 @@ Cypress.Commands.add('disableGrouping', () => {
         'search.insights.top_queries.cpu.enabled': false,
         'search.insights.top_queries.memory.enabled': false,
         'search.insights.top_queries.group_by': 'none',
+        'search.insights.top_queries.exporter.type': 'none',
       },
     },
-    failOnStatusCode: false,
+    failOnStatusCode: true,
   });
 });
 


### PR DESCRIPTION
### Description
_Describe what this change achieves._

Change attempts to fix the buggy query grouping related cypress tests.

The tests seem to be failing due interference from exporter and running slow on the build machine.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
