### PR TITLE
Resolve duplicate dependency version for @testing-library/user-event

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@elastic/eslint-import-resolver-kibana": "link:../../packages/osd-eslint-import-resolver-opensearch-dashboards",
     "@testing-library/dom": "^8.11.3",
     "@testing-library/jest-dom": "^5.17.0",
-    "@testing-library/user-event": "^14.4.3",
+    "@testing-library/user-event": "^13.5.0",
     "@types/react-dom": "^16.9.8",
     "@types/object-hash": "^3.0.0",
     "@types/react-router-dom": "^5.3.2",


### PR DESCRIPTION
### Description

This PR addresses the following build failure due to conflicting versions of @testing-library/user-event declared across the plugin:

^13.5.0 (previously in devDependencies)

^14.4.3 (latest version intended for compatibility)

Why:
OpenSearch Dashboards enforces strict dependency resolution. Multiple versions of the same package across plugin and platform break the build process. This fix ensures compatibility and successful bootstrap.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
