### PR TITLE
[Bug Fix] Window size changing unexpectedly

### DIFF
--- a/public/pages/TopNQueries/TopNQueries.tsx
+++ b/public/pages/TopNQueries/TopNQueries.tsx
@@ -313,18 +313,26 @@ const TopNQueries = ({
             deleteAfterDays: newDeleteAfterDays,
             exporterType: newExporterType,
           });
-          await core.http.put('/api/update_settings', {
-            query: {
-              metric,
-              enabled,
-              top_n_size: newTopN,
-              window_size: `${newWindowSize}${newTimeUnit === 'MINUTES' ? 'm' : 'h'}`,
-              exporterType: newExporterType,
-              group_by: newGroupBy,
-              delete_after_days: newDeleteAfterDays,
-              dataSourceId: getDataSourceFromUrl().id, // TODO: get this dynamically from the URL
-            },
-          });
+          const queryParams: Record<string, any> = {
+            metric,
+            enabled,
+            top_n_size: newTopN,
+            exporterType: newExporterType,
+            group_by: newGroupBy,
+            delete_after_days: newDeleteAfterDays,
+            dataSourceId: getDataSourceFromUrl().id,
+          };
+          if (newTimeUnit === 'MINUTES') {
+            newTimeUnit = 'm';
+          }
+          if (newTimeUnit === 'HOURS') {
+            newTimeUnit = 'h';
+          }
+          if (newWindowSize && newTimeUnit) {
+            queryParams.window_size = `${newWindowSize}${newTimeUnit}`;
+          }
+
+          await core.http.put('/api/update_settings', { query: queryParams });
         } catch (error) {
           console.error('Failed to set settings:', error);
         }


### PR DESCRIPTION
### Description

This PR addresses a bug in the Query Insights configuration page where updating the top_n_size also unintentionally updated the window_size setting — even when the user did not modify it.

- Before
<img width="1728" alt="Screenshot 2025-04-24 at 2 01 00 AM" src="https://github.com/user-attachments/assets/8a20cb75-4496-46f9-9077-dcbd11f705c3" />

- After

<img width="1728" alt="Screenshot 2025-04-24 at 8 55 47 PM" src="https://github.com/user-attachments/assets/96368cb1-198a-41d7-907e-b1916b1f6843" />

Checked other cases as well.


### Issues Resolved
Closes [#166]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
