### PR TITLE
More reliable check on dashboards readiness in cypress test pipelines

### DIFF
--- a/.github/workflows/cypress-tests-qi-wlm-interaction.yml
+++ b/.github/workflows/cypress-tests-qi-wlm-interaction.yml
@@ -140,21 +140,81 @@ jobs:
           sleep 10
         shell: bash
 
-      - name: Wait for OpenSearch-Dashboards to be ready
+      - name: Wait for OpenSearch-Dashboards HTTP server to start
         run: |
-          echo "Waiting for OpenSearch-Dashboards to start..."
+          cd OpenSearch-Dashboards
+          echo "Waiting for OpenSearch-Dashboards HTTP server..."
           max_attempts=150
           attempt=0
           while [ $attempt -lt $max_attempts ]; do
             if curl -s -f http://localhost:5601/api/status > /dev/null 2>&1; then
-              echo "OpenSearch-Dashboards is ready!"
-              sleep 45
+              echo "HTTP server is responding"
               break
             fi
             attempt=$((attempt + 1))
-            echo "Attempt $attempt/$max_attempts: waiting 10 seconds..."
+            echo "Attempt $attempt/$max_attempts: waiting 10s..."
             sleep 10
           done
+          if [ $attempt -eq $max_attempts ]; then
+            echo "ERROR: HTTP server failed to start"
+            tail -n 100 dashboards.log
+            exit 1
+          fi
+        shell: bash
+
+      - name: Wait for UI bundles to compile and become ready
+        run: |
+          cd OpenSearch-Dashboards
+          echo "=========================================="
+          echo "Waiting for optimizer to compile bundles"
+          echo "This can take 5-10 minutes in CI"
+          echo "=========================================="
+
+          max_wait=600  # 10 minutes
+          elapsed=0
+          ui_ready=false
+
+          while [ $elapsed -lt $max_wait ]; do
+            # Monitor logs for optimizer completion message
+            # Pattern: "X bundle(s) compiled successfully after Y sec, watching for changes"
+            if grep -qE "[0-9]+ bundles? compiled successfully.*watching for changes" dashboards.log 2>/dev/null; then
+              latest_msg=$(grep -E "bundles? compiled successfully.*watching" dashboards.log | tail -1)
+              echo "Optimizer completed! $(echo "$latest_msg" | grep -oE '[0-9]+ bundles? compiled successfully.*watching for changes')"
+              ui_ready=true
+              break
+            fi
+
+            # Progress update every 30 seconds
+            if [ $((elapsed % 30)) -eq 0 ]; then
+              echo "[${elapsed}s/${max_wait}s] Waiting for bundle compilation..."
+
+              # Show recent optimizer activity if available
+              if tail -50 dashboards.log 2>/dev/null | grep -q "@osd/optimizer"; then
+                recent=$(tail -50 dashboards.log | grep "@osd/optimizer" | tail -1 | grep -oE '\[[0-9]+/[0-9]+\].*' || echo "compiling...")
+                echo "  Status: $recent"
+              fi
+            fi
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          if [ "$ui_ready" = false ]; then
+            echo ""
+            echo "WARNING: Bundle compilation not detected within ${max_wait}s"
+            echo "Continuing anyway - Cypress will handle timeouts if UI is not ready"
+            echo ""
+            echo "=== Last 200 lines of dashboards.log ==="
+            tail -n 200 dashboards.log
+            echo "=========================================="
+          else
+            # Extra wait for plugin initialization
+            echo "Waiting 20s for plugin initialization..."
+            sleep 20
+            echo "=========================================="
+            echo "OpenSearch-Dashboards is fully ready!"
+            echo "=========================================="
+          fi
         shell: bash
 
       - name: Install Cypress

--- a/.github/workflows/cypress-tests-wlm-no-security.yml
+++ b/.github/workflows/cypress-tests-wlm-no-security.yml
@@ -170,24 +170,80 @@ jobs:
           sleep 10
         shell: bash
 
-      - name: Wait for OpenSearch-Dashboards to be ready
+      - name: Wait for OpenSearch-Dashboards HTTP server to start
         run: |
-          echo "Waiting for OpenSearch-Dashboards to start..."
+          cd OpenSearch-Dashboards
+          echo "Waiting for OpenSearch-Dashboards HTTP server..."
           max_attempts=150
           attempt=0
           while [ $attempt -lt $max_attempts ]; do
             if curl -s -f http://localhost:5601/api/status > /dev/null 2>&1; then
-              echo "OpenSearch-Dashboards is ready!"
-              sleep 45
+              echo "✓ HTTP server is responding"
               break
             fi
             attempt=$((attempt + 1))
-            echo "Attempt $attempt/$max_attempts: OpenSearch-Dashboards not ready yet, waiting 10 seconds..."
+            echo "Attempt $attempt/$max_attempts: waiting 10s..."
             sleep 10
           done
           if [ $attempt -eq $max_attempts ]; then
-            echo "OpenSearch-Dashboards failed to start within timeout"
+            echo "ERROR: HTTP server failed to start"
+            tail -n 100 dashboards.log
             exit 1
+          fi
+        shell: bash
+
+      - name: Wait for UI bundles to compile and become ready
+        run: |
+          cd OpenSearch-Dashboards
+          echo "=========================================="
+          echo "Waiting for optimizer to compile bundles"
+          echo "This can take 5-10 minutes in CI"
+          echo "=========================================="
+
+          max_wait=600  # 10 minutes
+          elapsed=0
+          ui_ready=false
+
+          while [ $elapsed -lt $max_wait ]; do
+            # Monitor logs for optimizer completion message
+            # Pattern: "X bundle(s) compiled successfully after Y sec, watching for changes"
+            if grep -qE "[0-9]+ bundles? compiled successfully.*watching for changes" dashboards.log 2>/dev/null; then
+              latest_msg=$(grep -E "bundles? compiled successfully.*watching" dashboards.log | tail -1)
+              echo "Optimizer completed! $(echo "$latest_msg" | grep -oE '[0-9]+ bundles? compiled successfully.*watching for changes')"
+              ui_ready=true
+              break
+            fi
+
+            # Progress update every 30 seconds
+            if [ $((elapsed % 30)) -eq 0 ]; then
+              echo "[${elapsed}s/${max_wait}s] Waiting for bundle compilation..."
+
+              # Show recent optimizer activity if available
+              if tail -50 dashboards.log 2>/dev/null | grep -q "@osd/optimizer"; then
+                recent=$(tail -50 dashboards.log | grep "@osd/optimizer" | tail -1 | grep -oE '\[[0-9]+/[0-9]+\].*' || echo "compiling...")
+                echo "  Status: $recent"
+              fi
+            fi
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          if [ "$ui_ready" = false ]; then
+            echo ""
+            echo "WARNING: Bundle compilation not detected within ${max_wait}s"
+            echo "Continuing anyway - Cypress will handle timeouts if UI is not ready"
+            echo ""
+            echo "=== Last 200 lines of dashboards.log ==="
+            tail -n 200 dashboards.log
+            echo "=========================================="
+          else
+            # Extra wait for plugin initialization
+            echo "Waiting 20s for plugin initialization..."
+            sleep 20
+            echo "=========================================="
+            echo "OpenSearch-Dashboards is fully ready!"
+            echo "=========================================="
           fi
         shell: bash
 

--- a/.github/workflows/cypress-tests-wlm.yml
+++ b/.github/workflows/cypress-tests-wlm.yml
@@ -193,30 +193,83 @@ jobs:
           head -n 100 dashboards.log || true
         shell: bash
 
-      - name: Wait for OpenSearch-Dashboards to be ready
+      - name: Wait for OpenSearch-Dashboards HTTP server to start
         run: |
-          echo "Waiting for OpenSearch-Dashboards to start..."
-          max_attempts=180
+          cd OpenSearch-Dashboards
+          echo "Waiting for OpenSearch-Dashboards HTTP server..."
+          max_attempts=150
           attempt=0
           while [ $attempt -lt $max_attempts ]; do
-            code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:5601/api/status || true)
+            code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:5601/api/status || echo "000")
             if [ "$code" = "200" ]; then
-              state=$(curl -s http://localhost:5601/api/status | jq -r '.status.overall.state // .status.overall.level // "unknown"')
-              echo "OpenSearch-Dashboards is ready (state=$state)"
+              echo "HTTP server is responding"
               break
             fi
             attempt=$((attempt + 1))
-            echo "Attempt $attempt/$max_attempts: /api/status -> $code; waiting 10s..."
-            if [ $((attempt % 10)) -eq 0 ]; then
-              echo "=== tail dashboards.log ==="
-              tail -n 120 OpenSearch-Dashboards/dashboards.log || true
-              echo "=== tail $LOCAL_DISTRO/os.log ==="
-              tail -n 200 OpenSearch/$LOCAL_DISTRO/os.log || true
-              echo "==========================="
-            fi
+            echo "Attempt $attempt/$max_attempts: HTTP $code, waiting 10s..."
             sleep 10
           done
-          [ $attempt -lt $max_attempts ] || { echo "Timeout waiting for Dashboards"; tail -n 200 OpenSearch-Dashboards/dashboards.log || true; exit 1; }
+          if [ $attempt -eq $max_attempts ]; then
+            echo "ERROR: HTTP server failed to start"
+            tail -n 100 dashboards.log
+            exit 1
+          fi
+        shell: bash
+
+      - name: Wait for UI bundles to compile and become ready
+        run: |
+          cd OpenSearch-Dashboards
+          echo "=========================================="
+          echo "Waiting for optimizer to compile bundles"
+          echo "This can take 5-10 minutes in CI"
+          echo "=========================================="
+
+          max_wait=600  # 10 minutes
+          elapsed=0
+          ui_ready=false
+
+          while [ $elapsed -lt $max_wait ]; do
+            # Monitor logs for optimizer completion message
+            # Pattern: "X bundle(s) compiled successfully after Y sec, watching for changes"
+            if grep -qE "[0-9]+ bundles? compiled successfully.*watching for changes" dashboards.log 2>/dev/null; then
+              latest_msg=$(grep -E "bundles? compiled successfully.*watching" dashboards.log | tail -1)
+              echo "Optimizer completed! $(echo "$latest_msg" | grep -oE '[0-9]+ bundles? compiled successfully.*watching for changes')"
+              ui_ready=true
+              break
+            fi
+
+            # Progress update every 30 seconds
+            if [ $((elapsed % 30)) -eq 0 ]; then
+              echo "[${elapsed}s/${max_wait}s] Waiting for bundle compilation..."
+
+              # Show recent optimizer activity if available
+              if tail -50 dashboards.log 2>/dev/null | grep -q "@osd/optimizer"; then
+                recent=$(tail -50 dashboards.log | grep "@osd/optimizer" | tail -1 | grep -oE '\[[0-9]+/[0-9]+\].*' || echo "compiling...")
+                echo "  Status: $recent"
+              fi
+            fi
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          if [ "$ui_ready" = false ]; then
+            echo ""
+            echo "WARNING: Bundle compilation not detected within ${max_wait}s"
+            echo "Continuing anyway - Cypress will handle timeouts if UI is not ready"
+            echo ""
+            echo "=== Last 200 lines of dashboards.log ==="
+            tail -n 200 dashboards.log
+            echo "=========================================="
+          else
+            # Extra wait for plugin initialization
+            echo "Waiting 20s for plugin initialization..."
+            sleep 20
+            echo "=========================================="
+            echo "OpenSearch-Dashboards is fully ready!"
+            echo "=========================================="
+          fi
+        shell: bash
 
       - name: Verify services are running
         run: |

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -209,37 +209,81 @@ jobs:
           head -n 100 dashboards.log || true
         shell: bash
 
-      - name: Wait for OpenSearch-Dashboards to be ready
+      - name: Wait for OpenSearch-Dashboards HTTP server to start
         run: |
-          echo "Waiting for OpenSearch-Dashboards to start..."
+          cd OpenSearch-Dashboards
+          echo "Waiting for OpenSearch-Dashboards HTTP server..."
           max_attempts=150
           attempt=0
           while [ $attempt -lt $max_attempts ]; do
             if curl -s -f http://localhost:5601/api/status > /dev/null 2>&1; then
-              echo "OpenSearch-Dashboards is ready!"
-              echo "=== OpenSearch-Dashboards Status Debug Info ==="
-              curl -s http://localhost:5601/api/status | jq '.' || curl -s http://localhost:5601/api/status
-              echo "=============================================="
-              sleep 45
+              echo "HTTP server is responding"
               break
             fi
             attempt=$((attempt + 1))
-            echo "Attempt $attempt/$max_attempts: OpenSearch-Dashboards not ready yet, waiting 10 seconds..."
-            if [ $((attempt % 10)) -eq 0 ]; then
-              echo "Debug: Attempting to connect to http://localhost:5601/api/status"
-              curl -s -v http://localhost:5601/api/status || echo "Connection failed"
-            fi
+            echo "Attempt $attempt/$max_attempts: waiting 10s..."
             sleep 10
           done
           if [ $attempt -eq $max_attempts ]; then
-            echo "OpenSearch-Dashboards failed to start within timeout"
-            echo "Final debug attempt:"
-            curl -s -v http://localhost:5601/api/status || echo "Final connection attempt failed"
+            echo "ERROR: HTTP server failed to start"
+            tail -n 100 dashboards.log
             exit 1
           fi
-          curl -s http://localhost:5601/api/status || (echo "OpenSearch-Dashboards health check failed" && exit 1)
-          echo "Waiting additional time for plugin initialization..."
-          sleep 15
+        shell: bash
+
+      - name: Wait for UI bundles to compile and become ready
+        run: |
+          cd OpenSearch-Dashboards
+          echo "=========================================="
+          echo "Waiting for optimizer to compile bundles"
+          echo "This can take 5-10 minutes in CI"
+          echo "=========================================="
+
+          max_wait=600  # 10 minutes
+          elapsed=0
+          ui_ready=false
+
+          while [ $elapsed -lt $max_wait ]; do
+            # Monitor logs for optimizer completion message
+            # Pattern: "X bundle(s) compiled successfully after Y sec, watching for changes"
+            if grep -qE "[0-9]+ bundles? compiled successfully.*watching for changes" dashboards.log 2>/dev/null; then
+              latest_msg=$(grep -E "bundles? compiled successfully.*watching" dashboards.log | tail -1)
+              echo "Optimizer completed! $(echo "$latest_msg" | grep -oE '[0-9]+ bundles? compiled successfully.*watching for changes')"
+              ui_ready=true
+              break
+            fi
+
+            # Progress update every 30 seconds
+            if [ $((elapsed % 30)) -eq 0 ]; then
+              echo "[${elapsed}s/${max_wait}s] Waiting for bundle compilation..."
+
+              # Show recent optimizer activity if available
+              if tail -50 dashboards.log 2>/dev/null | grep -q "@osd/optimizer"; then
+                recent=$(tail -50 dashboards.log | grep "@osd/optimizer" | tail -1 | grep -oE '\[[0-9]+/[0-9]+\].*' || echo "compiling...")
+                echo "  Status: $recent"
+              fi
+            fi
+
+            sleep 10
+            elapsed=$((elapsed + 10))
+          done
+
+          if [ "$ui_ready" = false ]; then
+            echo ""
+            echo "WARNING: Bundle compilation not detected within ${max_wait}s"
+            echo "Continuing anyway - Cypress will handle timeouts if UI is not ready"
+            echo ""
+            echo "=== Last 200 lines of dashboards.log ==="
+            tail -n 200 dashboards.log
+            echo "=========================================="
+          else
+            # Extra wait for plugin initialization
+            echo "Waiting 20s for plugin initialization..."
+            sleep 20
+            echo "=========================================="
+            echo "OpenSearch-Dashboards is fully ready!"
+            echo "=========================================="
+          fi
         shell: bash
 
       - name: Verify services are running

--- a/cypress/e2e/wlm-no-security/6_WLM_main.cy.js
+++ b/cypress/e2e/wlm-no-security/6_WLM_main.cy.js
@@ -7,9 +7,20 @@ import { WLM_AUTH } from '../../support/constants';
 
 describe('WLM Main Page', () => {
   beforeEach(() => {
+    // Detect CI environment for appropriate timeouts
+    const isCI = Cypress.env('CI') || !Cypress.config('isInteractive');
+    const pageLoadTimeout = isCI ? 180000 : 60000; // 3 minutes in CI, 1 minute locally
+
     cy.visit('/app/workload-management#/workloadManagement', {
       auth: WLM_AUTH,
+      timeout: pageLoadTimeout,
     });
+
+    // Wait for the page to be fully loaded with the main heading
+    cy.contains('Workload groups', { timeout: pageLoadTimeout }).should('be.visible');
+
+    // Wait for the table to be rendered
+    cy.get('.euiBasicTable', { timeout: pageLoadTimeout }).should('exist');
   });
 
   it('should display the WLM page with the workload group table', () => {

--- a/cypress/e2e/wlm-no-security/7_WLM_details.cy.js
+++ b/cypress/e2e/wlm-no-security/7_WLM_details.cy.js
@@ -32,8 +32,17 @@ describe('WLM Details Page', () => {
   });
 
   beforeEach(() => {
-    cy.visit(`/app/workload-management#/wlm-details?name=${groupName}`, { auth: WLM_AUTH });
-    cy.contains(groupName).should('exist');
+    // Detect CI environment for appropriate timeouts
+    const isCI = Cypress.env('CI') || !Cypress.config('isInteractive');
+    const pageLoadTimeout = isCI ? 180000 : 60000; // 3 minutes in CI, 1 minute locally
+
+    cy.visit(`/app/workload-management#/wlm-details?name=${groupName}`, {
+      auth: WLM_AUTH,
+      timeout: pageLoadTimeout,
+    });
+
+    // Wait for the page to be fully loaded with the group name
+    cy.contains(groupName, { timeout: pageLoadTimeout }).should('exist');
   });
 
   it('should display workload group summary panel', () => {
@@ -131,9 +140,18 @@ describe('WLM Details Page', () => {
 
 describe('WLM Details – DEFAULT_WORKLOAD_GROUP', () => {
   it('should disable settings tab for DEFAULT_WORKLOAD_GROUP', () => {
+    // Detect CI environment for appropriate timeouts
+    const isCI = Cypress.env('CI') || !Cypress.config('isInteractive');
+    const pageLoadTimeout = isCI ? 180000 : 60000; // 3 minutes in CI, 1 minute locally
+
     cy.visit('/app/workload-management#/wlm-details?name=DEFAULT_WORKLOAD_GROUP', {
       auth: WLM_AUTH,
+      timeout: pageLoadTimeout,
     });
+
+    // Wait for the page to be fully loaded
+    cy.contains('DEFAULT_WORKLOAD_GROUP', { timeout: pageLoadTimeout }).should('exist');
+
     cy.get('[data-testid="wlm-tab-settings"]').click();
     cy.contains('Settings are not available for the DEFAULT_WORKLOAD_GROUP').should('exist');
   });

--- a/cypress/e2e/wlm-no-security/8_WLM_create.cy.js
+++ b/cypress/e2e/wlm-no-security/8_WLM_create.cy.js
@@ -9,7 +9,17 @@ const auth = WLM_AUTH;
 
 describe('WLM Create Page', () => {
   beforeEach(() => {
-    cy.visit('/app/workload-management#/wlm-create', { auth });
+    // Detect CI environment for appropriate timeouts
+    const isCI = Cypress.env('CI') || !Cypress.config('isInteractive');
+    const pageLoadTimeout = isCI ? 180000 : 60000; // 3 minutes in CI, 1 minute locally
+
+    cy.visit('/app/workload-management#/wlm-create', {
+      auth,
+      timeout: pageLoadTimeout,
+    });
+
+    // Wait for the page to be fully loaded with the main heading
+    cy.contains('h1', 'Create workload group', { timeout: pageLoadTimeout }).should('exist');
   });
 
   it('renders the full create form with required fields', () => {


### PR DESCRIPTION
### Description
Dashboards start process: Bootstrap -> server ready -> optimizer bundles ready. 
The current check only waits until server ready. We will need to wait until the last step before cypress tests.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
