### PR TITLE
Bug fix for filter and date picker [2.19]

### DIFF
--- a/cypress/e2e/1_top_queries.cy.js
+++ b/cypress/e2e/1_top_queries.cy.js
@@ -6,16 +6,10 @@
 import sampleDocument from '../fixtures/sample_document.json';
 import { METRICS } from '../support/constants';
 
-// Stub payloads (static imports so they exist at module load)
 import MIXED from '../fixtures/stub_top_queries.json';
 import QUERY_ONLY from '../fixtures/stub_top_queries_query_only.json';
 import GROUP_ONLY from '../fixtures/stub_top_queries_group_only.json';
 
-/* ============================================================================
-   Shared helpers (define ONCE)
-============================================================================ */
-
-// timestamp-only rewrite so rows land in current picker window
 const makeTimestampedBody = (raw) => {
   const body = JSON.parse(JSON.stringify(raw));
   const list = body?.response?.top_queries ?? body?.top_queries ?? [];
@@ -65,12 +59,8 @@ const expectSortedBy = (label, colIdx) => {
   });
 };
 
-// ==== Canonical filter helpers (single source of truth) ====
-
-// Normalize strings for matching
 const norm = (s) => (s || '').replace(/\s+/g, ' ').trim().toLowerCase();
 
-// Find a filter button by any of several label candidates, checking text + a11y attrs
 const findFilterButton = (labels) => {
   const candidates = (Array.isArray(labels) ? labels : [labels]).map(norm);
 
@@ -128,11 +118,10 @@ const setListFilter = (buttonLabels, values = []) => {
       .scrollIntoView()
       .click();
   });
-  cy.get('body').click(0, 0); // close popover
+  cy.get('body').click(0, 0);
   cy.wait(300);
 };
 
-// ---- Specific wrappers (do NOT duplicate these elsewhere) ----
 const setNodeIdFilter = (nodeIds = []) => setListFilter(['Coordinator Node ID'], nodeIds);
 const setSearchTypeFilter = (types = []) => setListFilter(['Search Type'], types);
 const setIndicesFilter = (indices = []) => setListFilter(['Indices'], indices);
@@ -171,7 +160,6 @@ const resetTypeFilterToNone = () => {
   cy.wait(300);
 };
 
-// -------- Utility to derive expectations (readable names) --------
 const deriveExpectations = (payload, type = 'all') => {
   const allRows = getRowsFromRaw(payload);
 
@@ -215,6 +203,11 @@ const deriveExpectations = (payload, type = 'all') => {
 
 const indexName = 'sample_index';
 
+/**
+ Helper function to clean up the environment:
+ - Deletes the test index.
+ - Disables the top queries features.
+ */
 const clearAll = () => {
   cy.deleteIndexByName(indexName);
   cy.disableTopQueries(METRICS.LATENCY);
@@ -224,6 +217,7 @@ const clearAll = () => {
 };
 
 describe('Query Insights Dashboard', () => {
+  // Setup before each test
   beforeEach(() => {
     clearAll();
     cy.createIndexByName(indexName, sampleDocument);
@@ -231,51 +225,75 @@ describe('Query Insights Dashboard', () => {
     cy.enableTopQueries(METRICS.CPU);
     cy.enableTopQueries(METRICS.MEMORY);
     cy.searchOnIndex(indexName);
+    // wait for 1s to avoid same timestamp
     cy.wait(1000);
     cy.searchOnIndex(indexName);
     cy.wait(1000);
     cy.searchOnIndex(indexName);
+    // waiting for the query insights queue to drain
     cy.wait(10000);
     cy.waitForQueryInsightsPlugin();
   });
 
+  /**
+   * Validate the main overview page loads correctly
+   */
   it('should display the main overview page', () => {
+    // Verify the page title is visible (already loaded by waitForQueryInsightsPlugin)
     cy.contains('Query insights - Top N queries').should('be.visible');
+
+    // Verify the URL is correct
     cy.url().should('include', '/queryInsights');
+
+    // Verify the table is visible and has content
     cy.get('.euiBasicTable').should('be.visible');
     cy.get('.euiTableHeaderCell').should('have.length.greaterThan', 0);
+
+    // Verify there are query rows in the table
     cy.get('.euiTableRow').should('have.length.greaterThan', 0);
   });
 
+  /**
+   * Validate sorting by the "Timestamp" column works correctly
+   */
   it('should sort the table by the Timestamp column', () => {
+    // waiting for the query insights queue to drain
     cy.wait(10000);
     cy.navigateToOverview();
+    // Click the Timestamp column header to sort
     cy.get('.euiTableHeaderCell').contains('Timestamp').click();
+    // eslint-disable-next-line jest/valid-expect-in-promise
     cy.get('.euiTableRow')
       .first()
       .invoke('text')
       .then((firstRowAfterSort) => {
         const firstTimestamp = firstRowAfterSort.trim();
         cy.get('.euiTableHeaderCell').contains('Timestamp').click();
+        // eslint-disable-next-line jest/valid-expect-in-promise
         cy.get('.euiTableRow')
           .first()
           .invoke('text')
-          .then((second) => {
-            expect(second.trim()).to.not.equal(firstTimestamp);
+          .then((firstRowAfterSecondSort) => {
+            expect(firstRowAfterSecondSort.trim()).to.not.equal(firstTimestamp);
           });
       });
   });
 
   it('should switch between tabs', () => {
+    // Click Configuration tab
     cy.getElementByText('.euiTab', 'Configuration').click({ force: true });
     cy.contains('Query insights - Configuration');
     cy.url().should('include', '/configuration');
+
+    // Click back to Query Insights tab
     cy.getElementByText('.euiTab', 'Top N queries').click({ force: true });
     cy.url().should('include', '/queryInsights');
   });
 
   it('should filter queries', () => {
-    cy.get('.euiFieldSearch').should('be.visible').type('sample_index');
+    cy.get('.euiFieldSearch').should('be.visible');
+    cy.get('.euiFieldSearch').type('sample_index');
+    // Add assertions for filtered results
     cy.get('.euiTableRow').should('have.length.greaterThan', 0);
   });
 
@@ -294,11 +312,14 @@ describe('Query Insights Dashboard', () => {
   });
 
   it('should paginate the query table', () => {
-    for (let i = 0; i < 20; i++) cy.searchOnIndex(indexName);
+    for (let i = 0; i < 20; i++) {
+      cy.searchOnIndex(indexName);
+    }
     cy.wait(10000);
     cy.reload();
     cy.get('.euiPagination').should('be.visible');
     cy.get('.euiPagination__item').contains('2').click();
+    // Verify rows on the second page
     cy.get('.euiTableRow').should('have.length.greaterThan', 0);
   });
 
@@ -310,20 +331,23 @@ describe('Query Insights Dashboard', () => {
       .request({
         method: 'GET',
         url: `/api/top_queries/latency`,
-        qs: { from, to, verbose: false },
+        qs: {
+          from: from,
+          to: to,
+          verbose: false,
+        },
       })
       .then((response) => {
         expect(response.status).to.eq(200);
         expect(response.body).to.have.property('ok', true);
 
         const responseData = response.body.response;
-        expect(responseData)
-          .to.have.property('top_queries')
-          .that.is.an('array')
-          .with.length.greaterThan(0);
+        expect(responseData).to.have.property('top_queries');
+        expect(responseData.top_queries).to.be.an('array');
+        expect(responseData.top_queries.length).to.be.greaterThan(0);
 
         const firstQuery = responseData.top_queries[0];
-        const required = [
+        const requiredFields = [
           'group_by',
           'id',
           'indices',
@@ -334,9 +358,9 @@ describe('Query Insights Dashboard', () => {
           'timestamp',
           'total_shards',
         ];
-        expect(firstQuery).to.include.all.keys(required);
 
-        const types = {
+        expect(firstQuery).to.include.all.keys(requiredFields);
+        const typeValidations = {
           group_by: 'string',
           id: 'string',
           indices: 'array',
@@ -347,15 +371,16 @@ describe('Query Insights Dashboard', () => {
           timestamp: 'number',
           total_shards: 'number',
         };
-        Object.entries(types).forEach(([k, t]) =>
-          expect(firstQuery[k]).to.be.a(t, `${k} should be a ${t}`)
-        );
-
+        Object.entries(typeValidations).forEach(([field, type]) => {
+          expect(firstQuery[field]).to.be.a(type, `${field} should be a ${type}`);
+        });
         expect(firstQuery.measurements).to.have.all.keys(['cpu', 'latency', 'memory']);
-        ['cpu', 'latency', 'memory'].forEach((m) =>
-          expect(firstQuery.measurements[m]).to.be.an('object')
-        );
+        ['cpu', 'latency', 'memory'].forEach((metric) => {
+          expect(firstQuery.measurements[metric]).to.be.an('object');
+        });
       });
+
+    after(() => clearAll());
   });
 });
 

--- a/cypress/e2e/1_top_queries.cy.js
+++ b/cypress/e2e/1_top_queries.cy.js
@@ -6,14 +6,215 @@
 import sampleDocument from '../fixtures/sample_document.json';
 import { METRICS } from '../support/constants';
 
-// Name of the test index used in tests
+// Stub payloads (static imports so they exist at module load)
+import MIXED from '../fixtures/stub_top_queries.json';
+import QUERY_ONLY from '../fixtures/stub_top_queries_query_only.json';
+import GROUP_ONLY from '../fixtures/stub_top_queries_group_only.json';
+
+/* ============================================================================
+   Shared helpers (define ONCE)
+============================================================================ */
+
+// timestamp-only rewrite so rows land in current picker window
+const makeTimestampedBody = (raw) => {
+  const body = JSON.parse(JSON.stringify(raw));
+  const list = body?.response?.top_queries ?? body?.top_queries ?? [];
+  const now = Date.now();
+  body.response = body.response || {};
+  body.response.top_queries = list.map((q, i) => ({ ...q, timestamp: now - i * 1000 }));
+  return body;
+};
+
+const getRowsFromRaw = (raw) => (raw?.response?.top_queries ?? raw?.top_queries ?? []).slice();
+
+const assertRowCountEquals = (expected) => {
+  cy.get('.euiTableRow').should('have.length', expected);
+};
+
+const getHeaders = () =>
+  cy.get('.euiTableHeaderCell').then(($h) =>
+    $h
+      .map((_, el) => Cypress.$(el).text().trim())
+      .get()
+      .filter(Boolean)
+  );
+
+const expectSortedBy = (label, colIdx) => {
+  const extract = ($rows) =>
+    [...$rows].map(($r) => {
+      const txt = Cypress.$($r).find('td').eq(colIdx).text().trim();
+      if (/ms|s|B|KB|MB|GB|TB/i.test(txt)) return parseFloat(txt.replace(/[^\d.]/g, '')) || 0;
+      const ms = Date.parse(txt);
+      if (!Number.isNaN(ms)) return ms;
+      const num = parseFloat(txt.replace(/[^\d.-]/g, ''));
+      return Number.isNaN(num) ? 0 : num;
+    });
+
+  cy.get('.euiTableHeaderCell').contains(label).click();
+  cy.get('.euiTableRow').then(($r) => {
+    const v = extract($r);
+    const asc = [...v].sort((a, b) => a - b);
+    expect(v, `${label} asc`).to.deep.equal(asc);
+  });
+
+  cy.get('.euiTableHeaderCell').contains(label).click();
+  cy.get('.euiTableRow').then(($r) => {
+    const v = extract($r);
+    const desc = [...v].sort((a, b) => b - a);
+    expect(v, `${label} desc`).to.deep.equal(desc);
+  });
+};
+
+// ==== Canonical filter helpers (single source of truth) ====
+
+// Normalize strings for matching
+const norm = (s) => (s || '').replace(/\s+/g, ' ').trim().toLowerCase();
+
+// Find a filter button by any of several label candidates, checking text + a11y attrs
+const findFilterButton = (labels) => {
+  const candidates = (Array.isArray(labels) ? labels : [labels]).map(norm);
+
+  return cy.get('button.euiFilterButton').then(($btns) => {
+    const found = [...$btns].find((btn) => {
+      const txt = norm(btn.innerText);
+      const aria = norm(btn.getAttribute('aria-label'));
+      const title = norm(btn.getAttribute('title'));
+      const subj = norm(btn.getAttribute('data-test-subj'));
+      return candidates.some(
+        (lab) =>
+          txt.includes(lab) || aria.includes(lab) || title.includes(lab) || subj.includes(lab)
+      );
+    });
+
+    if (!found) {
+      const dump = [...$btns]
+        .map(
+          (el) =>
+            norm(el.innerText) ||
+            norm(el.getAttribute('aria-label')) ||
+            norm(el.getAttribute('title')) ||
+            norm(el.getAttribute('data-test-subj'))
+        )
+        .join(' | ');
+      throw new Error(
+        `Filter button not found. Tried [${candidates.join(', ')}]. Buttons seen: ${dump}`
+      );
+    }
+
+    return cy.wrap(found);
+  });
+};
+
+const openFilter = (labels) => {
+  findFilterButton(labels).scrollIntoView().click();
+  cy.get('.euiFilterSelectItem', { timeout: 10000 }).should('exist');
+};
+
+const clearAllOpenFilterOptions = () => {
+  cy.get('.euiFilterSelectItem').each(($item) => {
+    const isOn = $item.find('svg[data-euiicon-type="check"]').length > 0;
+    if (isOn) cy.wrap($item).click();
+  });
+};
+
+const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const setListFilter = (buttonLabels, values = []) => {
+  openFilter(buttonLabels);
+  clearAllOpenFilterOptions();
+  values.forEach((label) => {
+    const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    cy.contains('.euiFilterSelectItem', new RegExp(`^${esc(label)}$`, 'i'))
+      .scrollIntoView()
+      .click();
+  });
+  cy.get('body').click(0, 0); // close popover
+  cy.wait(300);
+};
+
+// ---- Specific wrappers (do NOT duplicate these elsewhere) ----
+const setNodeIdFilter = (nodeIds = []) => setListFilter(['Coordinator Node ID'], nodeIds);
+const setSearchTypeFilter = (types = []) => setListFilter(['Search Type'], types);
+const setIndicesFilter = (indices = []) => setListFilter(['Indices'], indices);
+
+const setTypeFilter = (mode /* 'query' | 'group' | 'both' */) => {
+  cy.contains('button', /^Type\b/).click();
+  const ensureToggle = (label, on) => {
+    cy.contains('.euiFilterSelectItem', new RegExp(`^${esc(label)}$`, 'i')).then(($item) => {
+      const isOn = $item.find('svg[data-euiicon-type="check"]').length > 0;
+      if (isOn !== on) cy.wrap($item).click();
+    });
+  };
+  if (mode === 'query') {
+    ensureToggle('query', true);
+    ensureToggle('group', false);
+  } else if (mode === 'group') {
+    ensureToggle('query', false);
+    ensureToggle('group', true);
+  } else {
+    ensureToggle('query', true);
+    ensureToggle('group', true);
+  }
+  cy.get('body').click(0, 0);
+  cy.wait(300);
+};
+
+const resetTypeFilterToNone = () => {
+  cy.contains('button', /^Type\b/).click();
+  ['query', 'group'].forEach((label) => {
+    cy.contains('.euiFilterSelectItem', new RegExp(`^${esc(label)}$`, 'i')).then(($item) => {
+      const isOn = $item.find('svg[data-euiicon-type="check"]').length > 0;
+      if (isOn) cy.wrap($item).click();
+    });
+  });
+  cy.get('body').click(0, 0);
+  cy.wait(300);
+};
+
+// -------- Utility to derive expectations (readable names) --------
+const deriveExpectations = (payload, type = 'all') => {
+  const allRows = getRowsFromRaw(payload);
+
+  let rows = allRows;
+  if (type === 'query') {
+    rows = allRows.filter((r) => String(r.group_by).toUpperCase() === 'NONE');
+  } else if (type === 'group') {
+    rows = allRows.filter((r) => String(r.group_by).toUpperCase() !== 'NONE');
+  }
+
+  const uniq = (arr) => [...new Set(arr)];
+  const countBy = (items, keyFn) =>
+    items.reduce((acc, item) => {
+      const k = keyFn(item);
+      if (Array.isArray(k)) {
+        k.filter(Boolean).forEach((kk) => {
+          acc[kk] = (acc[kk] || 0) + 1;
+        });
+      } else if (k) {
+        acc[k] = (acc[k] || 0) + 1;
+      }
+      return acc;
+    }, {});
+
+  const nodeIds = uniq(rows.map((r) => r.node_id).filter(Boolean));
+  const indexNames = uniq(rows.flatMap((r) => r.indices || []).filter(Boolean));
+  const searchTypes = uniq(rows.map((r) => r.search_type).filter(Boolean));
+
+  return {
+    appliedType: type,
+    rows,
+    totalRowCount: rows.length,
+    nodeIds,
+    nodeIdCounts: countBy(rows, (r) => r.node_id),
+    indexNames,
+    indexCounts: countBy(rows, (r) => r.indices || []),
+    searchTypes,
+    searchTypeCounts: countBy(rows, (r) => r.search_type),
+  };
+};
+
 const indexName = 'sample_index';
 
-/**
- Helper function to clean up the environment:
- - Deletes the test index.
- - Disables the top queries features.
- */
 const clearAll = () => {
   cy.deleteIndexByName(indexName);
   cy.disableTopQueries(METRICS.LATENCY);
@@ -23,7 +224,6 @@ const clearAll = () => {
 };
 
 describe('Query Insights Dashboard', () => {
-  // Setup before each test
   beforeEach(() => {
     clearAll();
     cy.createIndexByName(indexName, sampleDocument);
@@ -31,75 +231,51 @@ describe('Query Insights Dashboard', () => {
     cy.enableTopQueries(METRICS.CPU);
     cy.enableTopQueries(METRICS.MEMORY);
     cy.searchOnIndex(indexName);
-    // wait for 1s to avoid same timestamp
     cy.wait(1000);
     cy.searchOnIndex(indexName);
     cy.wait(1000);
     cy.searchOnIndex(indexName);
-    // waiting for the query insights queue to drain
     cy.wait(10000);
     cy.waitForQueryInsightsPlugin();
   });
 
-  /**
-   * Validate the main overview page loads correctly
-   */
   it('should display the main overview page', () => {
-    // Verify the page title is visible (already loaded by waitForQueryInsightsPlugin)
     cy.contains('Query insights - Top N queries').should('be.visible');
-
-    // Verify the URL is correct
     cy.url().should('include', '/queryInsights');
-
-    // Verify the table is visible and has content
     cy.get('.euiBasicTable').should('be.visible');
     cy.get('.euiTableHeaderCell').should('have.length.greaterThan', 0);
-
-    // Verify there are query rows in the table
     cy.get('.euiTableRow').should('have.length.greaterThan', 0);
   });
 
-  /**
-   * Validate sorting by the "Timestamp" column works correctly
-   */
   it('should sort the table by the Timestamp column', () => {
-    // waiting for the query insights queue to drain
     cy.wait(10000);
     cy.navigateToOverview();
-    // Click the Timestamp column header to sort
     cy.get('.euiTableHeaderCell').contains('Timestamp').click();
-    // eslint-disable-next-line jest/valid-expect-in-promise
     cy.get('.euiTableRow')
       .first()
       .invoke('text')
       .then((firstRowAfterSort) => {
         const firstTimestamp = firstRowAfterSort.trim();
         cy.get('.euiTableHeaderCell').contains('Timestamp').click();
-        // eslint-disable-next-line jest/valid-expect-in-promise
         cy.get('.euiTableRow')
           .first()
           .invoke('text')
-          .then((firstRowAfterSecondSort) => {
-            expect(firstRowAfterSecondSort.trim()).to.not.equal(firstTimestamp);
+          .then((second) => {
+            expect(second.trim()).to.not.equal(firstTimestamp);
           });
       });
   });
 
   it('should switch between tabs', () => {
-    // Click Configuration tab
     cy.getElementByText('.euiTab', 'Configuration').click({ force: true });
     cy.contains('Query insights - Configuration');
     cy.url().should('include', '/configuration');
-
-    // Click back to Query Insights tab
     cy.getElementByText('.euiTab', 'Top N queries').click({ force: true });
     cy.url().should('include', '/queryInsights');
   });
 
   it('should filter queries', () => {
-    cy.get('.euiFieldSearch').should('be.visible');
-    cy.get('.euiFieldSearch').type('sample_index');
-    // Add assertions for filtered results
+    cy.get('.euiFieldSearch').should('be.visible').type('sample_index');
     cy.get('.euiTableRow').should('have.length.greaterThan', 0);
   });
 
@@ -118,14 +294,11 @@ describe('Query Insights Dashboard', () => {
   });
 
   it('should paginate the query table', () => {
-    for (let i = 0; i < 20; i++) {
-      cy.searchOnIndex(indexName);
-    }
+    for (let i = 0; i < 20; i++) cy.searchOnIndex(indexName);
     cy.wait(10000);
     cy.reload();
     cy.get('.euiPagination').should('be.visible');
     cy.get('.euiPagination__item').contains('2').click();
-    // Verify rows on the second page
     cy.get('.euiTableRow').should('have.length.greaterThan', 0);
   });
 
@@ -137,23 +310,20 @@ describe('Query Insights Dashboard', () => {
       .request({
         method: 'GET',
         url: `/api/top_queries/latency`,
-        qs: {
-          from: from,
-          to: to,
-          verbose: false,
-        },
+        qs: { from, to, verbose: false },
       })
       .then((response) => {
         expect(response.status).to.eq(200);
         expect(response.body).to.have.property('ok', true);
 
         const responseData = response.body.response;
-        expect(responseData).to.have.property('top_queries');
-        expect(responseData.top_queries).to.be.an('array');
-        expect(responseData.top_queries.length).to.be.greaterThan(0);
+        expect(responseData)
+          .to.have.property('top_queries')
+          .that.is.an('array')
+          .with.length.greaterThan(0);
 
         const firstQuery = responseData.top_queries[0];
-        const requiredFields = [
+        const required = [
           'group_by',
           'id',
           'indices',
@@ -164,9 +334,9 @@ describe('Query Insights Dashboard', () => {
           'timestamp',
           'total_shards',
         ];
+        expect(firstQuery).to.include.all.keys(required);
 
-        expect(firstQuery).to.include.all.keys(requiredFields);
-        const typeValidations = {
+        const types = {
           group_by: 'string',
           id: 'string',
           indices: 'array',
@@ -177,120 +347,34 @@ describe('Query Insights Dashboard', () => {
           timestamp: 'number',
           total_shards: 'number',
         };
-        Object.entries(typeValidations).forEach(([field, type]) => {
-          expect(firstQuery[field]).to.be.a(type, `${field} should be a ${type}`);
-        });
-        expect(firstQuery.measurements).to.have.all.keys(['cpu', 'latency', 'memory']);
-        ['cpu', 'latency', 'memory'].forEach((metric) => {
-          expect(firstQuery.measurements[metric]).to.be.an('object');
-        });
-      });
+        Object.entries(types).forEach(([k, t]) =>
+          expect(firstQuery[k]).to.be.a(t, `${k} should be a ${t}`)
+        );
 
-    after(() => clearAll());
+        expect(firstQuery.measurements).to.have.all.keys(['cpu', 'latency', 'memory']);
+        ['cpu', 'latency', 'memory'].forEach((m) =>
+          expect(firstQuery.measurements[m]).to.be.an('object')
+        );
+      });
   });
 });
 
-describe('Query Insights Dashboard - Dynamic Columns change with Intercepted Top Queries', () => {
+describe('Query Insights — Dynamic Columns with Intercepted Top Queries (MIXED)', () => {
+  const mixedRows = getRowsFromRaw(MIXED);
+  const totalRowCount = mixedRows.length;
+
   beforeEach(() => {
-    cy.fixture('stub_top_queries.json').then((stubResponse) => {
-      cy.intercept('GET', '**/api/top_queries/*', {
-        statusCode: 200,
-        body: stubResponse,
-      }).as('getTopQueries');
-    });
+    cy.intercept('GET', '**/api/top_queries/**', (req) => {
+      req.reply({ statusCode: 200, body: makeTimestampedBody(MIXED) });
+    }).as('topQueries');
 
     cy.waitForQueryInsightsPlugin();
-    cy.wait(2000);
-    cy.wait('@getTopQueries');
+    cy.wait('@topQueries');
   });
 
-  const testMetricSorting = (columnLabel, columnIndex) => {
-    cy.get('.euiTableHeaderCell').contains(columnLabel).click();
-    cy.wait(1000);
-
-    cy.get('.euiTableRow').then(($rows) => {
-      const values = [...$rows].map(($row) => {
-        const rawText = Cypress.$($row).find('td').eq(columnIndex).text().trim();
-        return parseFloat(rawText.replace(/[^\d.]/g, '')); // remove 'ms'/'B'
-      });
-      const sortedAsc = [...values].sort((a, b) => a - b);
-      expect(values).to.deep.equal(sortedAsc);
-    });
-
-    cy.get('.euiTableHeaderCell').contains(columnLabel).click();
-    cy.wait(1000);
-
-    cy.get('.euiTableRow').then(($rows) => {
-      const values = [...$rows].map(($row) => {
-        const rawText = Cypress.$($row).find('td').eq(columnIndex).text().trim();
-        return parseFloat(rawText.replace(/[^\d.]/g, ''));
-      });
-      const sortedDesc = [...values].sort((a, b) => b - a);
-      expect(values).to.deep.equal(sortedDesc);
-    });
-  };
-
-  it('should render only individual query-related headers when NONE filter is applied', () => {
-    cy.wait(1000);
-    cy.get('.euiFilterButton').contains('Type').click();
-    cy.get('.euiFilterSelectItem').contains('query').click();
-    cy.wait(1000);
-
-    const expectedHeaders = [
-      'Id',
-      'Type',
-      'Timestamp',
-      'Latency',
-      'CPU Time',
-      'Memory Usage',
-      'Indices',
-      'Search Type',
-      'Coordinator Node ID',
-      'Total Shards',
-    ];
-
-    cy.get('.euiTableHeaderCell').should('have.length', expectedHeaders.length);
-
-    cy.get('.euiTableHeaderCell').should(($headers) => {
-      const actualHeaders = $headers.map((index, el) => Cypress.$(el).text().trim()).get();
-      expect(actualHeaders).to.deep.equal(expectedHeaders);
-    });
-    testMetricSorting('Timestamp', 2);
-    testMetricSorting('Latency', 3);
-    testMetricSorting('CPU Time', 4);
-    testMetricSorting('Memory Usage', 5);
-  });
-
-  it('should render only group-related headers in the correct order when SIMILARITY filter is applied', () => {
-    cy.get('.euiFilterButton').contains('Type').click();
-    cy.get('.euiFilterSelectItem').contains('group').click();
-    cy.wait(1000);
-
-    const expectedHeaders = [
-      'Id',
-      'Type',
-      'Query Count',
-      'Average Latency',
-      'Average CPU Time',
-      'Average Memory Usage',
-    ];
-
-    cy.get('.euiTableHeaderCell').should(($headers) => {
-      const actualHeaders = $headers.map((index, el) => Cypress.$(el).text().trim()).get();
-      expect(actualHeaders).to.deep.equal(expectedHeaders);
-    });
-    testMetricSorting('Query Count', 2);
-    testMetricSorting('Average Latency', 3);
-    testMetricSorting('Average CPU Time', 4);
-    testMetricSorting('Average Memory Usage', 5);
-  });
-  it('should display both query and group data with proper headers when both are selected', () => {
-    cy.get('.euiFilterButton').contains('Type').click();
-    cy.get('.euiFilterSelectItem').contains('query').click();
-    cy.get('.euiFilterSelectItem').contains('group').click();
-    cy.wait(1000);
-
-    const expectedGroupHeaders = [
+  it('renders combined headers when Nothing is selected in type', () => {
+    resetTypeFilterToNone();
+    const expected = [
       'Id',
       'Type',
       'Query Count',
@@ -303,14 +387,219 @@ describe('Query Insights Dashboard - Dynamic Columns change with Intercepted Top
       'Coordinator Node ID',
       'Total Shards',
     ];
-    cy.get('.euiTableHeaderCell').should(($headers) => {
-      const actualHeaders = $headers.map((index, el) => Cypress.$(el).text().trim()).get();
-      expect(actualHeaders).to.deep.equal(expectedGroupHeaders);
-    });
-    testMetricSorting('Query Count', 2);
-    testMetricSorting('Timestamp', 3);
-    testMetricSorting('Avg Latency / Latency', 4);
-    testMetricSorting('Avg CPU Time / CPU Time', 5);
-    testMetricSorting('Avg Memory Usage / Memory Usage', 6);
+    getHeaders().should('deep.equal', expected);
+    assertRowCountEquals(totalRowCount);
+    expectSortedBy('Query Count', 2);
+    expectSortedBy('Avg Latency / Latency', 4);
+    expectSortedBy('Avg CPU Time / CPU Time', 5);
+    expectSortedBy('Avg Memory Usage / Memory Usage', 6);
+  });
+
+  it('renders query-only headers when Type=query', () => {
+    setTypeFilter('query');
+    const expected = [
+      'Id',
+      'Type',
+      'Timestamp',
+      'Latency',
+      'CPU Time',
+      'Memory Usage',
+      'Indices',
+      'Search Type',
+      'Coordinator Node ID',
+      'Total Shards',
+    ];
+    getHeaders().should('deep.equal', expected);
+
+    const queryOnlyCount = mixedRows.filter((r) => String(r.group_by).toUpperCase() === 'NONE')
+      .length;
+    assertRowCountEquals(queryOnlyCount);
+
+    expectSortedBy('Timestamp', 2);
+    expectSortedBy('Latency', 3);
+    expectSortedBy('CPU Time', 4);
+    expectSortedBy('Memory Usage', 5);
+  });
+
+  it('renders group-only headers when Type=group', () => {
+    setTypeFilter('group');
+    const expected = [
+      'Id',
+      'Type',
+      'Query Count',
+      'Average Latency',
+      'Average CPU Time',
+      'Average Memory Usage',
+    ];
+    getHeaders().should('deep.equal', expected);
+
+    const groupOnlyCount = mixedRows.filter((r) => String(r.group_by).toUpperCase() !== 'NONE')
+      .length;
+    assertRowCountEquals(groupOnlyCount);
+
+    expectSortedBy('Query Count', 2);
+    expectSortedBy('Average Latency', 3);
+    expectSortedBy('Average CPU Time', 4);
+    expectSortedBy('Average Memory Usage', 5);
+  });
+
+  it('renders combined headers when Type=both', () => {
+    setTypeFilter('both');
+    const expected = [
+      'Id',
+      'Type',
+      'Query Count',
+      'Timestamp',
+      'Avg Latency / Latency',
+      'Avg CPU Time / CPU Time',
+      'Avg Memory Usage / Memory Usage',
+      'Indices',
+      'Search Type',
+      'Coordinator Node ID',
+      'Total Shards',
+    ];
+    getHeaders().should('deep.equal', expected);
+    assertRowCountEquals(totalRowCount);
+
+    expectSortedBy('Query Count', 2);
+    expectSortedBy('Avg Latency / Latency', 4);
+    expectSortedBy('Avg CPU Time / CPU Time', 5);
+    expectSortedBy('Avg Memory Usage / Memory Usage', 6);
+  });
+});
+
+// ---- QUERY ONLY fixture (no Type toggle)
+describe('Query Insights — Dynamic Columns (QUERY ONLY fixture)', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/top_queries/**', (req) => {
+      req.reply({ statusCode: 200, body: makeTimestampedBody(QUERY_ONLY) });
+    }).as('topQueries');
+
+    cy.waitForQueryInsightsPlugin();
+    cy.wait('@topQueries');
+  });
+
+  it('renders only query headers (without changing Type filter)', () => {
+    const expected = [
+      'Id',
+      'Type',
+      'Timestamp',
+      'Latency',
+      'CPU Time',
+      'Memory Usage',
+      'Indices',
+      'Search Type',
+      'Coordinator Node ID',
+      'Total Shards',
+    ];
+    getHeaders().should('deep.equal', expected);
+    assertRowCountEquals(getRowsFromRaw(QUERY_ONLY).length);
+  });
+});
+
+// ---- GROUP ONLY fixture (no Type toggle)
+describe('Query Insights — Dynamic Columns (GROUP ONLY fixture)', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/top_queries/**', (req) => {
+      req.reply({ statusCode: 200, body: makeTimestampedBody(GROUP_ONLY) });
+    }).as('topQueries');
+
+    cy.waitForQueryInsightsPlugin();
+    cy.wait('@topQueries');
+  });
+
+  it('renders only group headers (without changing Type filter)', () => {
+    const expected = [
+      'Id',
+      'Type',
+      'Query Count',
+      'Average Latency',
+      'Average CPU Time',
+      'Average Memory Usage',
+    ];
+    getHeaders().should('deep.equal', expected);
+    assertRowCountEquals(getRowsFromRaw(GROUP_ONLY).length);
+  });
+});
+
+describe('Query Insights — Filters: Node ID, Search Type, Indices (QUERY_ONLY, no Type toggle)', () => {
+  let expected;
+  let expectingAll;
+  let primaryNodeId;
+  let secondaryNodeId;
+  let primaryIndexName;
+  let secondaryIndexName;
+  let defaultSearchType;
+
+  before(() => {
+    // derive expectations from query-only payload
+    expected = deriveExpectations(MIXED, 'query');
+    expectingAll = deriveExpectations(MIXED);
+    [primaryNodeId, secondaryNodeId] = expected.nodeIds;
+    [primaryIndexName, secondaryIndexName] = expected.indexNames;
+    [defaultSearchType] = expected.searchTypes;
+  });
+
+  beforeEach(() => {
+    // intercept with ONLY query rows, plus fresh timestamps
+    cy.intercept('GET', '**/api/top_queries/**', (req) => {
+      req.reply({ statusCode: 200, body: makeTimestampedBody(MIXED) });
+    }).as('topQueries');
+
+    cy.waitForQueryInsightsPlugin();
+    cy.wait('@topQueries');
+  });
+
+  it('filters by Node ID', () => {
+    if (primaryNodeId) {
+      setNodeIdFilter([primaryNodeId]);
+      assertRowCountEquals(expected.nodeIdCounts[primaryNodeId]);
+      cy.get('.euiTableRow').each(($r) => cy.wrap($r).contains('td', primaryNodeId));
+    }
+    setNodeIdFilter([primaryNodeId]); // clear
+
+    if (secondaryNodeId) {
+      setNodeIdFilter([secondaryNodeId]);
+      assertRowCountEquals(expected.nodeIdCounts[secondaryNodeId]);
+      cy.get('.euiTableRow').each(($r) => cy.wrap($r).contains('td', secondaryNodeId));
+    }
+    setNodeIdFilter([secondaryNodeId]); // clear
+    assertRowCountEquals(expectingAll.totalRowCount);
+  });
+
+  it('filters by Search Type', () => {
+    if (defaultSearchType) {
+      setSearchTypeFilter([defaultSearchType]);
+      assertRowCountEquals(expected.searchTypeCounts[defaultSearchType]);
+      cy.get('.euiTableRow').each(($r) => cy.wrap($r).contains('td', 'query then fetch'));
+    }
+    setSearchTypeFilter([defaultSearchType]);
+
+    assertRowCountEquals(expectingAll.totalRowCount);
+  });
+
+  it('filters by Indices', () => {
+    if (primaryIndexName) {
+      setIndicesFilter([primaryIndexName]);
+      assertRowCountEquals(expected.indexCounts[primaryIndexName]);
+      cy.get('.euiTableRow').each(($r) => cy.wrap($r).contains('td', primaryIndexName));
+    }
+    setIndicesFilter([primaryIndexName]);
+
+    if (secondaryIndexName) {
+      setIndicesFilter([secondaryIndexName]);
+      assertRowCountEquals(expected.indexCounts[secondaryIndexName]);
+      cy.get('.euiTableRow').each(($r) => cy.wrap($r).contains('td', secondaryIndexName));
+    }
+    setIndicesFilter([secondaryIndexName]);
+
+    const both = [primaryIndexName, secondaryIndexName].filter(Boolean);
+    if (both.length > 1) {
+      setIndicesFilter(both);
+      assertRowCountEquals(expected.totalRowCount);
+    }
+
+    setIndicesFilter([]); // clear
+    assertRowCountEquals(expected.totalRowCount);
   });
 });

--- a/cypress/fixtures/stub_top_queries_group_only.json
+++ b/cypress/fixtures/stub_top_queries_group_only.json
@@ -3,23 +3,6 @@
   "response": {
     "top_queries": [
       {
-        "timestamp": 1713934974000,
-        "id": "a2e1c822-3e3c-4d1b-adb2-258e04f96f78",
-        "search_type": "query_then_fetch",
-        "indices": [".kibana"],
-        "node_id": "UYKFun8PSAeJvkkt9cWf0w",
-        "group_by": "NONE",
-        "total_shards": 1,
-        "labels": {
-          "X-Opaque-Id": "90eb5c3b-8448-4af3-84ce-a941eee9ed5f"
-        },
-        "measurements": {
-          "cpu": { "number": 1340000, "count": 1, "aggregationType": "NONE" },
-          "latency": { "number": 22, "count": 1, "aggregationType": "NONE" },
-          "memory": { "number": 204800, "count": 1, "aggregationType": "NONE" }
-        }
-      },
-      {
         "timestamp": 1713934989000,
         "id": "130a5d36-615e-43e8-ad99-e1b90d527f44",
         "search_type": "query_then_fetch",
@@ -36,45 +19,11 @@
         }
       },
       {
-        "timestamp": 1713935004000,
-        "id": "a2e1c822-3e3c-4d1b-adb2-9f73af094b43",
-        "search_type": "query_then_fetch",
-        "indices": ["my-index"],
-        "node_id": "UYKFun8PSAeJvkkt9cWf0w",
-        "group_by": "NONE",
-        "total_shards": 1,
-        "labels": {
-          "X-Opaque-Id": "90eb5c3b-8448-4af3-84ce-a941eee9ed5f"
-        },
-        "measurements": {
-          "memory": { "number": 170320, "count": 1, "aggregationType": "NONE" },
-          "cpu": { "number": 2100000, "count": 1, "aggregationType": "NONE" },
-          "latency": { "number": 13, "count": 1, "aggregationType": "NONE" }
-        }
-      },
-      {
-        "timestamp": 1713935019000,
-        "id": "7cd4c7f1-3803-4c5e-a41c-258e04f96f78",
-        "search_type": "query_then_fetch",
-        "indices": [".kibana"],
-        "node_id": "KINGun8PSAeJvkkt9cWf0w",
-        "group_by": "NONE",
-        "total_shards": 1,
-        "labels": {
-          "X-Opaque-Id": "8a936346-8d19-409c-9fe6-8b890eca1f7c"
-        },
-        "measurements": {
-          "cpu": { "number": 990000, "count": 1, "aggregationType": "NONE" },
-          "latency": { "number": 18, "count": 1, "aggregationType": "NONE" },
-          "memory": { "number": 81200, "count": 1, "aggregationType": "NONE" }
-        }
-      },
-      {
         "timestamp": 1713935033000,
         "id": "76f5e51f-33f6-480c-8b20-8003abb93d19",
         "search_type": "query_then_fetch",
         "indices": [".kibana"],
-        "node_id": "KINGun8PSAeJvkkt9cWf0w",
+        "node_id": "UYKFun8PSAeJvkkt9cWf0w",
         "group_by": "SIMILARITY",
         "total_shards": 1,
         "labels": {
@@ -92,7 +41,7 @@
         "id": "37d633a7-20e6-41a1-96e9-cd4806511dbf",
         "search_type": "query_then_fetch",
         "indices": [".kibana"],
-        "node_id": "KINGun8PSAeJvkkt9cWf0w",
+        "node_id": "UYKFun8PSAeJvkkt9cWf0w",
         "group_by": "SIMILARITY",
         "total_shards": 1,
         "labels": {},
@@ -100,7 +49,7 @@
         "measurements": {
           "memory": { "number": 640320, "count": 3, "aggregationType": "AVERAGE" },
           "cpu": { "number": 3190000, "count": 3, "aggregationType": "AVERAGE" },
-          "latency": { "number": 6, "count": 1, "aggregationType": "NONE" }
+          "latency": { "number": 6, "count": 1, "aggregationType": "AVERAGE" }
         }
       },
       {
@@ -108,7 +57,7 @@
         "id": "9982b7fc-0339-47d8-b77f-8de1bda76b72",
         "search_type": "query_then_fetch",
         "indices": [".kibana"],
-        "node_id": "KINGun8PSAeJvkkt9cWf0w",
+        "node_id": "UYKFun8PSAeJvkkt9cWf0w",
         "group_by": "SIMILARITY",
         "total_shards": 1,
         "labels": {},
@@ -124,7 +73,7 @@
         "id": "d8dccf54-8dcb-4411-9fd6-977844be8fb3",
         "search_type": "query_then_fetch",
         "indices": [".kibana"],
-        "node_id": "KINGun8PSAeJvkkt9cWf0w",
+        "node_id": "UYKFun8PSAeJvkkt9cWf0w",
         "group_by": "SIMILARITY",
         "total_shards": 1,
         "labels": {},
@@ -132,7 +81,7 @@
         "measurements": {
           "memory": { "number": 59000, "count": 1, "aggregationType": "AVERAGE" },
           "cpu": { "number": 1720000, "count": 1, "aggregationType": "AVERAGE" },
-          "latency": { "number": 11, "count": 1, "aggregationType": "NONE" }
+          "latency": { "number": 11, "count": 1, "aggregationType": "AVERAGE" }
         }
       }
     ]

--- a/cypress/fixtures/stub_top_queries_query_only.json
+++ b/cypress/fixtures/stub_top_queries_query_only.json
@@ -1,0 +1,58 @@
+{
+  "ok": true,
+  "response": {
+    "top_queries": [
+      {
+        "timestamp": 1713934974000,
+        "id": "a2e1c822-3e3c-4d1b-adb2-258e04f96f78",
+        "search_type": "query_then_fetch",
+        "indices": ["my-index"],
+        "node_id": "UYKFun8PSAeJvkkt9cWf0w",
+        "group_by": "NONE",
+        "total_shards": 1,
+        "labels": {
+          "X-Opaque-Id": "90eb5c3b-8448-4af3-84ce-a941eee9ed5f"
+        },
+        "measurements": {
+          "cpu": { "number": 1340000, "count": 1, "aggregationType": "NONE" },
+          "latency": { "number": 22, "count": 1, "aggregationType": "NONE" },
+          "memory": { "number": 204800, "count": 1, "aggregationType": "NONE" }
+        }
+      },
+      {
+        "timestamp": 1713935004000,
+        "id": "a2e1c822-3e3c-4d1b-adb2-9f73af094b43",
+        "search_type": "query_then_fetch",
+        "indices": ["my-index"],
+        "node_id": "UYKFun8PSAeJvkkt9cWf0w",
+        "group_by": "NONE",
+        "total_shards": 1,
+        "labels": {
+          "X-Opaque-Id": "90eb5c3b-8448-4af3-84ce-a941eee9ed5f"
+        },
+        "measurements": {
+          "memory": { "number": 170320, "count": 1, "aggregationType": "NONE" },
+          "cpu": { "number": 2100000, "count": 1, "aggregationType": "NONE" },
+          "latency": { "number": 13, "count": 1, "aggregationType": "NONE" }
+        }
+      },
+      {
+        "timestamp": 1713935019000,
+        "id": "7cd4c7f1-3803-4c5e-a41c-258e04f96f78",
+        "search_type": "query_then_fetch",
+        "indices": ["my-index"],
+        "node_id": "UYKFun8PSAeJvkkt9cWf0w",
+        "group_by": "NONE",
+        "total_shards": 1,
+        "labels": {
+          "X-Opaque-Id": "8a936346-8d19-409c-9fe6-8b890eca1f7c"
+        },
+        "measurements": {
+          "cpu": { "number": 990000, "count": 1, "aggregationType": "NONE" },
+          "latency": { "number": 18, "count": 1, "aggregationType": "NONE" },
+          "memory": { "number": 81200, "count": 1, "aggregationType": "NONE" }
+        }
+      }
+    ]
+  }
+}

--- a/public/components/__snapshots__/app.test.tsx.snap
+++ b/public/components/__snapshots__/app.test.tsx.snap
@@ -343,7 +343,7 @@ exports[`<QueryInsightsDashboardsApp /> spec renders the component 1`] = `
                       class="euiSuperDatePicker__prettyFormat"
                       data-test-subj="superDatePickerShowDatesButton"
                     >
-                      Last 1 hour
+                      Last hour
                       <span
                         class="euiSuperDatePicker__prettyFormatLink"
                       >

--- a/public/pages/QueryInsights/QueryInsights.test.tsx
+++ b/public/pages/QueryInsights/QueryInsights.test.tsx
@@ -127,12 +127,12 @@ describe('QueryInsights Component', () => {
     ]);
   });
 
-  it('triggers onTimeChange when the date picker refresh is changes', () => {
+  it('triggers onTimeChange when the date picker changes', () => {
     renderQueryInsights();
 
     const updateButton = screen.getByRole('button', { name: /Refresh/i });
     fireEvent.click(updateButton);
-    
+
     expect(mockOnTimeChange).toHaveBeenCalled();
   });
 
@@ -151,7 +151,6 @@ describe('QueryInsights Component', () => {
         group_by: 'NONE',
       },
     ];
-
     expect(() => {
       render(
         <MemoryRouter>
@@ -164,6 +163,7 @@ describe('QueryInsights Component', () => {
               currStart="now-15m"
               currEnd="now"
               retrieveQueries={mockRetrieveQueries}
+              // @ts-ignore
               core={mockCore}
               depsStart={{} as any}
               params={{} as any}
@@ -174,17 +174,18 @@ describe('QueryInsights Component', () => {
       );
     }).not.toThrow();
 
+    // Verify that the table component renders successfully
     expect(screen.getByRole('table')).toBeInTheDocument();
   });
 
   it('renders the expected column headers for default (mixed) view', async () => {
     renderQueryInsights();
+
     await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
 
     const headers = await waitFor(() => screen.getAllByRole('columnheader', { hidden: false }));
-    const texts = headers.map((h) => h.textContent?.trim());
-
-    expect(texts).toEqual([
+    const headerTexts = headers.map((h) => h.textContent?.trim());
+    const expectedHeaders = [
       'Id',
       'Type',
       'Query Count',
@@ -196,7 +197,9 @@ describe('QueryInsights Component', () => {
       'Search Type',
       'Coordinator Node ID',
       'Total Shards',
-    ]);
+    ];
+
+    expect(headerTexts).toEqual(expectedHeaders);
   });
 
   it('renders correct columns when SIMILARITY filter (group-only) is applied', async () => {
@@ -206,15 +209,16 @@ describe('QueryInsights Component', () => {
 
     const headers = await screen.findAllByRole('columnheader', { hidden: true });
     const headerTexts = headers.map((h) => h.textContent?.trim());
-
-    expect(headerTexts).toEqual([
+    const expectedHeaders = [
       'Id',
       'Type',
       'Query Count',
       'Average Latency',
       'Average CPU Time',
       'Average Memory Usage',
-    ]);
+    ];
+
+    expect(headerTexts).toEqual(expectedHeaders);
   });
 
   it('renders only query-related headers when NONE filter (query-only) is applied', async () => {
@@ -224,8 +228,7 @@ describe('QueryInsights Component', () => {
 
     const headers = await screen.findAllByRole('columnheader', { hidden: true });
     const headerTexts = headers.map((h) => h.textContent?.trim());
-
-    expect(headerTexts).toEqual([
+    const expectedHeaders = [
       'Id',
       'Type',
       'Timestamp',
@@ -236,7 +239,9 @@ describe('QueryInsights Component', () => {
       'Search Type',
       'Coordinator Node ID',
       'Total Shards',
-    ]);
+    ];
+
+    expect(headerTexts).toEqual(expectedHeaders);
   });
 
   it('renders mixed headers when both NONE and SIMILARITY filters are applied', async () => {
@@ -247,8 +252,7 @@ describe('QueryInsights Component', () => {
 
     const headers = await screen.findAllByRole('columnheader', { hidden: true });
     const headerTexts = headers.map((h) => h.textContent?.trim());
-
-    expect(headerTexts).toEqual([
+    const expectedHeaders = [
       'Id',
       'Type',
       'Query Count',
@@ -260,6 +264,8 @@ describe('QueryInsights Component', () => {
       'Search Type',
       'Coordinator Node ID',
       'Total Shards',
-    ]);
+    ];
+
+    expect(headerTexts).toEqual(expectedHeaders);
   });
 });

--- a/public/pages/QueryInsights/QueryInsights.test.tsx
+++ b/public/pages/QueryInsights/QueryInsights.test.tsx
@@ -11,16 +11,22 @@ import { MemoryRouter } from 'react-router-dom';
 import stubTopQueries from '../../../cypress/fixtures/stub_top_queries.json';
 import { DataSourceContext } from '../TopNQueries/TopNQueries';
 
+// Mock functions and data
 const sampleQueries = (stubTopQueries as any).response.top_queries;
 
 const mockOnTimeChange = jest.fn();
 const mockCore = {
-  chrome: { setBreadcrumbs: jest.fn() },
+  chrome: {
+    setBreadcrumbs: jest.fn(),
+  },
 } as any;
 
 const dataSourceMenuMock = jest.fn(() => <div>Mock DataSourceMenu</div>);
+
 const dataSourceManagementMock = {
-  ui: { getDataSourceMenu: jest.fn().mockReturnValue(dataSourceMenuMock) },
+  ui: {
+    getDataSourceMenu: jest.fn().mockReturnValue(dataSourceMenuMock),
+  },
 } as any;
 
 const mockDataSourceContext = {
@@ -42,6 +48,7 @@ const renderQueryInsights = () =>
           currStart="now-15m"
           currEnd="now"
           retrieveQueries={mockRetrieveQueries}
+          // @ts-ignore
           core={mockCore}
           depsStart={{} as any}
           params={{} as any}
@@ -104,7 +111,7 @@ describe('QueryInsights Component', () => {
     jest.clearAllMocks();
   });
 
-  it('renders the table with the correct columns and data (snapshot)', () => {
+  it('renders the table with the correct columns and data', () => {
     const { container } = renderQueryInsights();
     expect(container).toMatchSnapshot();
   });
@@ -112,16 +119,20 @@ describe('QueryInsights Component', () => {
   it('calls setBreadcrumbs on mount', () => {
     renderQueryInsights();
     expect(mockCore.chrome.setBreadcrumbs).toHaveBeenCalledWith([
-      { text: 'Query insights', href: '/queryInsights', onClick: expect.any(Function) },
+      {
+        text: 'Query insights',
+        href: '/queryInsights',
+        onClick: expect.any(Function),
+      },
     ]);
   });
 
-  it('triggers onTimeChange when the date picker refresh is clicked', () => {
+  it('triggers onTimeChange when the date picker refresh is changes', () => {
     renderQueryInsights();
-    const btn =
-      screen.queryByRole('button', { name: /refresh/i }) ||
-      screen.getByRole('button', { name: /update/i });
-    fireEvent.click(btn!);
+
+    const updateButton = screen.getByRole('button', { name: /Refresh/i });
+    fireEvent.click(updateButton);
+    
     expect(mockOnTimeChange).toHaveBeenCalled();
   });
 

--- a/public/pages/QueryInsights/__snapshots__/QueryInsights.test.tsx.snap
+++ b/public/pages/QueryInsights/__snapshots__/QueryInsights.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`QueryInsights Component renders the table with the correct columns and data 1`] = `
+exports[`QueryInsights Component renders the table with the correct columns and data (snapshot) 1`] = `
 <div>
   <div>
     <div
@@ -705,22 +705,1615 @@ exports[`QueryInsights Component renders the table with the correct columns and 
               class="euiTableRow"
             >
               <td
-                class="euiTableRowCell euiTableRowCell--isMobileFullWidth"
-                colspan="11"
+                class="euiTableRowCell"
               >
                 <div
-                  class="euiTableCellContent euiTableCellContent--alignCenter"
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Id
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
                 >
                   <span
-                    class="euiTableCellContent__text"
+                    class=""
                   >
-                    No items found
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      a2e1c822-3e3c-4d1b-adb2-258e04f96f78
+                    </button>
                   </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Type
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      query
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Query Count
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  1
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Timestamp
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      Jan 13, 2025 @ 12:00:00 AM
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg Latency / Latency
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  22.00 ms
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg CPU Time / CPU Time
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  1.34 ms
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg Memory Usage / Memory Usage
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  204800.00 B
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Indices
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  .kibana
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Search Type
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  query then fetch
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Coordinator Node ID
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  UYKFun8PSAeJvkkt9cWf0w
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Total Shards
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  1
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="euiTableRow"
+            >
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Id
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      130a5d36-615e-43e8-ad99-e1b90d527f44
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Type
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      group
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Query Count
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  1
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Timestamp
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      -
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg Latency / Latency
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  10.00 ms
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg CPU Time / CPU Time
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  1.78 ms
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg Memory Usage / Memory Usage
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  58000.00 B
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Indices
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  -
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Search Type
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  -
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Coordinator Node ID
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  -
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Total Shards
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  -
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="euiTableRow"
+            >
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Id
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      a2e1c822-3e3c-4d1b-adb2-9f73af094b43
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Type
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      query
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Query Count
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  1
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Timestamp
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      Jan 13, 2025 @ 12:00:00 AM
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg Latency / Latency
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  13.00 ms
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg CPU Time / CPU Time
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  2.10 ms
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg Memory Usage / Memory Usage
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  170320.00 B
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Indices
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  my-index
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Search Type
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  query then fetch
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Coordinator Node ID
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  UYKFun8PSAeJvkkt9cWf0w
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Total Shards
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  1
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="euiTableRow"
+            >
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Id
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      7cd4c7f1-3803-4c5e-a41c-258e04f96f78
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Type
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      query
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Query Count
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  1
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Timestamp
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      Jan 13, 2025 @ 12:00:00 AM
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg Latency / Latency
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  18.00 ms
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg CPU Time / CPU Time
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  0.99 ms
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg Memory Usage / Memory Usage
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  81200.00 B
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Indices
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  .kibana
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Search Type
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  query then fetch
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Coordinator Node ID
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  KINGun8PSAeJvkkt9cWf0w
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Total Shards
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  1
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="euiTableRow"
+            >
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Id
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      76f5e51f-33f6-480c-8b20-8003abb93d19
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Type
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      group
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Query Count
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  1
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Timestamp
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      -
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg Latency / Latency
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  9.00 ms
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg CPU Time / CPU Time
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  0.99 ms
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg Memory Usage / Memory Usage
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  133600.00 B
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Indices
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  -
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Search Type
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  -
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Coordinator Node ID
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  -
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Total Shards
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  -
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="euiTableRow"
+            >
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Id
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      37d633a7-20e6-41a1-96e9-cd4806511dbf
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Type
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      group
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Query Count
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  1
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Timestamp
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      -
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg Latency / Latency
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  6.00 ms
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg CPU Time / CPU Time
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  1.06 ms
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg Memory Usage / Memory Usage
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  213440.00 B
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Indices
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  -
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Search Type
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  -
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Coordinator Node ID
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  -
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Total Shards
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  -
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="euiTableRow"
+            >
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Id
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      9982b7fc-0339-47d8-b77f-8de1bda76b72
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Type
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      group
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Query Count
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  4
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Timestamp
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      -
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg Latency / Latency
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  1.00 ms
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg CPU Time / CPU Time
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  0.57 ms
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg Memory Usage / Memory Usage
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  203100.00 B
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Indices
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  -
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Search Type
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  -
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Coordinator Node ID
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  -
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Total Shards
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  -
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="euiTableRow"
+            >
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Id
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      d8dccf54-8dcb-4411-9fd6-977844be8fb3
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Type
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      group
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Query Count
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  1
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Timestamp
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  <span
+                    class=""
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      -
+                    </button>
+                  </span>
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg Latency / Latency
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  11.00 ms
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg CPU Time / CPU Time
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  1.72 ms
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Avg Memory Usage / Memory Usage
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  59000.00 B
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Indices
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  -
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Search Type
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  -
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Coordinator Node ID
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  -
+                </div>
+              </td>
+              <td
+                class="euiTableRowCell"
+              >
+                <div
+                  class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                >
+                  Total Shards
+                </div>
+                <div
+                  class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
+                >
+                  -
                 </div>
               </td>
             </tr>
           </tbody>
         </table>
+      </div>
+      <div>
+        <div
+          class="euiSpacer euiSpacer--m"
+        />
+        <div
+          class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+        >
+          <div
+            class="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <div
+              class="euiPopover euiPopover--anchorUpRight"
+            >
+              <div
+                class="euiPopover__anchor"
+              >
+                <button
+                  class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                  data-test-subj="tablePaginationPopoverButton"
+                  type="button"
+                >
+                  <span
+                    class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiButtonContent__icon"
+                      focusable="false"
+                      height="16"
+                      role="img"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                      />
+                    </svg>
+                    <span
+                      class="euiButtonEmpty__text"
+                    >
+                      Rows per page
+                      : 
+                      10
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <nav
+              class="euiPagination"
+            >
+              <button
+                aria-label="Previous page"
+                class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                data-test-subj="pagination-button-previous"
+                disabled=""
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                  />
+                </svg>
+              </button>
+              <ul
+                class="euiPagination__list"
+              >
+                <li
+                  class="euiPagination__item"
+                >
+                  <button
+                    aria-controls="random_html_id"
+                    aria-current="true"
+                    aria-label="Page 1 of 1"
+                    class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                    data-test-subj="pagination-button-0"
+                    disabled=""
+                    type="button"
+                  >
+                    <span
+                      class="euiButtonContent euiButtonEmpty__content"
+                    >
+                      <span
+                        class="euiButtonEmpty__text"
+                      >
+                        1
+                      </span>
+                    </span>
+                  </button>
+                </li>
+              </ul>
+              <button
+                aria-label="Next page"
+                class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                data-test-subj="pagination-button-next"
+                disabled=""
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                  />
+                </svg>
+              </button>
+            </nav>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/public/pages/QueryInsights/__snapshots__/QueryInsights.test.tsx.snap
+++ b/public/pages/QueryInsights/__snapshots__/QueryInsights.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`QueryInsights Component renders the table with the correct columns and data (snapshot) 1`] = `
+exports[`QueryInsights Component renders the table with the correct columns and data 1`] = `
 <div>
   <div>
     <div


### PR DESCRIPTION
### Description

This PR fixes four bugs on the Top N queries page that affected filtering, metrics display, and time range selection. The fixes ensure users get consistent, accurate results when applying filters and date ranges.

Bugs:

1. Indices filter didn’t filter the table.

<img width="1728" height="957" alt="Screenshot 2025-08-27 at 2 16 04 PM" src="https://github.com/user-attachments/assets/2e8bc0d0-be69-4404-b2c1-b005f159b40d" />

2. Query Count was shown for non-grouped (individual) queries.
3. Metric headers didn’t update correctly when toggling/deselecting grouping mode.

<img width="1728" height="957" alt="Screenshot 2025-08-27 at 2 16 38 PM" src="https://github.com/user-attachments/assets/929a519c-05d6-4948-9e28-e35ad6203098" />

4. Date picker didn’t work for relative ranges (Today, Yesterday, Last week, Last month, Last year).

<img width="1728" height="957" alt="Screenshot 2025-08-27 at 2 17 12 PM" src="https://github.com/user-attachments/assets/cf17f0dc-8448-4902-bf8f-bf8eb6aa1a54" />


After fix

<img width="1725" height="1035" alt="Screenshot 2025-08-25 at 12 16 26 AM" src="https://github.com/user-attachments/assets/48a064f0-3543-4f52-9875-8cd9257f054a" />


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
