### PR TITLE
[Improvement] fetch only once if the first call returns a valid response on Detail page

### DIFF
--- a/common/utils/QueryUtils.ts
+++ b/common/utils/QueryUtils.ts
@@ -43,12 +43,19 @@ export const retrieveQueryById = async (
   };
 
   try {
-    const topQueriesResponse = await Promise.any([
-      fetchMetric(`/api/top_queries/latency`),
-      fetchMetric(`/api/top_queries/cpu`),
-      fetchMetric(`/api/top_queries/memory`),
-    ]);
-    return topQueriesResponse.response.top_queries[0] || null;
+    const endpoints = [
+      `/api/top_queries/latency`,
+      `/api/top_queries/cpu`,
+      `/api/top_queries/memory`,
+    ];
+
+    for (const endpoint of endpoints) {
+      const result = await fetchMetric(endpoint);
+      if (result.response.top_queries.length > 0) {
+        return result.response.top_queries[0];
+      }
+    }
+    return null;
   } catch (error) {
     console.error('Error retrieving query details:', error);
     return null;


### PR DESCRIPTION
### Description

Issue: while loading details page retrieveQueryById always made three parallel requests even if the first one already returned a valid result. This was inefficient and unnecessary.

What Changes were made:

Updated retrieveQueryById utility:

  - Instead of fetching all metrics (latency, cpu, memory) in parallel, it now fetches sequentially.
  - Stops immediately once a non-empty top_queries response is found.
  - Reduces unnecessary API calls.

Screenshots

- Before

<img width="1722" alt="Screenshot 2025-04-25 at 12 49 14 PM" src="https://github.com/user-attachments/assets/1262693a-de75-47fa-ac28-97ea427da8d7" />

- After

<img width="1722" alt="Screenshot 2025-04-25 at 12 45 54 PM" src="https://github.com/user-attachments/assets/13764cde-ca22-4b69-90ec-ffbba874e328" />


### Issues Resolved
Closes [#105 ]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
