### PR TITLE
Fix version mismatch in pipeline

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -111,36 +111,46 @@ jobs:
 
       - name: Decide target ref for OpenSearch
         shell: bash
+        working-directory: OpenSearch
         run: |
           set -euo pipefail
-          cd OpenSearch
 
-          # Read version from OpenSearch/build.gradle
-          if [[ -f build.gradle ]]; then
-            os_version="$(node -e "const fs=require('fs'); const s=fs.readFileSync('build.gradle','utf8'); const m=s.match(/opensearch_version\\s*=\\s*System\\.getProperty\\(['\"][^'\"]+['\"],\\s*['\"]([^'\"]+)['\"]\\)/); console.log(m?m[1]:'');")"
-          else
-            echo "build.gradle not found in OpenSearch repo"; os_version=""
+          os_version=""
+
+          # check version in buildSrc/version.properties
+          if [[ -f buildSrc/version.properties ]]; then
+            echo "Found buildSrc/version.properties; reading opensearch…"
+            os_version="$(awk -F'=' '
+              $1 ~ /^[[:space:]]*opensearch[[:space:]]*$/ {
+                v=$2; sub(/\r$/,"",v); gsub(/^[[:space:]]+|[[:space:]]+$/,"",v); print v; exit
+              }
+            ' buildSrc/version.properties || true)"
+            echo "version.properties opensearch: ${os_version:-<empty>}"
           fi
 
           if [[ -z "${os_version}" ]]; then
-            echo "Could not determine OpenSearch main repo version; defaulting to main."
+            echo "Could not determine OpenSearch repo version; defaulting to main."
             echo "TARGET_REF=main" >> "$GITHUB_ENV"
             exit 0
           fi
 
+          # Convert to major.minor (e.g., 3.4 from 3.4.0 or 3.4.0-SNAPSHOT)
           os_short="$(echo "$os_version" | sed -E 's/^([0-9]+)\.([0-9]+).*$/\1.\2/')"
+
           echo "OpenSearch repo version: ${os_version}"
           echo "OpenSearch repo short:   ${os_short}"
           echo "QI short (env):          ${QI_BRANCH}"
 
-          if [[ "$os_short" == "$QI_BRANCH" ]]; then
+          if [[ "$os_short" == "${QI_BRANCH}" ]]; then
             target="main"
           else
-            # If your repo uses a prefix like "release/2.19", set: target="release/${QI_BRANCH}"
+            # If your repo uses release branches like "release/3.4", use:
+            # target="release/${QI_BRANCH}"
             target="${QI_BRANCH}"
           fi
 
           echo "TARGET_REF=$target" >> "$GITHUB_ENV"
+          echo "Decided TARGET_REF=$target"
 
       - name: Switch OpenSearch to target ref (if needed)
         shell: bash


### PR DESCRIPTION
### Description
This PR fixes the version mismatch between the Query Insights (QI) and Workload Management (WLM) plugins in the build pipeline. The workflow now automatically determines the correct branch to check out for the OpenSearch repository:
- It extracts the QI version from the QI plugin’s build.gradle file.
- It checks out the main branch of the OpenSearch repo and extracts its version from buildSrc/version.properties.

The two versions are compared:
- If they match, the workflow continues on the main branch of the OpenSearch repo.
- If they differ, it switches to the branch corresponding to the same version as QI.

This ensures that both QI and WLM are built against consistent OpenSearch versions in the pipeline.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
