### PR TITLE
Get version even if it is local cluster

### DIFF
--- a/public/utils/datasource-utils.ts
+++ b/public/utils/datasource-utils.ts
@@ -1,67 +1,86 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/*
- *   Copyright OpenSearch Contributors
  *
- *   Licensed under the Apache License, Version 2.0 (the "License").
- *   You may not use this file except in compliance with the License.
- *   A copy of the License is located at
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *   or in the "license" file accompanying this file. This file is distributed
- *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- *   express or implied. See the License for the specific language governing
- *   permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import semver from 'semver';
 import { DataSourceOption } from 'src/plugins/data_source_management/public';
-import pluginManifest from '../../opensearch_dashboards.json';
 import type { SavedObject } from '../../../../src/core/public';
 import type { DataSourceAttributes } from '../../../../src/plugins/data_source/common/data_sources';
-import { getSavedObjectsClient } from '../../public/service';
+import pluginManifest from '../../opensearch_dashboards.json';
 
-export function getDataSourceEnabledUrl(dataSource: DataSourceOption) {
+import { getSavedObjectsClient } from '../../public/service';
+import { getLocalClusterVersion } from './getLocalClusterVersion';
+
+/**
+ * Returns a URL with `dataSource` query param set.
+ */
+export function getDataSourceEnabledUrl(dataSource: DataSourceOption): URL {
   const url = new URL(window.location.href);
   url.searchParams.set('dataSource', JSON.stringify(dataSource));
   return url;
 }
 
+/**
+ * Gets the OpenSearch version of the specified data source.
+ * - if `dataSourceId` is undefined → returns undefined.
+ * - if `dataSourceId` is empty string → queries the local cluster.
+ * - otherwise → fetches the version from saved object.
+ */
 export const getDataSourceVersion = async (
   dataSourceId: string | undefined
 ): Promise<string | undefined> => {
   try {
-    if (dataSourceId === undefined) {
-      throw new Error();
+
+    if (dataSourceId === '' || dataSourceId === undefined) {
+      // Local cluster
+      return await getLocalClusterVersion();
     }
 
     const dataSource = await getSavedObjectsClient().get<DataSourceAttributes>(
       'data-source',
       dataSourceId
     );
+
     return dataSource?.attributes?.dataSourceVersion;
   } catch (error) {
-    console.error('Error getting version: ', error);
+    console.error('Error getting data source version: ', error);
     return undefined;
   }
 };
 
+/**
+ * Reads the `dataSource` param from the current URL.
+ */
 export function getDataSourceFromUrl(): DataSourceOption {
   const urlParams = new URLSearchParams(window.location.search);
-  const dataSourceParam = (urlParams && urlParams.get('dataSource')) || '{}';
-  // following block is needed if the dataSource param is set to non-JSON value, say 'undefined'
+  const dataSourceParam = urlParams.get('dataSource') || '{}';
   try {
     return JSON.parse(dataSourceParam);
   } catch (e) {
-    return JSON.parse('{}'); // Return an empty object or some default value if parsing fails
+    console.warn('Failed to parse dataSource param, using empty object');
+    return {} as DataSourceOption;
   }
 }
 
-export const isDataSourceCompatible = (dataSource: SavedObject<DataSourceAttributes>) => {
+/**
+ * Checks if a data source is compatible with this plugin, based on:
+ * - required OpenSearch plugins
+ * - supported OpenSearch versions
+ */
+export const isDataSourceCompatible = (dataSource: SavedObject<DataSourceAttributes>): boolean => {
   if (
     'requiredOSDataSourcePlugins' in pluginManifest &&
     !pluginManifest.requiredOSDataSourcePlugins.every((plugin) =>
@@ -71,7 +90,6 @@ export const isDataSourceCompatible = (dataSource: SavedObject<DataSourceAttribu
     return false;
   }
 
-  // filter out data sources which is NOT in the support range of plugin
   if (
     'supportedOSDataSourceVersions' in pluginManifest &&
     !semver.satisfies(
@@ -81,5 +99,6 @@ export const isDataSourceCompatible = (dataSource: SavedObject<DataSourceAttribu
   ) {
     return false;
   }
+
   return true;
 };

--- a/public/utils/datasource-utils.ts
+++ b/public/utils/datasource-utils.ts
@@ -23,7 +23,7 @@ import { DataSourceOption } from 'src/plugins/data_source_management/public';
 import pluginManifest from '../../opensearch_dashboards.json';
 import type { SavedObject } from '../../../../src/core/public';
 import type { DataSourceAttributes } from '../../../../src/plugins/data_source/common/data_sources';
-import { getSavedObjectsClient } from '../../public/service';
+import { getSavedObjectsClient } from '../service';
 import { getLocalClusterVersion } from './getLocalClusterVersion';
 
 export function getDataSourceEnabledUrl(dataSource: DataSourceOption) {

--- a/public/utils/datasource-utils.ts
+++ b/public/utils/datasource-utils.ts
@@ -1,49 +1,41 @@
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ *   Copyright OpenSearch Contributors
  *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
  */
 
 import semver from 'semver';
 import { DataSourceOption } from 'src/plugins/data_source_management/public';
+import pluginManifest from '../../opensearch_dashboards.json';
 import type { SavedObject } from '../../../../src/core/public';
 import type { DataSourceAttributes } from '../../../../src/plugins/data_source/common/data_sources';
-import pluginManifest from '../../opensearch_dashboards.json';
-
 import { getSavedObjectsClient } from '../../public/service';
 import { getLocalClusterVersion } from './getLocalClusterVersion';
 
-/**
- * Returns a URL with `dataSource` query param set.
- */
-export function getDataSourceEnabledUrl(dataSource: DataSourceOption): URL {
+export function getDataSourceEnabledUrl(dataSource: DataSourceOption) {
   const url = new URL(window.location.href);
   url.searchParams.set('dataSource', JSON.stringify(dataSource));
   return url;
 }
 
-/**
- * Gets the OpenSearch version of the specified data source.
- * - if `dataSourceId` is undefined → returns undefined.
- * - if `dataSourceId` is empty string → queries the local cluster.
- * - otherwise → fetches the version from saved object.
- */
 export const getDataSourceVersion = async (
   dataSourceId: string | undefined
 ): Promise<string | undefined> => {
   try {
-
     if (dataSourceId === '' || dataSourceId === undefined) {
       // Local cluster
       return await getLocalClusterVersion();
@@ -53,34 +45,25 @@ export const getDataSourceVersion = async (
       'data-source',
       dataSourceId
     );
-
     return dataSource?.attributes?.dataSourceVersion;
   } catch (error) {
-    console.error('Error getting data source version: ', error);
+    console.error('Error getting version: ', error);
     return undefined;
   }
 };
 
-/**
- * Reads the `dataSource` param from the current URL.
- */
 export function getDataSourceFromUrl(): DataSourceOption {
   const urlParams = new URLSearchParams(window.location.search);
-  const dataSourceParam = urlParams.get('dataSource') || '{}';
+  const dataSourceParam = (urlParams && urlParams.get('dataSource')) || '{}';
+  // following block is needed if the dataSource param is set to non-JSON value, say 'undefined'
   try {
     return JSON.parse(dataSourceParam);
   } catch (e) {
-    console.warn('Failed to parse dataSource param, using empty object');
-    return {} as DataSourceOption;
+    return JSON.parse('{}'); // Return an empty object or some default value if parsing fails
   }
 }
 
-/**
- * Checks if a data source is compatible with this plugin, based on:
- * - required OpenSearch plugins
- * - supported OpenSearch versions
- */
-export const isDataSourceCompatible = (dataSource: SavedObject<DataSourceAttributes>): boolean => {
+export const isDataSourceCompatible = (dataSource: SavedObject<DataSourceAttributes>) => {
   if (
     'requiredOSDataSourcePlugins' in pluginManifest &&
     !pluginManifest.requiredOSDataSourcePlugins.every((plugin) =>
@@ -90,6 +73,7 @@ export const isDataSourceCompatible = (dataSource: SavedObject<DataSourceAttribu
     return false;
   }
 
+  // filter out data sources which is NOT in the support range of plugin
   if (
     'supportedOSDataSourceVersions' in pluginManifest &&
     !semver.satisfies(
@@ -99,6 +83,5 @@ export const isDataSourceCompatible = (dataSource: SavedObject<DataSourceAttribu
   ) {
     return false;
   }
-
   return true;
 };

--- a/public/utils/getLocalClusterVersion.ts
+++ b/public/utils/getLocalClusterVersion.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { getRouteService } from '../service';
 
 export const getLocalClusterVersion = async (): Promise<string | undefined> => {

--- a/public/utils/getLocalClusterVersion.ts
+++ b/public/utils/getLocalClusterVersion.ts
@@ -1,0 +1,17 @@
+import { getRouteService } from '../service';
+
+export const getLocalClusterVersion = async (): Promise<string | undefined> => {
+  try {
+    const response = await getRouteService().post('/api/console/proxy', {
+      query: {
+        path: '/',
+        method: 'GET',
+        dataSourceId: '', // explicitly local cluster
+      },
+    });
+    return response?.version?.number;
+  } catch (e) {
+    console.error('Failed to fetch local cluster version', e);
+    return undefined;
+  }
+};


### PR DESCRIPTION
### Description

The PR ensures that the getDataSourceVersion method is able to get the correct version even if it is local cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
