### PR TITLE
[Fix]explicitly match query by id and fix q scope in retrieveQueryById [2.19]

### DIFF
--- a/common/utils/QueryUtils.ts
+++ b/common/utils/QueryUtils.ts
@@ -48,7 +48,8 @@ export const retrieveQueryById = async (
       fetchMetric(`/api/top_queries/cpu`),
       fetchMetric(`/api/top_queries/memory`),
     ]);
-    return topQueriesResponse.response.top_queries[0] || null;
+    const records = topQueriesResponse.response.top_queries || [];
+    return records.find(q => q.id === id) || null;
   } catch (error) {
     console.error('Error retrieving query details:', error);
     return null;

--- a/common/utils/QueryUtils.ts
+++ b/common/utils/QueryUtils.ts
@@ -49,7 +49,7 @@ export const retrieveQueryById = async (
       fetchMetric(`/api/top_queries/memory`),
     ]);
     const records = topQueriesResponse.response.top_queries || [];
-    return records.find(q => q.id === id) || null;
+    return records.find((q) => q.id === id) || null;
   } catch (error) {
     console.error('Error retrieving query details:', error);
     return null;


### PR DESCRIPTION
### Description

Issue: 

The function retrieveQueryById was designed to find a query record by its id from the API response. However:

- It returned top_queries[0] blindly from the API response, assuming the first record already matched the requested id.
- This could result in returning an incorrect record if the API response contained multiple records or did not filter properly.
- Consequently, this sometimes directed the user to the wrong query detail page, since the incorrect record was returned.

Fix:

Explicitly filter the top_queries array for the record where q.id === id, ensuring the correct record is returned and the detail page shows the right data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
