### PR TITLE
[manual backport] fetch only once if the first call returns a valid query

### DIFF
--- a/common/utils/QueryUtils.ts
+++ b/common/utils/QueryUtils.ts
@@ -45,13 +45,20 @@ export const retrieveQueryById = async (
   };
 
   try {
-    const topQueriesResponse = await Promise.any([
-      fetchMetric(`/api/top_queries/latency`),
-      fetchMetric(`/api/top_queries/cpu`),
-      fetchMetric(`/api/top_queries/memory`),
-    ]);
-    const records = topQueriesResponse.response.top_queries || [];
-    return records.find((q) => q.id === id) || null;
+    const endpoints = [
+      `/api/top_queries/latency`,
+      `/api/top_queries/cpu`,
+      `/api/top_queries/memory`,
+    ];
+
+    for (const endpoint of endpoints) {
+      const result = await fetchMetric(endpoint);
+      if (result.response.top_queries.length > 0) {
+        const records = result.response.top_queries || [];
+        return records.find((q) => q.id === id) || null;
+      }
+    }
+    return null;
   } catch (error) {
     console.error('Error retrieving query details:', error);
     return null;


### PR DESCRIPTION
(cherry picked from commit b00c4b4bafdc7c5a8fb68288b83bbb408c7131c1)

### Description
Manual backport https://github.com/opensearch-project/query-insights-dashboards/pull/182

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
