### PR TITLE
Update Default Time Range from 1 Day to 1 Hour in TopNQueries Component

### DIFF
--- a/public/components/__snapshots__/app.test.tsx.snap
+++ b/public/components/__snapshots__/app.test.tsx.snap
@@ -343,7 +343,7 @@ exports[`<QueryInsightsDashboardsApp /> spec renders the component 1`] = `
                       class="euiSuperDatePicker__prettyFormat"
                       data-test-subj="superDatePickerShowDatesButton"
                     >
-                      Last 1 day
+                      Last 1 hour
                       <span
                         class="euiSuperDatePicker__prettyFormatLink"
                       >

--- a/public/pages/TopNQueries/TopNQueries.test.tsx
+++ b/public/pages/TopNQueries/TopNQueries.test.tsx
@@ -183,7 +183,7 @@ describe('TopNQueries Component', () => {
       <MemoryRouter initialEntries={[QUERY_INSIGHTS]}>
         <TopNQueries
           core={mockCore}
-          initialStart="now-1d"
+          initialStart="now-1h"
           initialEnd="now"
           depsStart={{ navigation: {} }}
           params={{} as any}

--- a/public/pages/TopNQueries/TopNQueries.tsx
+++ b/public/pages/TopNQueries/TopNQueries.tsx
@@ -69,7 +69,7 @@ const TopNQueries = ({
   depsStart,
   params,
   dataSourceManagement,
-  initialStart = 'now-1d',
+  initialStart = 'now-1h',
   initialEnd = 'now',
 }: {
   core: CoreStart;


### PR DESCRIPTION
### Description


Updated the default time range in the TopNQueries component from last 1 day (now-1d) to last 1 hour (now-1h). This change helps reduce the number of requests by limiting the queried data to a shorter time window.


Before
<img width="555" alt="Screenshot 2025-03-17 at 1 03 25 PM" src="https://github.com/user-attachments/assets/f93e8fdc-3c39-4961-9cbd-703705718b42" />

After:

<img width="555" alt="Screenshot 2025-03-17 at 1 03 48 PM" src="https://github.com/user-attachments/assets/410fecd7-2167-46a0-a1b0-5d76ff2eee77" />


### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
