### PR TITLE
[Backport 2.x][Feature] Fetch top query with verbose=false on overview (#164)

### DIFF
--- a/common/utils/QueryUtils.ts
+++ b/common/utils/QueryUtils.ts
@@ -11,7 +11,8 @@ export const retrieveQueryById = async (
   dataSourceId: string,
   start: string | null,
   end: string | null,
-  id: string | null
+  id: string | null,
+  verbose: boolean
 ): Promise<SearchQueryRecord | null> => {
   const nullResponse = { response: { top_queries: [] } };
   const params = {
@@ -20,6 +21,7 @@ export const retrieveQueryById = async (
       from: start,
       to: end,
       id,
+      verbose,
     },
   };
 

--- a/cypress/e2e/2_query_details.cy.js
+++ b/cypress/e2e/2_query_details.cy.js
@@ -133,5 +133,52 @@ describe('Top Queries Details Page', () => {
     cy.get('#latency').trigger('mousemove', { clientX: 100, clientY: 100 });
   });
 
+  it('should get complete details of the query using verbose=true for query type', () => {
+    const to = new Date().toISOString();
+    const from = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+
+    return cy
+      .request({
+        method: 'GET',
+        url: `/api/top_queries/latency`,
+        qs: {
+          from: from,
+          to: to,
+          verbose: true,
+        },
+      })
+      .then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body).to.have.property('ok', true);
+
+        cy.log('Response structure:', JSON.stringify(response.body, null, 2));
+
+        const responseData = response.body.response;
+        expect(responseData).to.have.property('top_queries');
+        expect(responseData.top_queries).to.be.an('array');
+        expect(responseData.top_queries.length).to.be.greaterThan(0);
+
+        const firstQuery = responseData.top_queries[0];
+        expect(firstQuery).to.include.all.keys([
+          'group_by',
+          'id',
+          'indices',
+          'labels',
+          'measurements',
+          'node_id',
+          'phase_latency_map',
+          'search_type',
+          'source',
+          'task_resource_usages',
+          'timestamp',
+          'total_shards',
+        ]);
+
+        expect(firstQuery.group_by).to.equal('NONE');
+        expect(firstQuery.indices).to.be.an('array');
+        expect(firstQuery.measurements).to.have.all.keys(['cpu', 'latency', 'memory']);
+      });
+  });
+
   after(() => clearAll());
 });

--- a/cypress/e2e/4_group_details.cy.js
+++ b/cypress/e2e/4_group_details.cy.js
@@ -106,6 +106,62 @@ describe('Query Group Details Page', () => {
         cy.get('#latency').should('be.visible');
       });
   });
+  it('should get complete details of the query using verbose=true for group type', () => {
+    const to = new Date().toISOString();
+    const from = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+
+    return cy
+      .request({
+        method: 'GET',
+        url: `/api/top_queries/latency`,
+        qs: {
+          from: from,
+          to: to,
+          verbose: true,
+        },
+      })
+      .then((response) => {
+        // Verify response status and structure
+        expect(response.status).to.eq(200);
+        expect(response.body).to.have.property('ok', true);
+
+        cy.log('Response structure:', JSON.stringify(response.body, null, 2));
+
+        const responseData = response.body.response;
+        expect(responseData).to.have.property('top_queries');
+        expect(responseData.top_queries).to.be.an('array');
+        expect(responseData.top_queries.length).to.be.greaterThan(0);
+
+        const firstQuery = responseData.top_queries[0];
+        expect(firstQuery).to.include.all.keys([
+          'group_by',
+          'id',
+          'indices',
+          'labels',
+          'measurements',
+          'node_id',
+          'phase_latency_map',
+          'query_group_hashcode',
+          'search_type',
+          'source',
+          'task_resource_usages',
+          'timestamp',
+          'total_shards',
+        ]);
+        expect(firstQuery.group_by).to.equal('SIMILARITY');
+        expect(firstQuery.indices).to.be.an('array');
+        expect(firstQuery.id).to.be.a('string');
+        expect(firstQuery.labels).to.be.an('object');
+        expect(firstQuery.node_id).to.be.a('string');
+        expect(firstQuery.query_group_hashcode).to.be.a('string');
+        expect(firstQuery.search_type).to.be.a('string');
+        expect(firstQuery.timestamp).to.be.a('number');
+        expect(firstQuery.total_shards).to.be.a('number');
+        expect(firstQuery.measurements.cpu).to.be.an('object');
+        expect(firstQuery.measurements.latency).to.be.an('object');
+        expect(firstQuery.measurements.memory).to.be.an('object');
+      });
+  });
 
   after(() => clearAll());
 });

--- a/public/pages/QueryDetails/QueryDetails.test.tsx
+++ b/public/pages/QueryDetails/QueryDetails.test.tsx
@@ -58,7 +58,7 @@ describe('QueryDetails component', () => {
         initialEntries={[
           `/query-details/?id=${hash(
             mockQuery.id
-          )}&from=2025-01-21T22:30:33.347Z&to=2025-01-22T22:30:33.347Z`,
+          )}&from=2025-01-21T22:30:33.347Z&to=2025-01-22T22:30:33.347Z&verbose=true`,
         ]}
       >
         <DataSourceContext.Provider value={mockDataSourceContext}>

--- a/public/pages/QueryDetails/QueryDetails.tsx
+++ b/public/pages/QueryDetails/QueryDetails.tsx
@@ -47,6 +47,7 @@ const QueryDetails = ({
   const id = searchParams.get('id');
   const from = searchParams.get('from');
   const to = searchParams.get('to');
+  const verbose = Boolean(searchParams.get('verbose'));
 
   const [query, setQuery] = useState<SearchQueryRecord | null>(null);
   const history = useHistory();
@@ -60,15 +61,22 @@ const QueryDetails = ({
   }, []);
 
   const fetchQueryDetails = async () => {
-    const retrievedQuery = await retrieveQueryById(core, getDataSourceFromUrl().id, from, to, id);
+    const retrievedQuery = await retrieveQueryById(
+      core,
+      getDataSourceFromUrl().id,
+      from,
+      to,
+      id,
+      verbose
+    );
     setQuery(retrievedQuery);
   };
 
   useEffect(() => {
-    if (id && from && to) {
+    if (id && from && to && verbose != null) {
       fetchQueryDetails();
     }
-  }, [id, from, to]);
+  }, [id, from, to, verbose]);
 
   // Initialize the Plotly chart
   const initPlotlyChart = useCallback(() => {

--- a/public/pages/QueryGroupDetails/QueryGroupDetails.test.tsx
+++ b/public/pages/QueryGroupDetails/QueryGroupDetails.test.tsx
@@ -62,7 +62,9 @@ describe('QueryGroupDetails', () => {
   const renderComponent = () => {
     return render(
       <MemoryRouter
-        initialEntries={['/query-group-details?id=mockId&from=1632441600000&to=1632528000000']}
+        initialEntries={[
+          '/query-group-details?id=mockId&from=1632441600000&to=1632528000000&verbose=true',
+        ]}
       >
         <DataSourceContext.Provider value={mockDataSourceContext}>
           <Route path="/query-group-details">
@@ -101,7 +103,8 @@ describe('QueryGroupDetails', () => {
         undefined,
         '1632441600000',
         '1632528000000',
-        'mockId'
+        'mockId',
+        true
       );
     });
 

--- a/public/pages/QueryGroupDetails/QueryGroupDetails.tsx
+++ b/public/pages/QueryGroupDetails/QueryGroupDetails.tsx
@@ -49,6 +49,7 @@ export const QueryGroupDetails = ({
   const id = searchParams.get('id');
   const from = searchParams.get('from');
   const to = searchParams.get('to');
+  const verbose = Boolean(searchParams.get('verbose'));
 
   const [query, setQuery] = useState<SearchQueryRecord | null>(null);
   const { dataSource, setDataSource } = useContext(DataSourceContext)!;
@@ -62,15 +63,22 @@ export const QueryGroupDetails = ({
   const history = useHistory();
 
   const fetchQueryDetails = async () => {
-    const retrievedQuery = await retrieveQueryById(core, getDataSourceFromUrl().id, from, to, id);
+    const retrievedQuery = await retrieveQueryById(
+      core,
+      getDataSourceFromUrl().id,
+      from,
+      to,
+      id,
+      verbose
+    );
     setQuery(retrievedQuery);
   };
 
   useEffect(() => {
-    if (id && from && to) {
+    if (id && from && to && verbose) {
       fetchQueryDetails();
     }
-  }, [id, from, to]);
+  }, [id, from, to, verbose]);
 
   useEffect(() => {
     if (query) {

--- a/public/pages/QueryInsights/QueryInsights.tsx
+++ b/public/pages/QueryInsights/QueryInsights.tsx
@@ -117,8 +117,8 @@ const QueryInsights = ({
               onClick={() => {
                 const route =
                   query.group_by === 'SIMILARITY'
-                    ? `/query-group-details?from=${from}&to=${to}&id=${query.id}`
-                    : `/query-details?from=${from}&to=${to}&id=${query.id}`;
+                    ? `/query-group-details?from=${from}&to=${to}&id=${query.id}&verbose=${true}`
+                    : `/query-details?from=${from}&to=${to}&id=${query.id}&verbose=${true}`;
                 history.push(route);
               }}
             >
@@ -139,8 +139,8 @@ const QueryInsights = ({
               onClick={() => {
                 const route =
                   query.group_by === 'SIMILARITY'
-                    ? `/query-group-details?from=${from}&to=${to}&id=${query.id}`
-                    : `/query-details?from=${from}&to=${to}&id=${query.id}`;
+                    ? `/query-group-details?from=${from}&to=${to}&id=${query.id}&verbose=${true}`
+                    : `/query-details?from=${from}&to=${to}&id=${query.id}&verbose=${true}`;
                 history.push(route);
               }}
             >
@@ -251,7 +251,7 @@ const QueryInsights = ({
         const isQuery = query.group_by === 'NONE';
         const linkContent = isQuery ? convertTime(query.timestamp) : '-';
         const onClickHandler = () => {
-          const route = `/query-details?from=${from}&to=${to}&id=${query.id}`;
+          const route = `/query-details?from=${from}&to=${to}&id=${query.id}&verbose=true`;
           history.push(route);
         };
         return (

--- a/public/pages/TopNQueries/TopNQueries.tsx
+++ b/public/pages/TopNQueries/TopNQueries.tsx
@@ -171,6 +171,7 @@ const TopNQueries = ({
           from: parseDateString(start),
           to: parseDateString(end),
           dataSourceId: getDataSourceFromUrl().id, // TODO: get this dynamically from the URL
+          verbose: false,
         },
       };
       const fetchMetric = async (endpoint: string) => {

--- a/server/clusters/queryInsightsPlugin.ts
+++ b/server/clusters/queryInsightsPlugin.ts
@@ -17,7 +17,7 @@ export const QueryInsightsPlugin = function (Client, config, components) {
 
   queryInsights.getTopNQueriesLatency = ca({
     url: {
-      fmt: `/_insights/top_queries?type=latency&from=<%=from%>&to=<%=to%>`,
+      fmt: `/_insights/top_queries?type=latency&from=<%=from%>&to=<%=to%>&verbose=<%=verbose%>`,
       req: {
         from: {
           type: 'string',
@@ -25,6 +25,10 @@ export const QueryInsightsPlugin = function (Client, config, components) {
         },
         to: {
           type: 'string',
+          required: true,
+        },
+        verbose: {
+          type: 'boolean',
           required: true,
         },
       },
@@ -34,7 +38,7 @@ export const QueryInsightsPlugin = function (Client, config, components) {
 
   queryInsights.getTopNQueriesCpu = ca({
     url: {
-      fmt: `/_insights/top_queries?type=cpu&from=<%=from%>&to=<%=to%>`,
+      fmt: `/_insights/top_queries?type=cpu&from=<%=from%>&to=<%=to%>&verbose=<%=verbose%>`,
       req: {
         from: {
           type: 'string',
@@ -42,6 +46,10 @@ export const QueryInsightsPlugin = function (Client, config, components) {
         },
         to: {
           type: 'string',
+          required: true,
+        },
+        verbose: {
+          type: 'boolean',
           required: true,
         },
       },
@@ -51,7 +59,7 @@ export const QueryInsightsPlugin = function (Client, config, components) {
 
   queryInsights.getTopNQueriesMemory = ca({
     url: {
-      fmt: `/_insights/top_queries?type=memory&from=<%=from%>&to=<%=to%>`,
+      fmt: `/_insights/top_queries?type=memory&from=<%=from%>&to=<%=to%>&verbose=<%=verbose%>`,
       req: {
         from: {
           type: 'string',
@@ -59,6 +67,10 @@ export const QueryInsightsPlugin = function (Client, config, components) {
         },
         to: {
           type: 'string',
+          required: true,
+        },
+        verbose: {
+          type: 'boolean',
           required: true,
         },
       },
@@ -68,7 +80,7 @@ export const QueryInsightsPlugin = function (Client, config, components) {
 
   queryInsights.getTopNQueriesLatencyForId = ca({
     url: {
-      fmt: `/_insights/top_queries?type=latency&from=<%=from%>&to=<%=to%><% if (id) { %>&id=<%=id%><% } %>`,
+      fmt: `/_insights/top_queries?type=latency&from=<%=from%>&to=<%=to%><% if (id) { %>&id=<%=id%><% } %>&verbose=<%=verbose%>`,
       req: {
         from: {
           type: 'string',
@@ -80,6 +92,10 @@ export const QueryInsightsPlugin = function (Client, config, components) {
         },
         id: {
           type: 'string',
+          required: true,
+        },
+        verbose: {
+          type: 'boolean',
           required: true,
         },
       },
@@ -89,7 +105,7 @@ export const QueryInsightsPlugin = function (Client, config, components) {
 
   queryInsights.getTopNQueriesCpuForId = ca({
     url: {
-      fmt: `/_insights/top_queries?type=latency&from=<%=from%>&to=<%=to%><% if (id) { %>&id=<%=id%><% } %>`,
+      fmt: `/_insights/top_queries?type=cpu&from=<%=from%>&to=<%=to%><% if (id) { %>&id=<%=id%><% } %>&verbose=<%=verbose%>`,
       req: {
         from: {
           type: 'string',
@@ -101,6 +117,10 @@ export const QueryInsightsPlugin = function (Client, config, components) {
         },
         id: {
           type: 'string',
+          required: true,
+        },
+        verbose: {
+          type: 'boolean',
           required: true,
         },
       },
@@ -110,7 +130,7 @@ export const QueryInsightsPlugin = function (Client, config, components) {
 
   queryInsights.getTopNQueriesMemoryForId = ca({
     url: {
-      fmt: `/_insights/top_queries?type=latency&from=<%=from%>&to=<%=to%><% if (id) { %>&id=<%=id%><% } %>`,
+      fmt: `/_insights/top_queries?type=memory&from=<%=from%>&to=<%=to%><% if (id) { %>&id=<%=id%><% } %>&verbose=<%=verbose%>`,
       req: {
         from: {
           type: 'string',
@@ -122,6 +142,10 @@ export const QueryInsightsPlugin = function (Client, config, components) {
         },
         id: {
           type: 'string',
+          required: true,
+        },
+        verbose: {
+          type: 'boolean',
           required: true,
         },
       },

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -19,7 +19,6 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
     },
     async (context, request, response) => {
       try {
-        // data source disabled
         if (!dataSourceEnabled || !request.query?.dataSourceId) {
           const client = context.queryInsights_plugin.queryInsightsClient.asScoped(request)
             .callAsCurrentUser;
@@ -65,13 +64,14 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
           to: schema.maybe(schema.string({ defaultValue: '' })),
           id: schema.maybe(schema.string({ defaultValue: '' })),
           dataSourceId: schema.maybe(schema.string()),
+          verbose: schema.maybe(schema.boolean({ defaultValue: false })),
         }),
       },
     },
     async (context, request, response) => {
       try {
-        const { from, to, id } = request.query;
-        const params = { from, to, id };
+        const { from, to, id, verbose } = request.query;
+        const params = { from, to, id, verbose };
         if (!dataSourceEnabled || !request.query?.dataSourceId) {
           const client = context.queryInsights_plugin.queryInsightsClient.asScoped(request)
             .callAsCurrentUser;
@@ -123,13 +123,15 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
           to: schema.maybe(schema.string({ defaultValue: '' })),
           id: schema.maybe(schema.string({ defaultValue: '' })),
           dataSourceId: schema.maybe(schema.string()),
+          verbose: schema.maybe(schema.boolean({ defaultValue: false })),
         }),
       },
     },
     async (context, request, response) => {
       try {
-        const { from, to, id } = request.query;
-        const params = { from, to, id };
+        const { from, to, id, verbose } = request.query;
+        const params = { from, to, id, verbose };
+
         if (!dataSourceEnabled || !request.query?.dataSourceId) {
           const client = context.queryInsights_plugin.queryInsightsClient.asScoped(request)
             .callAsCurrentUser;
@@ -181,13 +183,14 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
           to: schema.maybe(schema.string({ defaultValue: '' })),
           id: schema.maybe(schema.string({ defaultValue: '' })),
           dataSourceId: schema.maybe(schema.string()),
+          verbose: schema.maybe(schema.boolean({ defaultValue: false })),
         }),
       },
     },
     async (context, request, response) => {
       try {
-        const { from, to, id } = request.query;
-        const params = { from, to, id };
+        const { from, to, id, verbose } = request.query;
+        const params = { from, to, id, verbose };
         if (!dataSourceEnabled || !request.query?.dataSourceId) {
           const client = context.queryInsights_plugin.queryInsightsClient.asScoped(request)
             .callAsCurrentUser;


### PR DESCRIPTION
* Fetch top query with verbose=false



* Fetch top query with verbose=false



* Updated the queryInsightPlugin.ts



* Updated the queryInsightPlugin.ts



* Updated the queryInsightPlugin.ts



* Disabling failing Cypress usecase



* Updated tests



* Updated tests



* Updated tests



* Update 1_top_queries.cy.js



* Updated tests



* Updated tests



* Updated tests



---------




(cherry picked from commit 3e9f57795c6ee3866f7e8e4eb56f7f2af964cd0a) (cherry picked from commit 84f40143a94a29b9508b0ebfc8068cbba0b88ffc)

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
