### PR TITLE
Fix version mismatch between OpenSearch and Dashboards in CI binary installation workflow

### DIFF
--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -2,7 +2,7 @@ name: 'Install Query Insights Dashboards with Plugin via Binary'
 
 on: [push, pull_request]
 env:
-  OPENSEARCH_VERSION: '3.0.0-beta1'
+  OPENSEARCH_VERSION: '3.1.0'
   CI: 1
   # avoid warnings like "tput: No value for $TERM and no -T specified"
   TERM: xterm

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@elastic/eslint-import-resolver-kibana": "link:../../packages/osd-eslint-import-resolver-opensearch-dashboards",
     "@testing-library/dom": "^8.11.3",
     "@testing-library/jest-dom": "^5.17.0",
-    "@testing-library/user-event": "^14.4.3",
+    "@testing-library/user-event": "^13.5.0",
     "@types/react-dom": "^16.9.8",
     "@types/object-hash": "^3.0.0",
     "@types/react-router-dom": "^5.3.2",


### PR DESCRIPTION
### Description
This PR updates the GitHub Actions workflow to ensure compatibility between OpenSearch and OpenSearch Dashboards versions during binary installation testing for the Query Insights Dashboards plugin.

Set both OPENSEARCH_VERSION and Dashboards version to 3.0.0 to avoid compatibility errors.

Prevents failure due to saved objects migration blocking startup when versions are mismatched.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
