### PR TITLE
Bug Fix - Placeholder ${metric} Not Replaced with Actual Metric Type

### DIFF
--- a/public/pages/Configuration/Configuration.tsx
+++ b/public/pages/Configuration/Configuration.tsx
@@ -274,7 +274,7 @@ const Configuration = ({
                       listItems={[
                         {
                           title: <h3>Enabled</h3>,
-                          description: 'Enable/disable top N query monitoring by ${metric}.',
+                          description: `Enable/disable top N query monitoring by ${metric}.`,
                         },
                       ]}
                     />

--- a/public/pages/Configuration/__snapshots__/Configuration.test.tsx.snap
+++ b/public/pages/Configuration/__snapshots__/Configuration.test.tsx.snap
@@ -132,7 +132,7 @@ exports[`Configuration Component renders with default settings: should match def
                     <dd
                       class="euiDescriptionList__description"
                     >
-                      Enable/disable top N query monitoring by \${metric}.
+                      Enable/disable top N query monitoring by latency.
                     </dd>
                   </dl>
                 </div>
@@ -1189,7 +1189,7 @@ exports[`Configuration Component updates state when toggling metrics and enables
                     <dd
                       class="euiDescriptionList__description"
                     >
-                      Enable/disable top N query monitoring by \${metric}.
+                      Enable/disable top N query monitoring by cpu.
                     </dd>
                   </dl>
                 </div>


### PR DESCRIPTION
### Description

The bug is that the placeholder ${metric} did not get replaced with the actual metric type (such as "Latency"). Instead, it remains as the literal string ${metric} in the configuration, indicating that the dynamic replacement process is not functioning properly.

<img width="1018" alt="Screenshot 2025-03-13 at 3 12 00 AM" src="https://github.com/user-attachments/assets/4b6a81ab-0a15-4cfb-a0d3-2490b4beb73f" />

now:

<img width="1018" alt="Screenshot 2025-03-13 at 3 12 27 AM" src="https://github.com/user-attachments/assets/6e33d866-0b99-4aa9-917f-e9db3eab12e4" />


### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
