### PR TITLE
Fixed version mismatch for @types/react-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "resolutions": {
     "@types/react": "^18.2.0",
     "**/@types/jest": "^29.3.1",
-    "**/@types/react-dom": "^18.2.0",
+    "**/@types/react-dom": "^16.9.8",
     "eslint-utils": "^1.4.2",
     "async": "^3.2.3",
     "json5": "^2.2.3",
@@ -74,7 +74,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@types/luxon": "^3.6.2",
     "@types/object-hash": "^3.0.0",
-    "@types/react-dom": "^18.2.0",
+    "@types/react-dom": "^16.9.8",
     "@types/react-router-dom": "^5.3.2",
     "cypress": "^13.6.0",
     "cypress-real-events": "1.7.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -797,10 +797,10 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.15.tgz#e6e5a86d602beaca71ce5163fadf5f95d70931c7"
   integrity sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==
 
-"@types/react-dom@^18.2.0":
-  version "18.3.7"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.7.tgz#b89ddf2cd83b4feafcc4e2ea41afdfb95a0d194f"
-  integrity sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==
+"@types/react-dom@^16.9.8":
+  version "16.9.25"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.25.tgz#fc6440aaae3d2d3aa10f6afeb7f1b0c4a55d5e31"
+  integrity sha512-ZK//eAPhwft9Ul2/Zj+6O11YR6L4JX0J2sVeBC9Ft7x7HFN7xk7yUV/zDxqV6rjvqgl6r8Dq7oQImxtyf/Mzcw==
 
 "@types/react-router-dom@^5.3.2":
   version "5.3.3"


### PR DESCRIPTION
### Description
Fixed version mismatch for @types/react-dom dependency to align with OpenSearch Dashboards core requirements.

```
ERROR [single_version_dependencies] Multiple version ranges for the same dependency
      were found declared across different package.json files. Please consolidate
      those to match across all package.json files. Different versions for the
      same dependency is not supported.

      If you have questions about this please reach out to the operations team.

      The conflicting dependencies are:

        @types/react-dom
          ^16.9.8 => opensearch-dashboards
          ^18.2.0 => opensearch_query_insights_dashboards
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Process completed with exit code 1.

```

### Changes
Updated @types/react-dom from ^18.2.0 to ^16.9.8 in both devDependencies and resolutions

### Issues Resolved
Resolves the single_version_dependencies error that prevented builds due to conflicting dependency versions between the plugin and OpenSearch Dashboards core.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
