### PR TITLE
[BUG FIX] Enable Correct Sorting for Metrics in Query Insights Dashboard

### DIFF
--- a/cypress/e2e/1_top_queries.cy.js
+++ b/cypress/e2e/1_top_queries.cy.js
@@ -142,6 +142,32 @@ describe('Query Insights Dashboard - Dynamic Columns with Stubbed Top Queries', 
     cy.wait('@getTopQueries');
   });
 
+  const testMetricSorting = (columnLabel, columnIndex) => {
+    cy.get('.euiTableHeaderCell').contains(columnLabel).click();
+    cy.wait(1000);
+
+    cy.get('.euiTableRow').then(($rows) => {
+      const values = [...$rows].map(($row) => {
+        const rawText = Cypress.$($row).find('td').eq(columnIndex).text().trim();
+        return parseFloat(rawText.replace(/[^\d.]/g, '')); // remove 'ms'/'B'
+      });
+      const sortedAsc = [...values].sort((a, b) => a - b);
+      expect(values).to.deep.equal(sortedAsc);
+    });
+
+    cy.get('.euiTableHeaderCell').contains(columnLabel).click();
+    cy.wait(1000);
+
+    cy.get('.euiTableRow').then(($rows) => {
+      const values = [...$rows].map(($row) => {
+        const rawText = Cypress.$($row).find('td').eq(columnIndex).text().trim();
+        return parseFloat(rawText.replace(/[^\d.]/g, ''));
+      });
+      const sortedDesc = [...values].sort((a, b) => b - a);
+      expect(values).to.deep.equal(sortedDesc);
+    });
+  };
+
   it('should render only individual query-related headers when NONE filter is applied', () => {
     cy.wait(1000);
     cy.get('.euiFilterButton').contains('Type').click();
@@ -161,12 +187,16 @@ describe('Query Insights Dashboard - Dynamic Columns with Stubbed Top Queries', 
       'Total Shards',
     ];
 
-    //cy.get('.euiTableHeaderCell').should('have.length', expectedHeaders.length);
+    cy.get('.euiTableHeaderCell').should('have.length', expectedHeaders.length);
 
     cy.get('.euiTableHeaderCell').should(($headers) => {
       const actualHeaders = $headers.map((index, el) => Cypress.$(el).text().trim()).get();
       expect(actualHeaders).to.deep.equal(expectedHeaders);
     });
+    testMetricSorting('Timestamp', 2);
+    testMetricSorting('Latency', 3);
+    testMetricSorting('CPU Time', 4);
+    testMetricSorting('Memory Usage', 5);
   });
 
   it('should render only group-related headers in the correct order when SIMILARITY filter is applied', () => {
@@ -187,6 +217,10 @@ describe('Query Insights Dashboard - Dynamic Columns with Stubbed Top Queries', 
       const actualHeaders = $headers.map((index, el) => Cypress.$(el).text().trim()).get();
       expect(actualHeaders).to.deep.equal(expectedHeaders);
     });
+    testMetricSorting('Query Count', 2);
+    testMetricSorting('Average Latency', 3);
+    testMetricSorting('Average CPU Time', 4);
+    testMetricSorting('Average Memory Usage', 5);
   });
   it('should display both query and group data with proper headers when both are selected', () => {
     cy.get('.euiFilterButton').contains('Type').click();
@@ -211,5 +245,10 @@ describe('Query Insights Dashboard - Dynamic Columns with Stubbed Top Queries', 
       const actualHeaders = $headers.map((index, el) => Cypress.$(el).text().trim()).get();
       expect(actualHeaders).to.deep.equal(expectedGroupHeaders);
     });
+    testMetricSorting('Query Count', 2);
+    testMetricSorting('Timestamp', 3);
+    testMetricSorting('Avg Latency / Latency', 4);
+    testMetricSorting('Avg CPU Time / CPU Time', 5);
+    testMetricSorting('Avg Memory Usage / Memory Usage', 6);
   });
 });

--- a/cypress/fixtures/stub_top_queries.json
+++ b/cypress/fixtures/stub_top_queries.json
@@ -3,12 +3,10 @@
   "response": {
     "top_queries": [
       {
-        "timestamp": 1443852054000,
+        "timestamp": 1713934974000,
         "id": "a2e1c822-3e3c-4d1b-adb2-9f73af094b43",
         "search_type": "query_then_fetch",
-        "indices": [
-          "my-index"
-        ],
+        "indices": ["my-index"],
         "node_id": "UYKFun8PSAeJvkkt9cWf0w",
         "group_by": "NONE",
         "total_shards": 1,
@@ -16,60 +14,32 @@
           "X-Opaque-Id": "90eb5c3b-8448-4af3-84ce-a941eee9ed5f"
         },
         "measurements": {
-          "cpu": {
-            "number": 2921000,
-            "count": 1,
-            "aggregationType": "NONE"
-          },
-          "latency": {
-            "number": 5,
-            "count": 1,
-            "aggregationType": "NONE"
-          },
-          "memory": {
-            "number": 100840,
-            "count": 1,
-            "aggregationType": "NONE"
-          }
+          "cpu": { "number": 1340000, "count": 1, "aggregationType": "NONE" },
+          "latency": { "number": 22, "count": 1, "aggregationType": "NONE" },
+          "memory": { "number": 204800, "count": 1, "aggregationType": "NONE" }
         }
       },
       {
-        "timestamp": 1443852054000,
+        "timestamp": 1713934989000,
         "id": "130a5d36-615e-43e8-ad99-e1b90d527f44",
         "search_type": "query_then_fetch",
-        "indices": [
-          ".kibana"
-        ],
+        "indices": [".kibana"],
         "node_id": "UYKFun8PSAeJvkkt9cWf0w",
         "group_by": "SIMILARITY",
         "total_shards": 1,
         "labels": {},
         "query_group_hashcode": "2219a4bb71bd0d262e6d0f5504b88537",
         "measurements": {
-          "memory": {
-            "number": 38024,
-            "count": 1,
-            "aggregationType": "AVERAGE"
-          },
-          "cpu": {
-            "number": 2613000,
-            "count": 1,
-            "aggregationType": "AVERAGE"
-          },
-          "latency": {
-            "number": 5,
-            "count": 1,
-            "aggregationType": "AVERAGE"
-          }
+          "memory": { "number": 58000, "count": 1, "aggregationType": "AVERAGE" },
+          "cpu": { "number": 1780000, "count": 1, "aggregationType": "AVERAGE" },
+          "latency": { "number": 10, "count": 1, "aggregationType": "AVERAGE" }
         }
       },
       {
-        "timestamp": 1443852054000,
+        "timestamp": 1713935004000,
         "id": "a2e1c822-3e3c-4d1b-adb2-9f73af094b43",
         "search_type": "query_then_fetch",
-        "indices": [
-          "my-index"
-        ],
+        "indices": ["my-index"],
         "node_id": "UYKFun8PSAeJvkkt9cWf0w",
         "group_by": "NONE",
         "total_shards": 1,
@@ -77,30 +47,16 @@
           "X-Opaque-Id": "90eb5c3b-8448-4af3-84ce-a941eee9ed5f"
         },
         "measurements": {
-          "memory": {
-            "number": 100840,
-            "count": 1,
-            "aggregationType": "NONE"
-          },
-          "cpu": {
-            "number": 2921000,
-            "count": 1,
-            "aggregationType": "NONE"
-          },
-          "latency": {
-            "number": 5,
-            "count": 1,
-            "aggregationType": "NONE"
-          }
+          "memory": { "number": 170320, "count": 1, "aggregationType": "NONE" },
+          "cpu": { "number": 2100000, "count": 1, "aggregationType": "NONE" },
+          "latency": { "number": 13, "count": 1, "aggregationType": "NONE" }
         }
       },
       {
-        "timestamp": 1443852054000,
+        "timestamp": 1713935019000,
         "id": "7cd4c7f1-3803-4c5e-a41c-258e04f96f78",
         "search_type": "query_then_fetch",
-        "indices": [
-          "my-index"
-        ],
+        "indices": ["my-index"],
         "node_id": "UYKFun8PSAeJvkkt9cWf0w",
         "group_by": "NONE",
         "total_shards": 1,
@@ -108,30 +64,16 @@
           "X-Opaque-Id": "8a936346-8d19-409c-9fe6-8b890eca1f7c"
         },
         "measurements": {
-          "cpu": {
-            "number": 1831000,
-            "count": 1,
-            "aggregationType": "NONE"
-          },
-          "latency": {
-            "number": 4,
-            "count": 1,
-            "aggregationType": "NONE"
-          },
-          "memory": {
-            "number": 65760,
-            "count": 1,
-            "aggregationType": "NONE"
-          }
+          "cpu": { "number": 990000, "count": 1, "aggregationType": "NONE" },
+          "latency": { "number": 18, "count": 1, "aggregationType": "NONE" },
+          "memory": { "number": 81200, "count": 1, "aggregationType": "NONE" }
         }
       },
       {
-        "timestamp": 1443852054000,
+        "timestamp": 1713935033000,
         "id": "76f5e51f-33f6-480c-8b20-8003abb93d19",
         "search_type": "query_then_fetch",
-        "indices": [
-          ".kibana"
-        ],
+        "indices": [".kibana"],
         "node_id": "UYKFun8PSAeJvkkt9cWf0w",
         "group_by": "SIMILARITY",
         "total_shards": 1,
@@ -140,111 +82,57 @@
         },
         "query_group_hashcode": "a336f9580d5d980f7403f6d179f454eb",
         "measurements": {
-          "memory": {
-            "number": 77784,
-            "count": 1,
-            "aggregationType": "AVERAGE"
-          },
-          "cpu": {
-            "number": 1589000,
-            "count": 1,
-            "aggregationType": "AVERAGE"
-          },
-          "latency": {
-            "number": 2,
-            "count": 1,
-            "aggregationType": "AVERAGE"
-          }
+          "memory": { "number": 133600, "count": 1, "aggregationType": "AVERAGE" },
+          "cpu": { "number": 990000, "count": 1, "aggregationType": "AVERAGE" },
+          "latency": { "number": 9, "count": 1, "aggregationType": "AVERAGE" }
         }
       },
       {
-        "timestamp": 1443852054000,
+        "timestamp": 1713935048000,
         "id": "37d633a7-20e6-41a1-96e9-cd4806511dbf",
         "search_type": "query_then_fetch",
-        "indices": [
-          ".kibana"
-        ],
+        "indices": [".kibana"],
         "node_id": "UYKFun8PSAeJvkkt9cWf0w",
         "group_by": "SIMILARITY",
         "total_shards": 1,
         "labels": {},
         "query_group_hashcode": "7cef9a399c117a0278025a89e943eebc",
         "measurements": {
-          "memory": {
-            "number": 981144,
-            "count": 4,
-            "aggregationType": "AVERAGE"
-          },
-          "cpu": {
-            "number": 6286000,
-            "count": 4,
-            "aggregationType": "AVERAGE"
-          },
-          "latency": {
-            "number": 2,
-            "count": 1,
-            "aggregationType": "NONE"
-          }
+          "memory": { "number": 640320, "count": 3, "aggregationType": "AVERAGE" },
+          "cpu": { "number": 3190000, "count": 3, "aggregationType": "AVERAGE" },
+          "latency": { "number": 6, "count": 1, "aggregationType": "NONE" }
         }
       },
       {
-        "timestamp": 1443852054000,
+        "timestamp": 1713935062000,
         "id": "9982b7fc-0339-47d8-b77f-8de1bda76b72",
         "search_type": "query_then_fetch",
-        "indices": [
-          ".kibana"
-        ],
+        "indices": [".kibana"],
         "node_id": "UYKFun8PSAeJvkkt9cWf0w",
         "group_by": "SIMILARITY",
         "total_shards": 1,
         "labels": {},
         "query_group_hashcode": "7cef9a399c117a0278025a89e943eebc",
         "measurements": {
-          "memory": {
-            "number": 1001464,
-            "count": 4,
-            "aggregationType": "AVERAGE"
-          },
-          "cpu": {
-            "number": 5562000,
-            "count": 4,
-            "aggregationType": "AVERAGE"
-          },
-          "latency": {
-            "number": 7,
-            "count": 4,
-            "aggregationType": "AVERAGE"
-          }
+          "memory": { "number": 812400, "count": 4, "aggregationType": "AVERAGE" },
+          "cpu": { "number": 2280000, "count": 4, "aggregationType": "AVERAGE" },
+          "latency": { "number": 4, "count": 4, "aggregationType": "AVERAGE" }
         }
       },
       {
-        "timestamp": 1443852054000,
+        "timestamp": 1713935078000,
         "id": "d8dccf54-8dcb-4411-9fd6-977844be8fb3",
         "search_type": "query_then_fetch",
-        "indices": [
-          ".kibana"
-        ],
+        "indices": [".kibana"],
         "node_id": "UYKFun8PSAeJvkkt9cWf0w",
         "group_by": "SIMILARITY",
         "total_shards": 1,
         "labels": {},
         "query_group_hashcode": "2219a4bb71bd0d262e6d0f5504b88537",
         "measurements": {
-          "memory": {
-            "number": 38024,
-            "count": 1,
-            "aggregationType": "AVERAGE"
-          },
-          "cpu": {
-            "number": 840000,
-            "count": 1,
-            "aggregationType": "AVERAGE"
-          },
-          "latency": {
-            "number": 1,
-            "count": 1,
-            "aggregationType": "NONE"
-          }
+          "memory": { "number": 59000, "count": 1, "aggregationType": "AVERAGE" },
+          "cpu": { "number": 1720000, "count": 1, "aggregationType": "AVERAGE" },
+          "latency": { "number": 11, "count": 1, "aggregationType": "NONE" }
         }
       }
     ]

--- a/public/components/__snapshots__/app.test.tsx.snap
+++ b/public/components/__snapshots__/app.test.tsx.snap
@@ -520,7 +520,7 @@ exports[`<QueryInsightsDashboardsApp /> spec renders the component 1`] = `
                   aria-live="polite"
                   aria-sort="none"
                   class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_measurements_2"
+                  data-test-subj="tableHeaderCell_Query Count_2"
                   role="columnheader"
                   scope="col"
                 >
@@ -570,7 +570,7 @@ exports[`<QueryInsightsDashboardsApp /> spec renders the component 1`] = `
                   aria-live="polite"
                   aria-sort="none"
                   class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_measurements_4"
+                  data-test-subj="tableHeaderCell_Latency_4"
                   role="columnheader"
                   scope="col"
                 >
@@ -595,7 +595,7 @@ exports[`<QueryInsightsDashboardsApp /> spec renders the component 1`] = `
                   aria-live="polite"
                   aria-sort="none"
                   class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_measurements_5"
+                  data-test-subj="tableHeaderCell_CPU Time_5"
                   role="columnheader"
                   scope="col"
                 >
@@ -617,21 +617,29 @@ exports[`<QueryInsightsDashboardsApp /> spec renders the component 1`] = `
                   </button>
                 </th>
                 <th
+                  aria-live="polite"
+                  aria-sort="none"
                   class="euiTableHeaderCell"
-                  data-test-subj="tableHeaderCell_measurements_6"
+                  data-test-subj="tableHeaderCell_Memory Usage_6"
                   role="columnheader"
                   scope="col"
                 >
-                  <span
-                    class="euiTableCellContent"
+                  <button
+                    class="euiTableHeaderButton"
+                    data-test-subj="tableHeaderSortButton"
+                    type="button"
                   >
                     <span
-                      class="euiTableCellContent__text"
-                      title="Memory Usage"
+                      class="euiTableCellContent"
                     >
-                      Memory Usage
+                      <span
+                        class="euiTableCellContent__text"
+                        title="Memory Usage"
+                      >
+                        Memory Usage
+                      </span>
                     </span>
-                  </span>
+                  </button>
                 </th>
                 <th
                   aria-live="polite"

--- a/public/pages/QueryInsights/QueryInsights.tsx
+++ b/public/pages/QueryInsights/QueryInsights.tsx
@@ -153,95 +153,96 @@ const QueryInsights = ({
       truncateText: true,
     },
   ];
-  const querycountColumn: Array<EuiBasicTableColumn<any>> = [
+  const querycountColumn: Array<EuiBasicTableColumn<SearchQueryRecord>> = [
     {
-      field: MEASUREMENTS_FIELD,
       name: QUERY_COUNT,
-      render: (measurements: SearchQueryRecord['measurements']) =>
-        `${
-          measurements?.latency?.count ||
-          measurements?.cpu?.count ||
-          measurements?.memory?.count ||
+      render: (query: SearchQueryRecord) => {
+        const count =
+          query.measurements?.latency?.count ||
+          query.measurements?.cpu?.count ||
+          query.measurements?.memory?.count ||
+          1;
+        return `${count}`;
+      },
+      sortable: (query: SearchQueryRecord) => {
+        return (
+          query.measurements?.latency?.count ||
+          query.measurements?.cpu?.count ||
+          query.measurements?.memory?.count ||
           1
-        }`,
-      sortable: (measurements: SearchQueryRecord['measurements']) => {
-        return Number(
-          measurements?.latency?.count ||
-            measurements?.cpu?.count ||
-            measurements?.memory?.count ||
-            1
         );
       },
       truncateText: true,
     },
   ];
+
   // @ts-ignore
-  const metricColumns: Array<EuiBasicTableColumn<any>> = [
+  const metricColumns: Array<EuiBasicTableColumn<SearchQueryRecord>> = [
     {
-      field: MEASUREMENTS_FIELD,
       name:
         selectedFilter.includes('SIMILARITY') && selectedFilter.includes('NONE')
           ? `Avg ${LATENCY} / ${LATENCY}`
           : selectedFilter.includes('SIMILARITY')
           ? `Average ${LATENCY}`
           : `${LATENCY}`,
-      render: (measurements: SearchQueryRecord['measurements']) => {
-        return calculateMetric(
-          measurements?.latency?.number,
-          measurements?.latency?.count,
+      render: (query: SearchQueryRecord) =>
+        calculateMetric(
+          query.measurements?.latency?.number,
+          query.measurements?.latency?.count,
           'ms',
           1,
           METRIC_DEFAULT_MSG
-        );
-      },
-      sortable: true,
+        ),
+      sortable: (query) =>
+        calculateMetricNumber(
+          query.measurements?.latency?.number,
+          query.measurements?.latency?.count
+        ),
       truncateText: true,
     },
     {
-      field: MEASUREMENTS_FIELD,
       name:
         selectedFilter.includes('SIMILARITY') && selectedFilter.includes('NONE')
           ? `Avg ${CPU_TIME} / ${CPU_TIME}`
           : selectedFilter.includes('SIMILARITY')
           ? `Average ${CPU_TIME}`
           : `${CPU_TIME}`,
-      render: (measurements: SearchQueryRecord['measurements']) => {
-        return calculateMetric(
-          measurements?.cpu?.number,
-          measurements?.cpu?.count,
-          'ms',
-          1000000, // Divide by 1,000,000 for CPU time
-          METRIC_DEFAULT_MSG
-        );
-      },
-      sortable: (query: SearchQueryRecord) => {
-        return calculateMetricNumber(
+      render: (query: SearchQueryRecord) =>
+        calculateMetric(
           query.measurements?.cpu?.number,
-          query.measurements?.cpu?.count
-        );
-      },
+          query.measurements?.cpu?.count,
+          'ms',
+          1000000,
+          METRIC_DEFAULT_MSG
+        ),
+      sortable: (query) =>
+        calculateMetricNumber(query.measurements?.cpu?.number, query.measurements?.cpu?.count),
       truncateText: true,
     },
     {
-      field: MEASUREMENTS_FIELD,
       name:
         selectedFilter.includes('SIMILARITY') && selectedFilter.includes('NONE')
           ? `Avg ${MEMORY_USAGE} / ${MEMORY_USAGE}`
           : selectedFilter.includes('SIMILARITY')
           ? `Average ${MEMORY_USAGE}`
           : MEMORY_USAGE,
-      render: (measurements: SearchQueryRecord['measurements']) => {
-        return calculateMetric(
-          measurements?.memory?.number,
-          measurements?.memory?.count,
+      render: (query: SearchQueryRecord) =>
+        calculateMetric(
+          query.measurements?.memory?.number,
+          query.measurements?.memory?.count,
           'B',
           1,
           METRIC_DEFAULT_MSG
-        );
-      },
+        ),
+      sortable: (query) =>
+        calculateMetricNumber(
+          query.measurements?.memory?.number,
+          query.measurements?.memory?.count
+        ),
       truncateText: true,
     },
   ];
+
   const timestampColumn: Array<EuiBasicTableColumn<any>> = [
     {
       // Make into flyout instead?
@@ -263,7 +264,7 @@ const QueryInsights = ({
       truncateText: true,
     },
   ];
-  const Columnsset5: Array<EuiBasicTableColumn<any>> = [
+  const QueryTypeSpecificColumns: Array<EuiBasicTableColumn<any>> = [
     {
       field: INDICES_FIELD,
       name: INDICES,
@@ -316,11 +317,16 @@ const QueryInsights = ({
     ...querycountColumn,
     ...timestampColumn,
     ...metricColumns,
-    ...Columnsset5,
+    ...QueryTypeSpecificColumns,
   ];
 
   const groupTypeColumns = [...baseColumns, ...querycountColumn, ...metricColumns];
-  const queryTypeColumns = [...baseColumns, ...timestampColumn, ...metricColumns, ...Columnsset5];
+  const queryTypeColumns = [
+    ...baseColumns,
+    ...timestampColumn,
+    ...metricColumns,
+    ...QueryTypeSpecificColumns,
+  ];
 
   const columnsToShow = useMemo(() => {
     const hasQueryType = selectedFilter.includes('NONE');

--- a/public/pages/QueryInsights/__snapshots__/QueryInsights.test.tsx.snap
+++ b/public/pages/QueryInsights/__snapshots__/QueryInsights.test.tsx.snap
@@ -477,7 +477,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                 aria-live="polite"
                 aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_measurements_2"
+                data-test-subj="tableHeaderCell_Query Count_2"
                 role="columnheader"
                 scope="col"
               >
@@ -527,7 +527,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                 aria-live="polite"
                 aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_measurements_4"
+                data-test-subj="tableHeaderCell_Avg Latency / Latency_4"
                 role="columnheader"
                 scope="col"
               >
@@ -552,7 +552,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                 aria-live="polite"
                 aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_measurements_5"
+                data-test-subj="tableHeaderCell_Avg CPU Time / CPU Time_5"
                 role="columnheader"
                 scope="col"
               >
@@ -574,21 +574,29 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                 </button>
               </th>
               <th
+                aria-live="polite"
+                aria-sort="none"
                 class="euiTableHeaderCell"
-                data-test-subj="tableHeaderCell_measurements_6"
+                data-test-subj="tableHeaderCell_Avg Memory Usage / Memory Usage_6"
                 role="columnheader"
                 scope="col"
               >
-                <span
-                  class="euiTableCellContent"
+                <button
+                  class="euiTableHeaderButton"
+                  data-test-subj="tableHeaderSortButton"
+                  type="button"
                 >
                   <span
-                    class="euiTableCellContent__text"
-                    title="Avg Memory Usage / Memory Usage"
+                    class="euiTableCellContent"
                   >
-                    Avg Memory Usage / Memory Usage
+                    <span
+                      class="euiTableCellContent__text"
+                      title="Avg Memory Usage / Memory Usage"
+                    >
+                      Avg Memory Usage / Memory Usage
+                    </span>
                   </span>
-                </span>
+                </button>
               </th>
               <th
                 aria-live="polite"


### PR DESCRIPTION
### Description
This PR fixes a bug in the Query Insights Dashboard where the following metric columns were not sorting correctly due to improper sortable configuration for Latency, CPU time, Memory Usage and Query Count.

Also improved the test coverage to ensure these functionalities work properly.

- Before

<img width="1728" alt="Screenshot 2025-04-24 at 12 08 16 AM" src="https://github.com/user-attachments/assets/243d05d3-336c-4f5b-9ace-dc5d39807ac8" />

- After

<img width="1728" alt="Screenshot 2025-04-24 at 1 24 43 AM" src="https://github.com/user-attachments/assets/34d5809c-2599-40b0-8c02-4eb1e8dee4d0" />


### Issues Resolved
Closes: [#170]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
