### PR TITLE
[Feature] Enhance User Experience with Bi-Directional Navigation Between WLM and Live Queries

### DIFF
--- a/common/utils/QueryUtils.ts
+++ b/common/utils/QueryUtils.ts
@@ -110,7 +110,7 @@ export const retrieveLiveQueries = async (
 export const retrieveLiveQueriesWithWLMGroup = async (
   core: CustomCore,
   dataSourceId?: string,
-  wlmGroup?: string
+  wlm_group?: string
 ): Promise<LiveSearchQueryResponse> => {
   const nullResponse: LiveSearchQueryResponse = {
     ok: true,
@@ -128,7 +128,7 @@ export const retrieveLiveQueriesWithWLMGroup = async (
 
     const response: LiveSearchQueryResponse = await http.get({
       path: API_ENDPOINTS.LIVE_QUERIES,
-      query: { wlm_group: wlmGroup },
+      query: { wlm_group : wlm_group },
     });
 
     const liveQueries = response?.response?.live_queries;

--- a/common/utils/QueryUtils.ts
+++ b/common/utils/QueryUtils.ts
@@ -106,3 +106,41 @@ export const retrieveLiveQueries = async (
     return errorResponse;
   }
 };
+
+export const retrieveLiveQueriesWithWLMGroup = async (
+  core: CustomCore,
+  dataSourceId?: string,
+  wlmGroup?: string
+): Promise<LiveSearchQueryResponse> => {
+  const nullResponse: LiveSearchQueryResponse = {
+    ok: true,
+    response: { live_queries: [] },
+  };
+
+  const errorResponse: LiveSearchQueryResponse = {
+    ok: false,
+    response: { live_queries: [] },
+  };
+
+  try {
+    const http =
+      dataSourceId && core.data?.dataSources ? core.data.dataSources.get(dataSourceId) : core.http;
+
+    const response: LiveSearchQueryResponse = await http.get({
+      path: API_ENDPOINTS.LIVE_QUERIES,
+      query: { wlm_group: wlmGroup },
+    });
+
+    const liveQueries = response?.response?.live_queries;
+
+    if (Array.isArray(liveQueries)) {
+      return response;
+    } else {
+      console.warn('No live queries found in response');
+      return nullResponse;
+    }
+  } catch (error) {
+    console.error('Error retrieving live queries:', error);
+    return errorResponse;
+  }
+};

--- a/cypress/fixtures/stub_live_queries.json
+++ b/cypress/fixtures/stub_live_queries.json
@@ -8,6 +8,7 @@
         "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
         "node_id": "node-A1B2C3D4E5",
         "is_cancelled": true,
+        "query_group_id": "DEFAULT_QUERY_GROUP",
         "measurements": {
           "latency": {
             "number": 7990852130,
@@ -32,6 +33,7 @@
         "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
         "node_id": "4W2VTHIgQY-oB7dSrYz4B",
         "is_cancelled": true,
+        "query_group_id": "DEFAULT_QUERY_GROUP",
         "measurements": {
           "latency": {
             "number": 6412938258,
@@ -56,6 +58,7 @@
         "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
         "node_id": "node-X9Y8Z7W6",
         "is_cancelled": false,
+        "query_group_id": "DEFAULT_QUERY_GROUP",
         "measurements": {
           "latency": {
             "number": 9633985711,
@@ -80,6 +83,7 @@
         "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
         "node_id": "node-P0Q9R8S7",
         "is_cancelled": false,
+        "query_group_id": "DEFAULT_QUERY_GROUP",
         "measurements": {
           "latency": {
             "number": 9530744641,
@@ -104,6 +108,7 @@
         "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
         "node_id": "4W2VTHIgQY-oB7dSrYz4",
         "is_cancelled": false,
+        "query_group_id": "DEFAULT_QUERY_GROUP",
         "measurements": {
           "latency": {
             "number": 6084339201,
@@ -128,6 +133,7 @@
         "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
         "node_id": "node-M2O3P4Q5",
         "is_cancelled": true,
+        "query_group_id": "DEFAULT_QUERY_GROUP",
         "measurements": {
           "latency": {
             "number": 5967857684,
@@ -152,6 +158,7 @@
         "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
         "node_id": "node-B2C3D4E5",
         "is_cancelled": true,
+        "query_group_id": "DEFAULT_QUERY_GROUP",
         "measurements": {
           "latency": {
             "number": 6454136095,
@@ -176,6 +183,7 @@
         "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
         "node_id": "node-N2O3P4Q5",
         "is_cancelled": false,
+        "query_group_id": "DEFAULT_QUERY_GROUP",
         "measurements": {
           "latency": {
             "number": 8450990820,
@@ -200,6 +208,7 @@
         "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
         "node_id": "2VTHIgQY-oB7dSrYz4BQ",
         "is_cancelled": true,
+        "query_group_id": "DEFAULT_QUERY_GROUP",
         "measurements": {
           "latency": {
             "number": 7308762773,
@@ -224,6 +233,7 @@
         "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
         "node_id": "node-X9Y8Z7W6V5",
         "is_cancelled": true,
+        "query_group_id": "DEFAULT_QUERY_GROUP",
         "measurements": {
           "latency": {
             "number": 5167823987,
@@ -248,6 +258,7 @@
         "description": "indices[opensearch], search_type[Query_THEN_FETCH]",
         "node_id": "de-M1N2O3P4Q5",
         "is_cancelled": true,
+        "query_group_id": "DEFAULT_QUERY_GROUP",
         "measurements": {
           "latency": {
             "number": 5708789476,
@@ -272,6 +283,7 @@
         "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
         "node_id": "no-P0Q9R8S7T6",
         "is_cancelled": false,
+        "query_group_id": "DEFAULT_QUERY_GROUP",
         "measurements": {
           "latency": {
             "number": 7501207171,
@@ -296,6 +308,7 @@
         "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
         "node_id": "4WTHIgQY-oB7dSrYz4BQ",
         "is_cancelled": true,
+        "query_group_id": "DEFAULT_QUERY_GROUP",
         "measurements": {
           "latency": {
             "number": 8887346819,
@@ -320,6 +333,7 @@
         "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
         "node_id": "4W2VTHQY-oB7dSrYz4BQ",
         "is_cancelled": true,
+        "query_group_id": "DEFAULT_QUERY_GROUP",
         "measurements": {
           "latency": {
             "number": 5672726176,
@@ -344,6 +358,7 @@
         "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
         "node_id": "node-A1B2C4E5",
         "is_cancelled": false,
+        "query_group_id": "DEFAULT_QUERY_GROUP",
         "measurements": {
           "latency": {
             "number": 9691523794,
@@ -368,6 +383,7 @@
         "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
         "node_id": "node-X8Z7W6V5",
         "is_cancelled": false,
+        "query_group_id": "DEFAULT_QUERY_GROUP",
         "measurements": {
           "latency": {
             "number": 6840833580,
@@ -392,6 +408,7 @@
         "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
         "node_id": "node-M1N2P4Q5",
         "is_cancelled": true,
+        "query_group_id": "DEFAULT_QUERY_GROUP",
         "measurements": {
           "latency": {
             "number": 5718519414,
@@ -416,6 +433,7 @@
         "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
         "node_id": "node-A1B2C3E5",
         "is_cancelled": true,
+        "query_group_id": "DEFAULT_QUERY_GROUP",
         "measurements": {
           "latency": {
             "number": 6063407743,
@@ -440,6 +458,7 @@
         "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
         "node_id": "4W2VTHIgQY-7dSrYz4BQ",
         "is_cancelled": true,
+        "query_group_id": "DEFAULT_QUERY_GROUP",
         "measurements": {
           "latency": {
             "number": 9215252980,
@@ -464,6 +483,7 @@
         "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
         "node_id": "node-A1B2C3D4E5",
         "is_cancelled": true,
+        "query_group_id": "DEFAULT_QUERY_GROUP",
         "measurements": {
           "latency": {
             "number": 5409476701,

--- a/public/pages/InflightQueries/InflightQueries.tsx
+++ b/public/pages/InflightQueries/InflightQueries.tsx
@@ -90,7 +90,7 @@ export const InflightQueries = ({
       const parsedQueries = retrievedQueries.response.live_queries.map((q) => {
         const indexMatch = q.description?.match(/indices\[(.*?)\]/);
         const searchTypeMatch = q.description?.match(/search_type\[(.*?)\]/);
-        const newWlmGroup =
+        const WlmGroup =
           typeof q.query_group_id === 'string' && q.query_group_id.trim() !== ''
             ? q.query_group_id
             : 'N/A';
@@ -100,7 +100,7 @@ export const InflightQueries = ({
           search_type: searchTypeMatch ? searchTypeMatch[1] : 'N/A',
           coordinator_node: q.node_id,
           node_label: q.node_id,
-          wlm_group: newWlmGroup,
+          wlm_group: WlmGroup,
         };
       });
 

--- a/public/pages/InflightQueries/InflightQueries.tsx
+++ b/public/pages/InflightQueries/InflightQueries.tsx
@@ -17,7 +17,7 @@ import {
   EuiSpacer,
   EuiInMemoryTable,
   EuiButton,
-  EuiLink
+  EuiLink,
 } from '@elastic/eui';
 import {
   RadialChart,
@@ -33,8 +33,12 @@ import { filesize } from 'filesize';
 import { AppMountParameters, CoreStart } from 'opensearch-dashboards/public';
 import { DataSourceManagementPluginSetup } from 'src/plugins/data_source_management/public';
 import { useContext } from 'react';
+import { useLocation } from 'react-router-dom';
 import { LiveSearchQueryResponse } from '../../../types/types';
-import { retrieveLiveQueries } from '../../../common/utils/QueryUtils';
+import {
+  retrieveLiveQueries,
+  retrieveLiveQueriesWithWLMGroup,
+} from '../../../common/utils/QueryUtils';
 import { API_ENDPOINTS } from '../../../common/utils/apiendpoints';
 import { QueryInsightsDashboardsPluginStartDependencies } from '../../types';
 import { DataSourceContext } from '../TopNQueries/TopNQueries';
@@ -51,16 +55,15 @@ export const InflightQueries = ({
   dataSourceManagement?: DataSourceManagementPluginSetup;
   depsStart: QueryInsightsDashboardsPluginStartDependencies;
 }) => {
-  const DEFAULT_REFRESH_INTERVAL = 1000; // default 5s
+  const DEFAULT_REFRESH_INTERVAL = 5000; // default 5s
   const TOP_N_DISPLAY_LIMIT = 9;
   const isFetching = useRef(false);
   const [query, setQuery] = useState<LiveSearchQueryResponse | null>(null);
   const { dataSource, setDataSource } = useContext(DataSourceContext)!;
   const [nodeCounts, setNodeCounts] = useState({});
   const [indexCounts, setIndexCounts] = useState({});
-  const [workloadGroups, setWorkloadGroups] = useState<string[]>([]);
-  const [selectedWorkloadGroup, setSelectedWorkloadGroup] = useState<string>('');
-
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
 
   const [autoRefreshEnabled, setAutoRefreshEnabled] = useState(true);
   const [refreshInterval, setRefreshInterval] = useState(DEFAULT_REFRESH_INTERVAL);
@@ -73,34 +76,21 @@ export const InflightQueries = ({
     return `${loc[1]} ${loc[2]}, ${loc[3]} @ ${date.toLocaleTimeString('en-US')}`;
   };
 
-  useEffect(() => {
-    const fetchStats = async () => {
-      try {
-        const response = await fetch('/oeg/api/_wlm/stats');
-        const data = await response.json();
-        // Assuming data format: { workloads: [{ group_id: 'group1' }, ...] }
-        const groups = data.workloads?.map((w: any) => w.group_id) || [];
-        setWorkloadGroups(groups);
-        if (groups.length && !selectedWorkloadGroup) {
-          setSelectedWorkloadGroup(groups[0]);
-        }
-      } catch (error) {
-        console.error('Failed to fetch workload stats', error);
-      }
-    };
-    fetchStats();
-  }, []);
-
   const fetchliveQueries = async () => {
-    const retrievedQueries = await retrieveLiveQueries(core, dataSource?.id);
-
+    const wlmGroup = searchParams.get('wlm_group');
+    let retrievedQueries;
+    if (wlmGroup) {
+      retrievedQueries = await retrieveLiveQueriesWithWLMGroup(core, dataSource?.id, wlmGroup);
+    } else {
+      retrievedQueries = await retrieveLiveQueries(core, dataSource?.id);
+    }
     if (retrievedQueries?.response?.live_queries) {
       const tempNodeCount: Record<string, number> = {};
       const indexCount: Record<string, number> = {};
       const parsedQueries = retrievedQueries.response.live_queries.map((q) => {
         const indexMatch = q.description?.match(/indices\[(.*?)\]/);
         const searchTypeMatch = q.description?.match(/search_type\[(.*?)\]/);
-        let wlmGroup =
+        const newWlmGroup =
           typeof q.query_group_id === 'string' && q.query_group_id.trim() !== ''
             ? q.query_group_id
             : 'N/A';
@@ -110,7 +100,7 @@ export const InflightQueries = ({
           search_type: searchTypeMatch ? searchTypeMatch[1] : 'N/A',
           coordinator_node: q.node_id,
           node_label: q.node_id,
-          wlm_group: wlmGroup,
+          wlm_group: newWlmGroup,
         };
       });
 
@@ -289,7 +279,6 @@ export const InflightQueries = ({
       totalLatency += latency;
       totalCPU += cpu;
       totalMemory += memory;
-
       if (latency > longestLatency) {
         longestLatency = latency;
         longestQueryId = q.id;
@@ -316,7 +305,6 @@ export const InflightQueries = ({
     }));
   };
 
-
   return (
     <div>
       <QueryInsightsDataSourceMenu
@@ -334,25 +322,6 @@ export const InflightQueries = ({
       />
       <EuiSpacer size="m" />
       <EuiFlexGroup alignItems="center" gutterSize="s" justifyContent="flexEnd">
-        <EuiFlexItem grow={false}>
-          <EuiText size="s">
-            <strong>Workload Group</strong>
-          </EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <select
-            value={selectedWorkloadGroup}
-            onChange={(e) => setSelectedWorkloadGroup(e.target.value)}
-            style={{ padding: '6px', borderRadius: '6px', minWidth: 150 }}
-            data-test-subj="live-queries-workload-group-selector"
-          >
-            {workloadGroups.map((groupId) => (
-              <option key={groupId} value={groupId}>
-                {groupId}
-              </option>
-            ))}
-          </select>
-        </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiSwitch
             label="Auto-refresh"

--- a/public/pages/InflightQueries/InflightQueries.tsx
+++ b/public/pages/InflightQueries/InflightQueries.tsx
@@ -17,6 +17,7 @@ import {
   EuiSpacer,
   EuiInMemoryTable,
   EuiButton,
+  EuiLink
 } from '@elastic/eui';
 import {
   RadialChart,
@@ -50,13 +51,16 @@ export const InflightQueries = ({
   dataSourceManagement?: DataSourceManagementPluginSetup;
   depsStart: QueryInsightsDashboardsPluginStartDependencies;
 }) => {
-  const DEFAULT_REFRESH_INTERVAL = 5000; // default 5s
+  const DEFAULT_REFRESH_INTERVAL = 1000; // default 5s
   const TOP_N_DISPLAY_LIMIT = 9;
   const isFetching = useRef(false);
   const [query, setQuery] = useState<LiveSearchQueryResponse | null>(null);
   const { dataSource, setDataSource } = useContext(DataSourceContext)!;
   const [nodeCounts, setNodeCounts] = useState({});
   const [indexCounts, setIndexCounts] = useState({});
+  const [workloadGroups, setWorkloadGroups] = useState<string[]>([]);
+  const [selectedWorkloadGroup, setSelectedWorkloadGroup] = useState<string>('');
+
 
   const [autoRefreshEnabled, setAutoRefreshEnabled] = useState(true);
   const [refreshInterval, setRefreshInterval] = useState(DEFAULT_REFRESH_INTERVAL);
@@ -69,6 +73,24 @@ export const InflightQueries = ({
     return `${loc[1]} ${loc[2]}, ${loc[3]} @ ${date.toLocaleTimeString('en-US')}`;
   };
 
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const response = await fetch('/oeg/api/_wlm/stats');
+        const data = await response.json();
+        // Assuming data format: { workloads: [{ group_id: 'group1' }, ...] }
+        const groups = data.workloads?.map((w: any) => w.group_id) || [];
+        setWorkloadGroups(groups);
+        if (groups.length && !selectedWorkloadGroup) {
+          setSelectedWorkloadGroup(groups[0]);
+        }
+      } catch (error) {
+        console.error('Failed to fetch workload stats', error);
+      }
+    };
+    fetchStats();
+  }, []);
+
   const fetchliveQueries = async () => {
     const retrievedQueries = await retrieveLiveQueries(core, dataSource?.id);
 
@@ -78,12 +100,17 @@ export const InflightQueries = ({
       const parsedQueries = retrievedQueries.response.live_queries.map((q) => {
         const indexMatch = q.description?.match(/indices\[(.*?)\]/);
         const searchTypeMatch = q.description?.match(/search_type\[(.*?)\]/);
+        let wlmGroup =
+          typeof q.query_group_id === 'string' && q.query_group_id.trim() !== ''
+            ? q.query_group_id
+            : 'N/A';
         return {
           ...q,
           index: indexMatch ? indexMatch[1] : 'N/A',
           search_type: searchTypeMatch ? searchTypeMatch[1] : 'N/A',
           coordinator_node: q.node_id,
           node_label: q.node_id,
+          wlm_group: wlmGroup,
         };
       });
 
@@ -289,6 +316,7 @@ export const InflightQueries = ({
     }));
   };
 
+
   return (
     <div>
       <QueryInsightsDataSourceMenu
@@ -306,6 +334,25 @@ export const InflightQueries = ({
       />
       <EuiSpacer size="m" />
       <EuiFlexGroup alignItems="center" gutterSize="s" justifyContent="flexEnd">
+        <EuiFlexItem grow={false}>
+          <EuiText size="s">
+            <strong>Workload Group</strong>
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <select
+            value={selectedWorkloadGroup}
+            onChange={(e) => setSelectedWorkloadGroup(e.target.value)}
+            style={{ padding: '6px', borderRadius: '6px', minWidth: 150 }}
+            data-test-subj="live-queries-workload-group-selector"
+          >
+            {workloadGroups.map((groupId) => (
+              <option key={groupId} value={groupId}>
+                {groupId}
+              </option>
+            ))}
+          </select>
+        </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiSwitch
             label="Auto-refresh"
@@ -683,6 +730,25 @@ export const InflightQueries = ({
                   <EuiText color="success">
                     <b>Running</b>
                   </EuiText>
+                ),
+            },
+            {
+              name: 'WLM Group',
+              render: (item: any) =>
+                item.wlm_group && item.wlm_group !== 'N/A' ? (
+                  <EuiLink
+                    onClick={() => {
+                      core.application.navigateToApp('workloadManagement', {
+                        path: `#/wlm-details?name=${item.wlm_group}`,
+                      });
+                    }}
+                    style={{ fontWeight: 'bold' }}
+                    color="primary"
+                  >
+                    {item.wlm_group}
+                  </EuiLink>
+                ) : (
+                  'N/A'
                 ),
             },
 

--- a/public/pages/WorkloadManagement/WLMMain/WLMMain.tsx
+++ b/public/pages/WorkloadManagement/WLMMain/WLMMain.tsx
@@ -526,17 +526,19 @@ export const WorkloadManagementMain = ({
       render: (val: number) => val.toLocaleString(),
     },
     {
-      field: 'topQueriesLink',
-      name: <EuiText size="m">Top N Queries</EuiText>,
-      render: (link: string) => (
-        <a
-          href={link}
+      field: 'liveQueriesLink',
+      name: <EuiText size="m">Live Queries</EuiText>,
+      render: (link: string, item: WorkloadGroupData) => (
+        <EuiLink
+          onClick={() => {
+            core.application.navigateToApp('query-insights-dashboards', {
+              path: `#/LiveQueries?wlm_group=${item.groupId}`,
+            });
+          }}
           style={{ color: '#0073e6', display: 'flex', alignItems: 'center', gap: '5px' }}
-          target="_blank"
-          rel="noopener noreferrer"
         >
           View <EuiIcon type="popout" size="s" />
-        </a>
+        </EuiLink>
       ),
     },
   ];

--- a/server/clusters/queryInsightsPlugin.ts
+++ b/server/clusters/queryInsightsPlugin.ts
@@ -175,6 +175,16 @@ export const QueryInsightsPlugin = function (Client, config, components) {
     method: 'GET',
   });
 
+  queryInsights.getLiveQueriesWLMGroup = ca({
+    url: {
+      fmt: `/_insights/live_queries?wlm_group=<%=wlm_group%>`,
+      req: {
+        wlm_group: { type: 'string', required: true },
+      },
+    },
+    method: 'GET',
+  });
+
   queryInsights.cancelTask = ca({
     url: {
       fmt: `/_tasks/<%=taskId%>/_cancel`,

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -362,13 +362,13 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
       validate: {
         query: schema.object({
           dataSourceId: schema.maybe(schema.string()),
-          wlmGroup: schema.maybe(schema.string()),
+          wlm_group: schema.maybe(schema.string()),
         }),
       },
     },
     async (context, request, response) => {
       try {
-        const { dataSourceId, wlmGroup } = request.query;
+        const { dataSourceId, wlm_group } = request.query;
 
         const client =
           !dataSourceEnabled || !dataSourceId
@@ -376,8 +376,8 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
             : context.dataSource.opensearch.legacy.getClient(dataSourceId);
 
         // Call the appropriate API based on whether wlm_group is provided
-        const res = wlmGroup
-          ? await client('queryInsights.getLiveQueriesWLMGroup', { wlmGroup })
+        const res = wlm_group
+          ? await client('queryInsights.getLiveQueriesWLMGroup', { wlm_group })
           : await client('queryInsights.getLiveQueries');
 
         if (!res || res.ok === false) {

--- a/types/types.ts
+++ b/types/types.ts
@@ -78,6 +78,7 @@ export interface LiveSearchQueryRecord {
   };
   node_id: string;
   is_cancelled: boolean;
+  query_group_id: string;
 }
 
 export interface LiveSearchQueryResponse {


### PR DESCRIPTION
### Description

This PR implements frontend changes to enable bi-directional navigation between the Workload Management (WLM) and Query Insights (QI) dashboards. Users will be able to navigate from QI Live Queries to WLM Group Details and vice versa, allowing for a more targeted and efficient analysis of workload-specific query behavior.

Changes:

### From QI Live Queries → WLM Group Details:

- Added a "WLM Group" column to the Live Queries dashboard.
- The item in WLM Group column in the Live Queries table becomes clickable.

<img width="1728" height="958" alt="Screenshot 2025-07-23 at 11 11 33 AM (1)" src="https://github.com/user-attachments/assets/01cde792-dc8b-416a-8195-bad72c7fbe10" />



- Clicking the WLM Group name will navigate the user to the corresponding WLM Group Details page.
- Enable each group name in the "WLM Group" column to be a clickable link that navigates to the WLM Group Details page with the selected wlm_group as a query parameter.

<img width="1728" height="1039" alt="Screenshot 2025-08-01 at 3 56 22 AM" src="https://github.com/user-attachments/assets/ed21a1e6-9825-4406-b644-6fb01cc5fab5" />




### From WLM Main Page → QI Live Queries:

- Clicking on a specific WLM group on the WLM Main page will filter the Query Insights Live Queries view to show only the queries for that specific workload group.

<img width="1680" height="863" alt="Screenshot 2025-08-01 at 4 25 38 AM" src="https://github.com/user-attachments/assets/1eed3dd0-90be-4e1e-899c-38736df880e1" />

<img width="1541" height="926" alt="Screenshot 2025-08-01 at 4 27 10 AM" src="https://github.com/user-attachments/assets/1dcd93ca-ff32-449f-850d-a6cfb0c6cfb3" />


This improves the flow of analysis, allowing users to drill down into specific workload groups from both the WLM Group Details page and the Live Queries dashboard.


### Issues Resolved
Closes [#153] 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
