### PR TITLE
Fix duplicated requests on refreshing the overview

### DIFF
--- a/public/pages/TopNQueries/TopNQueries.test.tsx
+++ b/public/pages/TopNQueries/TopNQueries.test.tsx
@@ -209,7 +209,7 @@ describe('TopNQueries Component', () => {
     );
     // Verify that the component re-fetches data for the new time range
     await waitFor(() => {
-      expect(mockCore.http.get).toHaveBeenCalledTimes(16);
+      expect(mockCore.http.get).toHaveBeenCalledTimes(7);
       expect(mockCore.http.get).toHaveBeenCalledWith('/api/settings', expect.any(Object));
       expect(mockCore.http.get).toHaveBeenCalledWith(
         '/api/top_queries/latency',

--- a/public/pages/TopNQueries/TopNQueries.tsx
+++ b/public/pages/TopNQueries/TopNQueries.tsx
@@ -163,6 +163,8 @@ const TopNQueries = ({
   // TODO: refactor retrieveQueries and retrieveConfigInfo into a Util function
   const retrieveQueries = useCallback(
     async (start: string, end: string) => {
+      if (loading) return;
+      setLoading(true);
       const nullResponse = { response: { top_queries: [] } };
       const apiParams = {
         query: {
@@ -190,7 +192,6 @@ const TopNQueries = ({
         }
       };
       try {
-        setLoading(true);
         const respLatency = latencySettings.isEnabled
           ? await fetchMetric('/api/top_queries/latency')
           : nullResponse;


### PR DESCRIPTION
### Description

On refreshing the overview page, we are sending multiple duplicate top n queries requests on all the metrics. See below screenshot.

<img width="540" alt="411109556-5918d6df-d4d8-429b-9599-4c4e4657ad2d" src="https://github.com/user-attachments/assets/5b0fcf35-2684-4cbb-a630-df94bbb84364" />

How can one reproduce the bug?
Run the QID with all metrics enabled
Hit the refresh button and check the network requests.

<img width="1691" alt="411109680-7ca86398-28a5-426a-b267-0bc6a21bdc7a" src="https://github.com/user-attachments/assets/83fc9caa-e4aa-4572-89e9-511562e69967" />

what changed: 

updated the dependency arrays for the useEffect

After Bug fix:

only one request per metric should be send to the backend on refresh.

<img width="1018" alt="Screenshot 2025-03-11 at 7 04 25 PM" src="https://github.com/user-attachments/assets/e7b946eb-f155-4b13-bec8-3b873146e266" />

### Issues Resolved
Closes: [https://github.com/opensearch-project/query-insights-dashboards/issues/105] 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
