### PR TITLE
Fix top queries table sorting with correct id

### DIFF
--- a/public/pages/QueryInsights/QueryInsights.test.tsx
+++ b/public/pages/QueryInsights/QueryInsights.test.tsx
@@ -96,6 +96,48 @@ describe('QueryInsights Component', () => {
     expect(mockOnTimeChange).toHaveBeenCalled();
   });
 
+  it('uses query ID as itemId for table rows to prevent duplicate row rendering', () => {
+    const testQueries = [
+      {
+        ...sampleQueries[0],
+        id: 'unique-query-id-1',
+        timestamp: 1000,
+        group_by: 'NONE',
+      },
+      {
+        ...sampleQueries[0],
+        id: 'unique-query-id-2',
+        timestamp: 2000,
+        group_by: 'NONE',
+      },
+    ];
+    expect(() => {
+      render(
+        <MemoryRouter>
+          <DataSourceContext.Provider value={mockDataSourceContext}>
+            <QueryInsights
+              queries={testQueries}
+              loading={false}
+              onTimeChange={mockOnTimeChange}
+              recentlyUsedRanges={[]}
+              currStart="now-15m"
+              currEnd="now"
+              retrieveQueries={mockRetrieveQueries}
+              // @ts-ignore
+              core={mockCore}
+              depsStart={{} as any}
+              params={{} as any}
+              dataSourceManagement={dataSourceManagementMock as any}
+            />
+          </DataSourceContext.Provider>
+        </MemoryRouter>
+      );
+    }).not.toThrow();
+
+    // Verify that the table component renders successfully
+    expect(screen.getByRole('table')).toBeInTheDocument();
+  });
+
   it('renders the expected column headers in the correct sequence for default', async () => {
     renderQueryInsights();
 

--- a/public/pages/QueryInsights/QueryInsights.tsx
+++ b/public/pages/QueryInsights/QueryInsights.tsx
@@ -530,7 +530,7 @@ const QueryInsights = ({
           ],
         }}
         allowNeutralSort={false}
-        itemId={(query) => `${query.id}-${query.timestamp}`}
+        itemId={(query) => query.id}
       />
     </>
   );

--- a/public/pages/TopNQueries/TopNQueries.tsx
+++ b/public/pages/TopNQueries/TopNQueries.tsx
@@ -214,9 +214,9 @@ const TopNQueries = ({
           ...respCpu.response.top_queries,
           ...respMemory.response.top_queries,
         ];
-        const noDuplicates: SearchQueryRecord[] = Array.from(
-          new Set(newQueries.map((item) => JSON.stringify(item)))
-        ).map((item) => JSON.parse(item));
+        const noDuplicates: SearchQueryRecord[] = newQueries.filter(
+          (query, index, self) => index === self.findIndex((q) => q.id === query.id)
+        );
         setQueries(noDuplicates);
       } catch (error) {
         console.error('Error retrieving queries:', error);

--- a/public/pages/TopNQueries/__snapshots__/TopNQueries.test.tsx.snap
+++ b/public/pages/TopNQueries/__snapshots__/TopNQueries.test.tsx.snap
@@ -1,5 +1,548 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TopNQueries Component Query deduplication should deduplicate queries by ID from multiple metric endpoints 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        style="padding: 35px 35px;"
+      >
+        <h1
+          class="euiTitle euiTitle--large"
+        >
+          Query insights - Top N queries
+        </h1>
+        <div
+          class="euiSpacer euiSpacer--l"
+        />
+        <div
+          class="euiTabs"
+          role="tablist"
+        >
+          <button
+            aria-selected="false"
+            class="euiTab"
+            role="tab"
+            type="button"
+          >
+            <span
+              class="euiTab__content"
+            >
+              Live queries
+            </span>
+          </button>
+          <button
+            aria-selected="true"
+            class="euiTab euiTab-isSelected"
+            role="tab"
+            type="button"
+          >
+            <span
+              class="euiTab__content"
+            >
+              Top N queries
+            </span>
+          </button>
+          <button
+            aria-selected="false"
+            class="euiTab"
+            role="tab"
+            type="button"
+          >
+            <span
+              class="euiTab__content"
+            >
+              Configuration
+            </span>
+          </button>
+        </div>
+        <div
+          class="euiSpacer euiSpacer--l"
+        />
+        <div>
+          Mocked QueryInsights
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      style="padding: 35px 35px;"
+    >
+      <h1
+        class="euiTitle euiTitle--large"
+      >
+        Query insights - Top N queries
+      </h1>
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
+      <div
+        class="euiTabs"
+        role="tablist"
+      >
+        <button
+          aria-selected="false"
+          class="euiTab"
+          role="tab"
+          type="button"
+        >
+          <span
+            class="euiTab__content"
+          >
+            Live queries
+          </span>
+        </button>
+        <button
+          aria-selected="true"
+          class="euiTab euiTab-isSelected"
+          role="tab"
+          type="button"
+        >
+          <span
+            class="euiTab__content"
+          >
+            Top N queries
+          </span>
+        </button>
+        <button
+          aria-selected="false"
+          class="euiTab"
+          role="tab"
+          type="button"
+        >
+          <span
+            class="euiTab__content"
+          >
+            Configuration
+          </span>
+        </button>
+      </div>
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
+      <div>
+        Mocked QueryInsights
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`TopNQueries Component Query deduplication should handle empty responses without errors 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        style="padding: 35px 35px;"
+      >
+        <h1
+          class="euiTitle euiTitle--large"
+        >
+          Query insights - Top N queries
+        </h1>
+        <div
+          class="euiSpacer euiSpacer--l"
+        />
+        <div
+          class="euiTabs"
+          role="tablist"
+        >
+          <button
+            aria-selected="false"
+            class="euiTab"
+            role="tab"
+            type="button"
+          >
+            <span
+              class="euiTab__content"
+            >
+              Live queries
+            </span>
+          </button>
+          <button
+            aria-selected="true"
+            class="euiTab euiTab-isSelected"
+            role="tab"
+            type="button"
+          >
+            <span
+              class="euiTab__content"
+            >
+              Top N queries
+            </span>
+          </button>
+          <button
+            aria-selected="false"
+            class="euiTab"
+            role="tab"
+            type="button"
+          >
+            <span
+              class="euiTab__content"
+            >
+              Configuration
+            </span>
+          </button>
+        </div>
+        <div
+          class="euiSpacer euiSpacer--l"
+        />
+        <div>
+          Mocked QueryInsights
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      style="padding: 35px 35px;"
+    >
+      <h1
+        class="euiTitle euiTitle--large"
+      >
+        Query insights - Top N queries
+      </h1>
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
+      <div
+        class="euiTabs"
+        role="tablist"
+      >
+        <button
+          aria-selected="false"
+          class="euiTab"
+          role="tab"
+          type="button"
+        >
+          <span
+            class="euiTab__content"
+          >
+            Live queries
+          </span>
+        </button>
+        <button
+          aria-selected="true"
+          class="euiTab euiTab-isSelected"
+          role="tab"
+          type="button"
+        >
+          <span
+            class="euiTab__content"
+          >
+            Top N queries
+          </span>
+        </button>
+        <button
+          aria-selected="false"
+          class="euiTab"
+          role="tab"
+          type="button"
+        >
+          <span
+            class="euiTab__content"
+          >
+            Configuration
+          </span>
+        </button>
+      </div>
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
+      <div>
+        Mocked QueryInsights
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`TopNQueries Component Query deduplication should preserve first occurrence when deduplicating by ID 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        style="padding: 35px 35px;"
+      >
+        <h1
+          class="euiTitle euiTitle--large"
+        >
+          Query insights - Top N queries
+        </h1>
+        <div
+          class="euiSpacer euiSpacer--l"
+        />
+        <div
+          class="euiTabs"
+          role="tablist"
+        >
+          <button
+            aria-selected="false"
+            class="euiTab"
+            role="tab"
+            type="button"
+          >
+            <span
+              class="euiTab__content"
+            >
+              Live queries
+            </span>
+          </button>
+          <button
+            aria-selected="true"
+            class="euiTab euiTab-isSelected"
+            role="tab"
+            type="button"
+          >
+            <span
+              class="euiTab__content"
+            >
+              Top N queries
+            </span>
+          </button>
+          <button
+            aria-selected="false"
+            class="euiTab"
+            role="tab"
+            type="button"
+          >
+            <span
+              class="euiTab__content"
+            >
+              Configuration
+            </span>
+          </button>
+        </div>
+        <div
+          class="euiSpacer euiSpacer--l"
+        />
+        <div>
+          Mocked QueryInsights
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      style="padding: 35px 35px;"
+    >
+      <h1
+        class="euiTitle euiTitle--large"
+      >
+        Query insights - Top N queries
+      </h1>
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
+      <div
+        class="euiTabs"
+        role="tablist"
+      >
+        <button
+          aria-selected="false"
+          class="euiTab"
+          role="tab"
+          type="button"
+        >
+          <span
+            class="euiTab__content"
+          >
+            Live queries
+          </span>
+        </button>
+        <button
+          aria-selected="true"
+          class="euiTab euiTab-isSelected"
+          role="tab"
+          type="button"
+        >
+          <span
+            class="euiTab__content"
+          >
+            Top N queries
+          </span>
+        </button>
+        <button
+          aria-selected="false"
+          class="euiTab"
+          role="tab"
+          type="button"
+        >
+          <span
+            class="euiTab__content"
+          >
+            Configuration
+          </span>
+        </button>
+      </div>
+      <div
+        class="euiSpacer euiSpacer--l"
+      />
+      <div>
+        Mocked QueryInsights
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`TopNQueries Component fetches queries for all metrics in retrieveQueries 1`] = `
 Object {
   "asFragment": [Function],


### PR DESCRIPTION
### Description
The current deduplication logic is error prune with JSON string. Replacing it with ID.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
