### PR TITLE
[Fix] Jest test failures due to Monaco editor ES module imports

### DIFF
--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -14,11 +14,10 @@ module.exports = {
     '^ui/(.*)': '<rootDir>/../../src/legacy/ui/public/$1/',
     '^vega-embed$': '<rootDir>/test/mocks/vega-embed.ts',
     '^monaco-editor/esm/vs/editor/editor.api$': '<rootDir>/test/mocks/monaco-editor.ts',
+    '^monaco-editor$': '<rootDir>/test/mocks/monaco-editor.ts',
     '^@osd/monaco$': '<rootDir>/test/mocks/monaco-editor.ts',
   },
-  transformIgnorePatterns: [
-    'node_modules/(?!(monaco-editor)/)',
-  ],
+  transformIgnorePatterns: ['node_modules/(?!(monaco-editor)/)'],
   coverageReporters: ['lcov', 'text', 'cobertura'],
   testMatch: ['**/*.test.js', '**/*.test.jsx', '**/*.test.ts', '**/*.test.tsx'],
   collectCoverageFrom: [

--- a/test/mocks/monaco-editor.ts
+++ b/test/mocks/monaco-editor.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export const editor = {
   create: jest.fn(),
   createModel: jest.fn(),
@@ -15,5 +20,3 @@ export const monaco = {
   editor,
   languages,
 };
-
-export default monaco;


### PR DESCRIPTION
### Description

Plugin tests were failing with SyntaxError: Cannot use import statement outside a module when importing Monaco editor dependencies.

```
FAIL public/plugin.test.tsx
  ● Test suite failed to run

    Jest encountered an unexpected token

    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.

    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.

    By default "node_modules" folder is ignored by transformers.

    Here's what you can do:
     • If you are trying to use ECMAScript Modules, see https://jestjs.io/docs/ecmascript-modules for how to enable it.
     • If you are trying to use TypeScript, see https://jestjs.io/docs/getting-started#using-typescript
     • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.
     • If you need a custom transformation specify a "transform" option in your config.
     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.

    You'll find more details and examples of these config options in the docs:
    https://jestjs.io/docs/configuration
    For information about custom transformations, see:
    https://jestjs.io/docs/code-transformation

    Details:

    /home/runner/work/query-insights-dashboards/query-insights-dashboards/OpenSearch-Dashboards/node_modules/monaco-editor/esm/vs/editor/editor.api.js:5
    import { EditorOptions } from './common/config/editorOptions.js';
    ^^^^^^

    SyntaxError: Cannot use import statement outside a module

      32 |
      33 | // Import the monaco-editor package directly
    > 34 | import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
         | ^
      35 |
      36 | // Import CSS for Monaco editor icons
      37 | import 'monaco-editor/min/vs/editor/editor.main.css';

      at Runtime.createScriptFromCode (../../node_modules/jest-runtime/build/index.js:1728:14)
      at Object.<anonymous> (../../packages/osd-monaco/src/monaco.ts:34:1)
      at Object.<anonymous> (../../packages/osd-monaco/src/index.ts:31:1)
      at Object.<anonymous> (../../src/core/public/core_system.ts:32:1)
      at Object.<anonymous> (../../src/core/public/index.ts:110:1)
      at Object.<anonymous> (public/plugin.test.tsx:6:1)
```




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
