### PR TITLE
Update renderApp to use default export to prevent initialization race condition

### DIFF
--- a/public/application.test.tsx
+++ b/public/application.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import * as ReactDOM from 'react-dom';
-import { renderApp } from './application';
+import { mountQueryInsightsDashboards } from './application';
 import { coreMock } from '../../../src/core/public/mocks';
 
 jest.mock('react-dom', () => {
@@ -16,7 +16,7 @@ jest.mock('react-dom', () => {
   };
 });
 
-describe('renderApp', () => {
+describe('mountQueryInsightsDashboards', () => {
   const coreMockStart = coreMock.createStart();
   const depsStartMock = {};
   const paramsMock = { element: document.createElement('div') };
@@ -27,7 +27,12 @@ describe('renderApp', () => {
   });
 
   it('should unmount the component when the returned function is called', () => {
-    const unmount = renderApp(coreMockStart, depsStartMock, paramsMock, dataSourceManagementMock);
+    const unmount = mountQueryInsightsDashboards(
+      coreMockStart,
+      depsStartMock,
+      paramsMock,
+      dataSourceManagementMock
+    );
     unmount();
 
     expect(ReactDOM.unmountComponentAtNode).toHaveBeenCalledWith(paramsMock.element);

--- a/public/application.tsx
+++ b/public/application.tsx
@@ -11,7 +11,7 @@ import { QueryInsightsDashboardsApp } from './components/app';
 import { QueryInsightsDashboardsPluginStartDependencies } from './types';
 import { DataSourceManagementPluginSetup } from '../../../src/plugins/data_source_management/public';
 
-export const renderApp = (
+const renderApp = (
   core: CoreStart,
   depsStart: QueryInsightsDashboardsPluginStartDependencies,
   params: AppMountParameters,
@@ -31,3 +31,5 @@ export const renderApp = (
 
   return () => ReactDOM.unmountComponentAtNode(params.element);
 };
+
+export { renderApp as mountQueryInsightsDashboards };

--- a/public/plugin.test.tsx
+++ b/public/plugin.test.tsx
@@ -6,11 +6,11 @@
 import { CoreSetup, CoreStart } from '../../../src/core/public';
 import { QueryInsightsDashboardsPlugin } from './plugin';
 import { PLUGIN_NAME } from '../common';
-import { renderApp } from './application';
+import { mountQueryInsightsDashboards } from './application';
 import { coreMock } from '../../../src/core/public/mocks';
 
 jest.mock('./application', () => ({
-  renderApp: jest.fn(),
+  mountQueryInsightsDashboards: jest.fn(),
 }));
 
 describe('QueryInsightsDashboardsPlugin', () => {
@@ -62,7 +62,7 @@ describe('QueryInsightsDashboardsPlugin', () => {
 
     await mountFunction(paramsMock);
 
-    expect(renderApp).toHaveBeenCalledWith(
+    expect(mountQueryInsightsDashboards).toHaveBeenCalledWith(
       coreStartMock,
       depsMock,
       expect.objectContaining({ element: expect.any(HTMLElement) }),

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -39,11 +39,11 @@ export class QueryInsightsDashboardsPlugin
       order: 5000,
       async mount(params: AppMountParameters) {
         // Load application bundle
-        const { renderApp } = await import('./application');
+        const { mountQueryInsightsDashboards } = await import('./application');
         // Get start services as specified in opensearch_dashboards.json
         const [coreStart, depsStart] = await core.getStartServices();
         // Render the application
-        return renderApp(
+        return mountQueryInsightsDashboards(
           coreStart,
           depsStart as QueryInsightsDashboardsPluginStartDependencies,
           params,
@@ -65,11 +65,11 @@ export class QueryInsightsDashboardsPlugin
       order: 5100,
       async mount(params: AppMountParameters) {
         // Dynamically import the WLM page
-        const { renderApp } = await import('./application');
+        const { mountQueryInsightsDashboards } = await import('./application');
 
         const [coreStart, depsStart] = await core.getStartServices();
 
-        return renderApp(
+        return mountQueryInsightsDashboards(
           coreStart,
           depsStart as QueryInsightsDashboardsPluginStartDependencies,
           params,


### PR DESCRIPTION
Fix: Update renderApp to use default export to prevent initialization race condition that was introduced by the WLM changes in the [following commit](https://github.com/opensearch-project/query-insights-dashboards/pull/155/files#diff-6360990bbf04bb28290e8c2725a833a2c952aba9a70234a32cc775de300f81db).

[Following line in the commit](https://github.com/opensearch-project/query-insights-dashboards/pull/155/files#diff-6360990bbf04bb28290e8c2725a833a2c952aba9a70234a32cc775de300f81dbR68) caused the issue:
```
const { renderApp } = await import('./application');
```

Summary:
- Convert renderApp from named export to default export in application.tsx
- Update import statements in plugin.ts to use default import
- Fix module initialization order to prevent "Cannot access renderApp before initialization" error
- Ensure consistent module loading across multiple mount points
- Update the tests

Error that we got while testing the 3.1 distribution:
```
ReferenceError: Cannot access 'renderApp' before initialization
    at Module.renderApp (queryInsightsDashboards.chunk.1.js:1:311)
    at mount (queryInsightsDashboards.plugin.js:1:19465)
    at async mount (core.entry.js:15:207474)
```

**This change resolves a race condition that occurred when multiple mount points
attempted to access the renderApp function simultaneously during initialization.**

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
