### PR TITLE
Add KishoreKicha14 to maintainers list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ansjcy @jainankitk @deshsidd @dzane17
+* @ansjcy @jainankitk @deshsidd @dzane17 @KishoreKicha14

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -14,6 +14,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Ankit Jain  | [jainankitk](https://github.com/jainankitk)                       | Amazon      |
 | Siddhant Deshmukh     | [deshsidd](https://github.com/deshsidd)                           | Amazon      |
 | David Zane         | [dzane17](https://github.com/dzane17)                 | Amazon      |
+| Kishore Kumaar Natarajan         | [KishoreKicha14](https://github.com/KishoreKicha14)                 | Amazon      |
 
 ## Emeritus
 


### PR DESCRIPTION
### Description
I’m proposing adding Kishore (@KishoreKicha14) to the maintainers list of query insights dashboards (https://github.com/opensearch-project/query-insights-dashboards).
 
Example contributions:
https://github.com/opensearch-project/query-insights-dashboards/pull/407
https://github.com/opensearch-project/query-insights-dashboards/pull/199
https://github.com/opensearch-project/query-insights-dashboards/pull/330
https://github.com/opensearch-project/query-insights-dashboards/pull/103

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
