### PR TITLE
search bar fix

### DIFF
--- a/cypress/e2e/1_top_queries.cy.js
+++ b/cypress/e2e/1_top_queries.cy.js
@@ -348,5 +348,3 @@ describe('Query Insights Table - Search & Filter', () => {
     cy.get('.euiTableRow').first().should('contain.text', targetId);
   });
 });
-
-

--- a/cypress/e2e/1_top_queries.cy.js
+++ b/cypress/e2e/1_top_queries.cy.js
@@ -314,3 +314,39 @@ describe('Query Insights Dashboard - Dynamic Columns change with Intercepted Top
     testMetricSorting('Avg Memory Usage / Memory Usage', 6);
   });
 });
+
+describe('Query Insights Table - Search & Filter', () => {
+  beforeEach(() => {
+    cy.fixture('stub_top_queries.json').then((stubResponse) => {
+      cy.intercept('GET', '**/api/top_queries/*', {
+        statusCode: 200,
+        body: stubResponse,
+      }).as('getTopQueries');
+    });
+
+    cy.waitForQueryInsightsPlugin();
+    cy.wait(2000);
+    cy.wait('@getTopQueries');
+  });
+
+  it('should show only one query after search and filter', () => {
+    const targetId = 'a2e1c822-3e3c-4d1b-adb2-9f73af094b43';
+
+    // Apply filter for group_by = NONE (i.e., query)
+    cy.get('.euiFilterButton').contains('Type').click();
+    cy.get('.euiFilterSelectItem').contains('query').click();
+    cy.wait(500);
+
+    // Search using exact ID
+    cy.get('.euiFieldSearch').clear().type(targetId);
+    cy.wait(500);
+
+    // Assert that only one row is displayed
+    cy.get('.euiTableRow').should('have.length', 1);
+
+    // Confirm that the row contains the expected ID
+    cy.get('.euiTableRow').first().should('contain.text', targetId);
+  });
+});
+
+

--- a/public/pages/QueryInsights/QueryInsights.tsx
+++ b/public/pages/QueryInsights/QueryInsights.tsx
@@ -82,7 +82,7 @@ const QueryInsights = ({
   const onSearchChange = ({ query }) => {
     const ast = query?.ast;
 
-    const textClause = ast?.clauses?.find(c => c.type === 'term' && !c.field);
+    const textClause = ast?.clauses?.find((c) => c.type === 'term' && !c.field);
 
     if (textClause) {
       setSearchText(textClause.value.trim().toLowerCase());
@@ -90,7 +90,6 @@ const QueryInsights = ({
       setSearchText('');
     }
   };
-
 
   useEffect(() => {
     core.chrome.setBreadcrumbs([
@@ -325,18 +324,14 @@ const QueryInsights = ({
     },
   ];
   const filteredQueries = useMemo(() => {
-    const base = queries.filter(q =>
-      selectedFilter.length === 0 || selectedFilter.includes(q.group_by)
+    const base = queries.filter(
+      (q) => selectedFilter.length === 0 || selectedFilter.includes(q.group_by)
     );
 
     if (!searchText) return base;
 
-    return base.filter(q =>
-      (q.id ?? '').toLowerCase().includes(searchText)
-    );
+    return base.filter((q) => (q.id ?? '').toLowerCase().includes(searchText));
   }, [queries, selectedFilter, searchText]);
-
-
 
   const defaultColumns = [
     ...baseColumns,

--- a/public/pages/QueryInsights/QueryInsights.tsx
+++ b/public/pages/QueryInsights/QueryInsights.tsx
@@ -68,11 +68,29 @@ const QueryInsights = ({
   const history = useHistory();
   const location = useLocation();
   const [pagination, setPagination] = useState({ pageIndex: 0 });
+  const [searchText, setSearchText] = useState('');
   const [selectedFilter, setSelectedFilter] = useState<string[]>([]);
+  const onChange = (state) => {
+    onChangeFilter(state);
+    onSearchChange(state);
+  };
 
   const from = parseDateString(currStart);
   const to = parseDateString(currEnd);
   const { dataSource, setDataSource } = useContext(DataSourceContext)!;
+
+  const onSearchChange = ({ query }) => {
+    const ast = query?.ast;
+
+    const textClause = ast?.clauses?.find(c => c.type === 'term' && !c.field);
+
+    if (textClause) {
+      setSearchText(textClause.value.trim().toLowerCase());
+    } else {
+      setSearchText('');
+    }
+  };
+
 
   useEffect(() => {
     core.chrome.setBreadcrumbs([
@@ -307,10 +325,18 @@ const QueryInsights = ({
     },
   ];
   const filteredQueries = useMemo(() => {
-    return queries.filter(
-      (query) => selectedFilter.length === 0 || selectedFilter.includes(query.group_by)
+    const base = queries.filter(q =>
+      selectedFilter.length === 0 || selectedFilter.includes(q.group_by)
     );
-  }, [queries, selectedFilter]);
+
+    if (!searchText) return base;
+
+    return base.filter(q =>
+      (q.id ?? '').toLowerCase().includes(searchText)
+    );
+  }, [queries, selectedFilter, searchText]);
+
+
 
   const defaultColumns = [
     ...baseColumns,
@@ -482,7 +508,7 @@ const QueryInsights = ({
               ),
             },
           ],
-          onChange: onChangeFilter,
+          onChange,
 
           toolsRight: [
             <EuiSuperDatePicker


### PR DESCRIPTION
### Description

Problem: 

The search bar on the Top N Queries overview page was not functioning as expected:

- When a user entered a Top N query record ID, the table results did not change.

Fix:

- onSearchChange able to correctly parse the AST for free-text terms and update the searchText state.
- Verified that the filteredQueries computation properly filters the id column of each row using the searchText.
- Added clarification (e.g., placeholder text) indicating that the search bar applies to the ID column only.
- Updated Cypress tests to cover the case where searching for a valid id returns exactly one result and an invalid id shows no results.

<img width="1728" height="958" alt="Screenshot 2025-07-20 at 10 31 43 PM" src="https://github.com/user-attachments/assets/3c0056e9-0dfd-4954-8f0b-c066bfcbdc6a" />


### Issues Resolved
Closes [#214]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
