### PR TITLE
[FIX] explicitly match query by id and fix q scope in retrieveQueryById

### DIFF
--- a/common/utils/QueryUtils.test.ts
+++ b/common/utils/QueryUtils.test.ts
@@ -106,4 +106,49 @@ describe('retrieveQueryById - Fetch Query Record by ID from API', () => {
     expect(result).toBeNull();
     expect(mockCore.http.get).toHaveBeenCalledTimes(3);
   });
+
+  it('should find query by id from records array', async () => {
+    const query1 = { ...mockQuery, id: '1111c38a-8eb8-436c-b825-ff97d75b8bd8' };
+    const query2 = { ...mockQuery, id: '2222c38a-8eb8-436c-b825-ff97d75b8bd8' };
+    const targetQuery = { ...mockQuery, id: '5073c38a-8eb8-436c-b825-ff97d75b8bd8' };
+    const query3 = { ...mockQuery, id: '3333c38a-8eb8-436c-b825-ff97d75b8bd8' };
+    const mockResponseWithTarget = {
+      response: {
+        top_queries: [query1, query2, targetQuery, query3],
+      },
+    };
+    mockCore.http.get.mockResolvedValue(mockResponseWithTarget);
+
+    const result = await retrieveQueryById(
+      mockCore,
+      undefined,
+      testStart,
+      testEnd,
+      '5073c38a-8eb8-436c-b825-ff97d75b8bd8'
+    );
+
+    expect(result).toEqual(targetQuery);
+  });
+
+  it('should return null when id not found in records', async () => {
+    const query1 = { ...mockQuery, id: '1111c38a-8eb8-436c-b825-ff97d75b8bd8' };
+    const query2 = { ...mockQuery, id: '2222c38a-8eb8-436c-b825-ff97d75b8bd8' };
+    const query3 = { ...mockQuery, id: '3333c38a-8eb8-436c-b825-ff97d75b8bd8' };
+    const mockResponseWithMultiple = {
+      response: {
+        top_queries: [query1, query2, query3],
+      },
+    };
+    mockCore.http.get.mockResolvedValue(mockResponseWithMultiple);
+
+    const result = await retrieveQueryById(
+      mockCore,
+      undefined,
+      testStart,
+      testEnd,
+      'a1a2a3a4-a5a6-7890-aaaa-aa1234567890'
+    );
+
+    expect(result).toBeNull();
+  });
 });

--- a/common/utils/QueryUtils.ts
+++ b/common/utils/QueryUtils.ts
@@ -64,7 +64,8 @@ export const retrieveQueryById = async (
     for (const endpoint of endpoints) {
       const result = await fetchMetric(endpoint);
       if (result.response.top_queries.length > 0) {
-        return result.response.top_queries[0];
+        const records = result.response.top_queries || [];
+        return records.find((q) => q.id === id) || null;
       }
     }
     return null;


### PR DESCRIPTION
### Description

Issue:

The function retrieveQueryById was designed to find a query record by its id from the API response. However:

It returned top_queries[0] blindly from the API response, assuming the first record already matched the requested id.
This could result in returning an incorrect record if the API response contained multiple records or did not filter properly.
Consequently, this sometimes directed the user to the wrong query detail page, since the incorrect record was returned.
Fix:

Explicitly filter the top_queries array for the record where q.id === id, ensuring the correct record is returned and the detail page shows the right data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
