### PR TITLE
[Feature] Add Query Profiler tool

### DIFF
--- a/.github/workflows/cypress-tests-wlm.yml
+++ b/.github/workflows/cypress-tests-wlm.yml
@@ -214,16 +214,15 @@ jobs:
           echo "This can take 5-10 minutes in CI"
           echo "=========================================="
 
-          max_wait=600  # 10 minutes
+          max_wait=1800  # 30 minutes
           elapsed=0
           ui_ready=false
 
           while [ $elapsed -lt $max_wait ]; do
             # Monitor logs for optimizer completion message
-            # Pattern: "X bundle(s) compiled successfully after Y sec, watching for changes"
-            if grep -qE "[0-9]+ bundles? compiled successfully.*watching for changes" dashboards.log 2>/dev/null; then
-              latest_msg=$(grep -E "bundles? compiled successfully.*watching" dashboards.log | tail -1)
-              echo "Optimizer completed! $(echo "$latest_msg" | grep -oE '[0-9]+ bundles? compiled successfully.*watching for changes')"
+            if grep -qE "[0-9]+ bundles? compiled successfully" dashboards.log 2>/dev/null; then
+              latest_msg=$(grep -E "bundles? compiled successfully" dashboards.log | tail -1)
+              echo "Optimizer completed! $latest_msg"
               ui_ready=true
               break
             fi

--- a/cypress/e2e/qi/6_profiler.cy.js
+++ b/cypress/e2e/qi/6_profiler.cy.js
@@ -1,0 +1,119 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BASE_PATH } from '../../support/constants';
+
+const PROFILER_PATH = `${BASE_PATH}/app/dev_tools#/queryProfiler`;
+
+describe('Query Profiler', () => {
+  beforeEach(() => {
+    cy.visit(PROFILER_PATH);
+    cy.contains('Import', { timeout: 30000 }).should('be.visible');
+  });
+
+  afterEach(() => {
+    cy.get('body').type('{esc}');
+  });
+
+  it('renders all tabs', () => {
+    cy.contains('.euiTab', 'Settings').should('be.visible');
+    cy.contains('.euiTab', 'Import').should('be.visible');
+    cy.contains('.euiTab', 'Export JSON').should('be.visible');
+    cy.contains('.euiTab', 'Help').should('be.visible');
+  });
+
+  it('renders editor panels', () => {
+    cy.get('.conApp__editorActionButton--success').should('have.length', 2);
+  });
+
+  it('opens settings modal', () => {
+    cy.contains('.euiTab', 'Settings').click();
+    cy.contains('Query Profiler Settings').should('be.visible');
+    cy.contains('Font Size').should('be.visible');
+    cy.contains('Wrap long lines').should('be.visible');
+    cy.contains('button', 'Cancel').click();
+    cy.contains('Query Profiler Settings').should('not.exist');
+  });
+
+  it('saves settings', () => {
+    cy.contains('.euiTab', 'Settings').click();
+    cy.get('input[type="number"]').clear().type('16');
+    cy.contains('button', 'Save').click();
+    cy.contains('Query Profiler Settings').should('not.exist');
+  });
+
+  it('opens import flyout', () => {
+    cy.contains('.euiTab', 'Import').click();
+    cy.contains('Search query').should('be.visible');
+    cy.contains('Profile JSON').should('be.visible');
+    cy.contains('button', 'Cancel').click();
+    cy.contains('Search query').should('not.exist');
+  });
+
+  it('opens help flyout', () => {
+    cy.contains('.euiTab', 'Help').click();
+    cy.contains('About Query Profiler').should('be.visible');
+    cy.contains('Reset All').scrollIntoView().should('be.visible');
+  });
+
+  it('executes a search query and returns 200', () => {
+    cy.intercept('POST', '**/api/profiler-proxy').as('profilerQuery');
+    cy.get('.conApp__editorActionButton--success').first().click();
+    cy.wait('@profilerQuery').its('response.statusCode').should('eq', 200);
+  });
+
+  it('shows meaningful error for invalid query', () => {
+    cy.intercept('POST', '**/api/profiler-proxy', {
+      statusCode: 400,
+      body: { message: '[illegal_argument_exception] bad parameter' },
+    }).as('profilerError');
+    cy.get('.conApp__editorActionButton--success').first().click();
+    cy.wait('@profilerError');
+    cy.get('.ace_content').last().invoke('text').should('include', 'Error');
+  });
+
+  it('resets editors when reset button clicked', () => {
+    cy.get('.conApp__editorActionButton--success').eq(1).click();
+    cy.contains('match_all').should('be.visible');
+  });
+
+  it('exports JSON file', () => {
+    cy.intercept('POST', '**/api/profiler-proxy').as('profilerQuery');
+    cy.get('.conApp__editorActionButton--success').first().click();
+    cy.wait('@profilerQuery').its('response.statusCode').should('eq', 200);
+    cy.contains('.euiTab', 'Export JSON').click();
+    cy.task('deleteFile', 'cypress/downloads/profile.json');
+  });
+
+  it('imports search query into editor', () => {
+    const query = 'GET _search\n{\n  "query": {\n    "term": { "status": "active" }\n  }\n}';
+    cy.contains('.euiTab', 'Import').click();
+    cy.contains('Search query').should('be.visible');
+    cy.get('input[type="file"]').selectFile(
+      { contents: Cypress.Buffer.from(query), fileName: 'test_query.txt', mimeType: 'text/plain' },
+      { force: true }
+    );
+    cy.get('[data-test-subj="importQueriesConfirmBtn"]').should('not.be.disabled').click();
+    cy.contains('Search query').should('not.exist');
+  });
+
+  it('imports profile JSON into output panel', () => {
+    const profile = JSON.stringify({
+      profile: { shards: [{ id: '[node1][index][0]', searches: [] }] },
+    });
+    cy.contains('.euiTab', 'Import').click();
+    cy.contains('Profile JSON').click();
+    cy.get('input[type="file"]').selectFile(
+      {
+        contents: Cypress.Buffer.from(profile),
+        fileName: 'test_profile.json',
+        mimeType: 'application/json',
+      },
+      { force: true }
+    );
+    cy.get('[data-test-subj="importQueriesConfirmBtn"]').should('not.be.disabled').click();
+    cy.contains('Profile JSON').should('not.exist');
+  });
+});

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -8,8 +8,18 @@
 /**
  * @type {Cypress.PluginConfig}
  */
+const fs = require('fs');
+
 module.exports = (on, config) => {
-  // `on` is used to hook into various events Cypress emits
-  // `config` is the resolved Cypress config
+  on('task', {
+    deleteFile(filePath) {
+      try {
+        fs.unlinkSync(filePath);
+      } catch (e) {
+        console.error(e);
+      }
+      return null;
+    },
+  });
   return config;
 };

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -6,7 +6,9 @@
   "ui": true,
   "requiredPlugins": [
     "navigation",
-    "opensearchDashboardsUtils"
+    "opensearchDashboardsUtils",
+    "devTools",
+    "opensearchDashboardsReact"
   ],
   "optionalPlugins": [
     "dataSource",

--- a/public/index.scss
+++ b/public/index.scss
@@ -1,1 +1,12 @@
 /* stylelint-disable no-empty-source */
+
+.conApp__editorActionButton {
+  padding: 0 $euiSizeXS;
+  appearance: none;
+  border: none;
+  background: none;
+}
+
+.conApp__editorActionButton--success {
+  color: $euiColorSuccess;
+}

--- a/public/pages/Profiler/Profiler.test.tsx
+++ b/public/pages/Profiler/Profiler.test.tsx
@@ -1,0 +1,356 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const mockEditor = {
+  setTheme: jest.fn(),
+  session: {
+    setMode: jest.fn(),
+    setUseWrapMode: jest.fn(),
+    setUseWorker: jest.fn(),
+  },
+  setValue: jest.fn(),
+  setOptions: jest.fn(),
+  setReadOnly: jest.fn(),
+  on: jest.fn(),
+  destroy: jest.fn(),
+  setFontSize: jest.fn(),
+  getValue: jest.fn(() => ''),
+};
+
+jest.mock('brace', () => ({
+  edit: jest.fn(() => mockEditor),
+  acequire: jest.fn(() => ({ Range: jest.fn() })),
+  require: jest.fn(() => ({ Range: jest.fn() })),
+  Range: jest.fn(),
+}));
+
+import React from 'react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
+import { ProfilerEditor, setCoreStart, renderProfiler } from './Profiler';
+import { CoreStart } from '../../../../../src/core/public';
+
+// @ts-ignore
+window.URL.revokeObjectURL = jest.fn();
+// @ts-ignore
+window.URL.createObjectURL = jest.fn(() => 'blob:mock');
+
+const mockHttp = {
+  post: jest.fn().mockResolvedValue({ profile: { shards: [] } }),
+  get: jest.fn(),
+};
+
+const mockCoreStart = ({ http: mockHttp } as unknown) as Parameters<typeof setCoreStart>[0];
+
+beforeAll(() => {
+  setCoreStart(mockCoreStart);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  jest.runAllTimers();
+  jest.useRealTimers();
+});
+
+const renderEditor = (props: { dataSourceId?: string; initialQuery?: string } = {}) =>
+  render(<ProfilerEditor http={mockHttp as CoreStart['http']} {...props} />);
+
+describe('ProfilerEditor', () => {
+  it('renders all tabs', () => {
+    const { getByText } = renderEditor();
+    expect(getByText('Settings')).toBeTruthy();
+    expect(getByText('Import')).toBeTruthy();
+    expect(getByText('Export JSON')).toBeTruthy();
+    expect(getByText('Help')).toBeTruthy();
+  });
+
+  it('opens and closes settings modal', async () => {
+    const { getByText, queryByText } = renderEditor();
+    act(() => fireEvent.click(getByText('Settings')));
+    await waitFor(() => expect(getByText('Query Profiler Settings')).toBeTruthy());
+
+    act(() => fireEvent.click(getByText('Cancel')));
+    await waitFor(() => expect(queryByText('Query Profiler Settings')).toBeNull());
+
+    act(() => fireEvent.click(getByText('Settings')));
+    await waitFor(() => expect(getByText('Query Profiler Settings')).toBeTruthy());
+    act(() => fireEvent.click(getByText('Save')));
+    await waitFor(() => expect(queryByText('Query Profiler Settings')).toBeNull());
+  });
+
+  it('toggles wrap mode in settings', async () => {
+    const { getByText } = renderEditor();
+    act(() => fireEvent.click(getByText('Settings')));
+    await waitFor(() => expect(getByText('Wrap long lines')).toBeTruthy());
+    const wrapSwitch = document.querySelector('[role="switch"]') as HTMLElement;
+    act(() => fireEvent.click(wrapSwitch));
+    expect(wrapSwitch.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('updates font size in settings', async () => {
+    const { getByText } = renderEditor();
+    act(() => fireEvent.click(getByText('Settings')));
+    await waitFor(() => expect(getByText('Font Size')).toBeTruthy());
+    const fontInput = document.querySelector('input[type="number"]') as HTMLInputElement;
+    act(() => fireEvent.change(fontInput, { target: { value: '18' } }));
+    expect(fontInput.value).toBe('18');
+  });
+
+  it('opens import flyout', async () => {
+    const { getByText } = renderEditor();
+    act(() => fireEvent.click(getByText('Import')));
+    await waitFor(() => {
+      expect(getByText('Search query')).toBeTruthy();
+      expect(getByText('Profile JSON')).toBeTruthy();
+    });
+  });
+
+  it('opens help flyout', async () => {
+    const { getByText } = renderEditor();
+    act(() => fireEvent.click(getByText('Help')));
+    await waitFor(() => expect(getByText('About Query Profiler')).toBeTruthy());
+  });
+
+  it('exports JSON and cleans up after timeout', () => {
+    const { getByText } = renderEditor();
+    const appendSpy = jest.spyOn(document.body, 'appendChild');
+    const removeSpy = jest
+      .spyOn(document.body, 'removeChild')
+      .mockImplementation(() => ({} as ChildNode));
+    act(() => fireEvent.click(getByText('Export JSON')));
+    expect(appendSpy).toHaveBeenCalled();
+    act(() => jest.runAllTimers());
+    expect(removeSpy).toHaveBeenCalled();
+    expect(window.URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock');
+    appendSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+
+  it('executes query when play button is clicked', async () => {
+    const { container } = renderEditor();
+    const playBtn = container.querySelectorAll(
+      '.conApp__editorActionButton--success'
+    )[0] as HTMLElement;
+    await waitFor(() => expect(playBtn).toBeTruthy());
+    act(() => fireEvent.click(playBtn));
+    await waitFor(() =>
+      expect(mockHttp.post).toHaveBeenCalledWith('/api/profiler-proxy', expect.any(Object))
+    );
+  });
+
+  it('sends correct dataSourceId in request', async () => {
+    const { container } = renderEditor({ dataSourceId: 'test-ds-id' });
+    const playBtn = container.querySelectorAll(
+      '.conApp__editorActionButton--success'
+    )[0] as HTMLElement;
+    await waitFor(() => expect(playBtn).toBeTruthy());
+    act(() => fireEvent.click(playBtn));
+    await waitFor(() => {
+      const callArg = JSON.parse((mockHttp.post as jest.Mock).mock.calls[0][1].body);
+      expect(callArg.dataSourceId).toBe('test-ds-id');
+    });
+  });
+
+  it('rejects non-_search paths and shows error', async () => {
+    renderEditor({ initialQuery: 'GET _cluster/settings\n{}' });
+    await waitFor(() => {
+      expect(mockHttp.post).not.toHaveBeenCalled();
+    });
+  });
+
+  it('rejects non-_search path when play button clicked', async () => {
+    // ace mock getValue returns '' so editor input defaults to _search
+    // test the validation logic directly via initialQuery
+    const { container } = renderEditor({ initialQuery: 'GET _cluster/settings\n{}' });
+    const playBtn = container.querySelectorAll(
+      '.conApp__editorActionButton--success'
+    )[0] as HTMLElement;
+    await waitFor(() => expect(playBtn).toBeTruthy());
+    // clicking play uses editor value (empty -> _search), so post IS called
+    // the path validation for initialQuery already ran on mount
+    expect(mockHttp.post).not.toHaveBeenCalled(); // not called from initialQuery
+  });
+
+  it('shows error message when request fails with body message', async () => {
+    mockHttp.post.mockRejectedValueOnce({
+      body: { message: '[illegal_argument_exception] bad param' },
+    });
+    const { container } = renderEditor();
+    const playBtn = container.querySelectorAll(
+      '.conApp__editorActionButton--success'
+    )[0] as HTMLElement;
+    await waitFor(() => expect(playBtn).toBeTruthy());
+    act(() => fireEvent.click(playBtn));
+    await waitFor(() => expect(mockHttp.post).toHaveBeenCalled());
+  });
+
+  it('shows error message when request fails with plain error', async () => {
+    mockHttp.post.mockRejectedValueOnce(new Error('Network failure'));
+    const { container } = renderEditor();
+    const playBtn = container.querySelectorAll(
+      '.conApp__editorActionButton--success'
+    )[0] as HTMLElement;
+    await waitFor(() => expect(playBtn).toBeTruthy());
+    act(() => fireEvent.click(playBtn));
+    await waitFor(() => expect(mockHttp.post).toHaveBeenCalled());
+  });
+
+  it('resets editors when reset button is clicked', async () => {
+    const { container } = renderEditor();
+    const resetBtn = container.querySelectorAll(
+      '.conApp__editorActionButton--success'
+    )[1] as HTMLElement;
+    await waitFor(() => expect(resetBtn).toBeTruthy());
+    act(() => fireEvent.click(resetBtn));
+    expect(resetBtn).toBeTruthy();
+  });
+
+  it('auto-executes initialQuery on mount', async () => {
+    renderEditor({ initialQuery: 'GET _search\n{"query":{"match_all":{}}}' });
+    await waitFor(() =>
+      expect(mockHttp.post).toHaveBeenCalledWith('/api/profiler-proxy', expect.any(Object))
+    );
+  });
+
+  it('injects profile:true into request body', async () => {
+    const { container } = renderEditor();
+    const playBtn = container.querySelectorAll(
+      '.conApp__editorActionButton--success'
+    )[0] as HTMLElement;
+    await waitFor(() => expect(playBtn).toBeTruthy());
+    act(() => fireEvent.click(playBtn));
+    await waitFor(() => {
+      const callArg = JSON.parse((mockHttp.post as jest.Mock).mock.calls[0][1].body);
+      const body = JSON.parse(callArg.body);
+      expect(body.profile).toBe(true);
+    });
+  });
+
+  it('shows and hides input panel toggle', async () => {
+    const { container, getByText } = renderEditor();
+    // trigger hideInput via import result
+    act(() => fireEvent.click(getByText('Import')));
+    await waitFor(() => expect(getByText('Profile JSON')).toBeTruthy());
+    const profileJsonRadio = document.querySelector('input[id="result"]') as HTMLInputElement;
+    if (profileJsonRadio) act(() => fireEvent.click(profileJsonRadio));
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['{"profile":{}}'], 'result.json', { type: 'application/json' });
+    act(() => fireEvent.change(fileInput, { target: { files: [file] } }));
+    const confirmBtn = document.querySelector(
+      '[data-test-subj="importQueriesConfirmBtn"]'
+    ) as HTMLElement;
+    await act(async () => fireEvent.click(confirmBtn));
+    await waitFor(() =>
+      expect(container.querySelector('[data-test-subj="show-input-toggle"]')).toBeTruthy()
+    );
+    // click toggle to show input again
+    const toggle = container.querySelector('[data-test-subj="show-input-toggle"]') as HTMLElement;
+    act(() => fireEvent.click(toggle));
+    await waitFor(() =>
+      expect(container.querySelector('[data-test-subj="show-input-toggle"]')).toBeNull()
+    );
+  });
+
+  it('restores editor via keyboard Enter on toggle panel', async () => {
+    const { container, getByText } = renderEditor();
+    act(() => fireEvent.click(getByText('Import')));
+    await waitFor(() => expect(getByText('Profile JSON')).toBeTruthy());
+    const profileJsonRadio = document.querySelector('input[id="result"]') as HTMLInputElement;
+    if (profileJsonRadio) act(() => fireEvent.click(profileJsonRadio));
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['{"profile":{}}'], 'result.json', { type: 'application/json' });
+    act(() => fireEvent.change(fileInput, { target: { files: [file] } }));
+    const confirmBtn = document.querySelector(
+      '[data-test-subj="importQueriesConfirmBtn"]'
+    ) as HTMLElement;
+    await act(async () => fireEvent.click(confirmBtn));
+    await waitFor(() =>
+      expect(container.querySelector('[data-test-subj="show-input-toggle"]')).toBeTruthy()
+    );
+    const toggle = container.querySelector('[data-test-subj="show-input-toggle"]') as HTMLElement;
+    act(() => fireEvent.keyDown(toggle, { key: 'Enter' }));
+    await waitFor(() =>
+      expect(container.querySelector('[data-test-subj="show-input-toggle"]')).toBeNull()
+    );
+  });
+
+  it('imports a query file', async () => {
+    const { getByText } = renderEditor();
+    act(() => fireEvent.click(getByText('Import')));
+    await waitFor(() => expect(getByText('Search query')).toBeTruthy());
+    const file = new File(['GET _search\n{}'], 'query.json', { type: 'application/json' });
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    act(() => fireEvent.change(fileInput, { target: { files: [file] } }));
+    const confirmBtn = document.querySelector(
+      '[data-test-subj="importQueriesConfirmBtn"]'
+    ) as HTMLElement;
+    await act(async () => fireEvent.click(confirmBtn));
+    await waitFor(() => expect(document.body.textContent).not.toContain('Select a file to import'));
+  });
+
+  it('closes import flyout on cancel', async () => {
+    const { getByText, queryByText } = renderEditor();
+    act(() => fireEvent.click(getByText('Import')));
+    await waitFor(() => expect(getByText('Search query')).toBeTruthy());
+    act(() => fireEvent.click(getByText('Cancel')));
+    await waitFor(() => expect(queryByText('Search query')).toBeNull());
+  });
+});
+
+describe('renderProfiler', () => {
+  let container: HTMLElement;
+  let unmount: () => void;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    act(() => {
+      unmount?.();
+    });
+    document.body.innerHTML = '';
+  });
+
+  it('renders ProfilerEditor via renderProfiler', () => {
+    act(() => {
+      unmount = renderProfiler(container);
+    });
+    expect(container.textContent).toContain('Settings');
+  });
+
+  it('reads initialQuery from localStorage', async () => {
+    localStorage.setItem('profilerQuery', 'GET _search\n{"query":{"match_all":{}}}');
+    act(() => {
+      unmount = renderProfiler(container);
+    });
+    expect(localStorage.getItem('profilerQuery')).toBeNull();
+  });
+
+  it('reads dataSourceId from URL search param', () => {
+    Object.defineProperty(window, 'location', {
+      value: { search: '?dataSource=test-id' },
+      writable: true,
+    });
+    act(() => {
+      unmount = renderProfiler(container, 'fallback-id');
+    });
+    expect(container.textContent).toContain('Settings');
+    Object.defineProperty(window, 'location', { value: { search: '' }, writable: true });
+  });
+
+  it('unmounts cleanly', () => {
+    act(() => {
+      unmount = renderProfiler(container);
+    });
+    expect(() => act(() => unmount())).not.toThrow();
+  });
+});

--- a/public/pages/Profiler/Profiler.tsx
+++ b/public/pages/Profiler/Profiler.tsx
@@ -1,0 +1,563 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useEffect, useRef } from 'react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiTitle,
+  EuiIcon,
+  EuiToolTip,
+  EuiFlyout,
+  EuiFlyoutHeader,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiText,
+  EuiCallOut,
+  EuiCompressedFilePicker,
+  EuiForm,
+  EuiCompressedFormRow,
+  EuiCompressedRadioGroup,
+  EuiTabs,
+  EuiTab,
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiSmallButtonEmpty,
+  EuiSmallButton,
+  EuiCompressedFieldNumber,
+  EuiCompressedSwitch,
+} from '@elastic/eui';
+import { createRoot } from 'react-dom/client';
+import ace from 'brace';
+import { AppMountParameters, CoreStart } from '../../../../../src/core/public';
+import { DataSourceManagementPluginSetup } from '../../../../../src/plugins/data_source_management/public';
+import { QueryInsightsDashboardsPluginStartDependencies } from '../../types';
+import { QueryInsightsDataSourceMenu } from '../../components/DataSourcePicker';
+import { getDataSourceFromUrl } from '../../utils/datasource-utils';
+import { OpenSearchDashboardsContextProvider } from '../../../../../src/plugins/opensearch_dashboards_react/public';
+import 'brace/mode/json';
+import 'brace/theme/textmate';
+
+const DEFAULT_PROFILER_QUERY = `GET _search\n{\n  "profile": true,\n  "query": {\n    "match_all": {}\n  }\n}`;
+
+const ImportFlyout: React.FC<{
+  onClose: () => void;
+  onImportQuery: (content: string) => void;
+  onImportResult: (content: string) => void;
+}> = ({ onClose, onImportQuery, onImportResult }) => {
+  const [file, setFile] = React.useState<File>();
+  const [error, setError] = React.useState<string>();
+  const [importType, setImportType] = React.useState<'query' | 'result'>('query');
+
+  const handleFileChange = (files: FileList | null) => {
+    if (!files?.[0]) {
+      setFile(undefined);
+      return;
+    }
+    setFile(files[0]);
+    setError(undefined);
+  };
+
+  const handleImport = () => {
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const content = e.target?.result as string;
+        if (importType === 'query') onImportQuery(content);
+        else onImportResult(content);
+        onClose();
+      } catch (err) {
+        setError('Failed to read file');
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  return (
+    <EuiFlyout onClose={onClose} size="s">
+      <EuiFlyoutHeader hasBorder>
+        <EuiText size="s">
+          <h2>Import</h2>
+        </EuiText>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        {error && (
+          <>
+            <EuiCallOut title="Sorry, there was an error" color="danger">
+              <p>{error}</p>
+            </EuiCallOut>
+            <EuiSpacer size="s" />
+          </>
+        )}
+        <EuiForm>
+          <EuiCompressedFormRow fullWidth label="Import to">
+            <EuiCompressedRadioGroup
+              options={[
+                { id: 'query', label: 'Search query' },
+                { id: 'result', label: 'Profile JSON' },
+              ]}
+              idSelected={importType}
+              onChange={(id) => setImportType(id as 'query' | 'result')}
+            />
+          </EuiCompressedFormRow>
+          <EuiCompressedFormRow fullWidth label="Select a file to import">
+            <EuiCompressedFilePicker
+              accept=".json,.txt"
+              fullWidth
+              initialPromptText="Import"
+              onChange={handleFileChange}
+            />
+          </EuiCompressedFormRow>
+        </EuiForm>
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiFlexGroup justifyContent="spaceBetween">
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty onClick={onClose} size="s">
+              Cancel
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              onClick={handleImport}
+              size="s"
+              fill
+              disabled={!file}
+              data-test-subj="importQueriesConfirmBtn"
+            >
+              Import
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutFooter>
+    </EuiFlyout>
+  );
+};
+
+// Settings modal — uses draft state so Cancel discards and Save applies
+const SettingsModal: React.FC<{
+  fontSize: number;
+  wrapMode: boolean;
+  onSave: (fontSize: number, wrapMode: boolean) => void;
+  onCancel: () => void;
+}> = ({ fontSize, wrapMode, onSave, onCancel }) => {
+  const [draftFontSize, setDraftFontSize] = React.useState(fontSize);
+  const [draftWrapMode, setDraftWrapMode] = React.useState(wrapMode);
+
+  return (
+    <EuiModal onClose={onCancel}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          <EuiText size="s">
+            <h2>Query Profiler Settings</h2>
+          </EuiText>
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody>
+        <EuiCompressedFormRow label="Font Size">
+          <EuiCompressedFieldNumber
+            value={draftFontSize}
+            min={6}
+            max={50}
+            onChange={(e) => setDraftFontSize(parseInt(e.target.value, 10) || 14)}
+          />
+        </EuiCompressedFormRow>
+        <EuiCompressedFormRow>
+          <EuiCompressedSwitch
+            label="Wrap long lines"
+            checked={draftWrapMode}
+            onChange={(e) => setDraftWrapMode(e.target.checked)}
+          />
+        </EuiCompressedFormRow>
+      </EuiModalBody>
+      <EuiModalFooter>
+        <EuiSmallButtonEmpty onClick={onCancel}>Cancel</EuiSmallButtonEmpty>
+        <EuiSmallButton fill onClick={() => onSave(draftFontSize, draftWrapMode)}>
+          Save
+        </EuiSmallButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};
+
+// Page component — used inside the query-insights app router
+export const ConsoleProfiler: React.FC<{
+  core: CoreStart;
+  depsStart: QueryInsightsDashboardsPluginStartDependencies;
+  params: AppMountParameters;
+  dataSourceManagement?: DataSourceManagementPluginSetup;
+}> = ({ core, depsStart, params, dataSourceManagement }) => {
+  const [dataSource, setDataSource] = useState(getDataSourceFromUrl());
+  const initialQuery = localStorage.getItem('profilerQuery') || undefined;
+  localStorage.removeItem('profilerQuery');
+
+  return (
+    <OpenSearchDashboardsContextProvider services={core}>
+      <QueryInsightsDataSourceMenu
+        coreStart={core}
+        depsStart={depsStart}
+        params={params}
+        dataSourceManagement={dataSourceManagement}
+        setDataSource={setDataSource}
+        selectedDataSource={dataSource}
+        onManageDataSource={() => {}}
+        onSelectedDataSource={() => {}}
+        dataSourcePickerReadOnly={false}
+      />
+      <ProfilerEditor http={core.http} dataSourceId={dataSource?.id} initialQuery={initialQuery} />
+    </OpenSearchDashboardsContextProvider>
+  );
+};
+
+// Core editor — used both by the page component and the dev_tools registration
+export const ProfilerEditor: React.FC<{
+  http: CoreStart['http'];
+  dataSourceId?: string;
+  initialQuery?: string;
+}> = ({ http, dataSourceId, initialQuery }) => {
+  const inputRef = useRef(DEFAULT_PROFILER_QUERY);
+  const [output, setOutput] = useState('');
+  const [isHelpOpen, setIsHelpOpen] = useState(false);
+  const [isImportOpen, setIsImportOpen] = useState(false);
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [fontSize, setFontSize] = useState(14);
+  const [wrapMode, setWrapMode] = useState(false);
+  const [hideInput, setHideInput] = useState(false);
+
+  const inputEditorRef = useRef<HTMLDivElement>(null);
+  const outputEditorRef = useRef<HTMLDivElement>(null);
+  const inputEditorInstance = useRef<ReturnType<typeof ace.edit> | null>(null);
+  const outputEditorInstance = useRef<ReturnType<typeof ace.edit> | null>(null);
+  const dataSourceIdRef = useRef<string | undefined>(dataSourceId);
+
+  useEffect(() => {
+    dataSourceIdRef.current = dataSourceId;
+  }, [dataSourceId]);
+
+  useEffect(() => {
+    if (inputEditorRef.current && !inputEditorInstance.current) {
+      inputEditorInstance.current = ace.edit(inputEditorRef.current);
+      inputEditorInstance.current.setTheme('ace/theme/textmate');
+      inputEditorInstance.current.session.setMode('ace/mode/json');
+      inputEditorInstance.current.session.setUseWorker(false);
+      inputEditorInstance.current.setValue(initialQuery || DEFAULT_PROFILER_QUERY, -1);
+      inputEditorInstance.current.setOptions({
+        fontSize,
+        showPrintMargin: false,
+        showFoldWidgets: true,
+        foldStyle: 'markbegin',
+      });
+      inputEditorInstance.current.session.setUseWrapMode(wrapMode);
+      inputEditorInstance.current.on(
+        'change',
+        () => (inputRef.current = inputEditorInstance.current!.getValue())
+      );
+    }
+    if (outputEditorRef.current && !outputEditorInstance.current) {
+      outputEditorInstance.current = ace.edit(outputEditorRef.current);
+      outputEditorInstance.current.setTheme('ace/theme/textmate');
+      outputEditorInstance.current.session.setMode('ace/mode/json');
+      outputEditorInstance.current.session.setUseWorker(false);
+      outputEditorInstance.current.setReadOnly(true);
+      outputEditorInstance.current.setOptions({
+        fontSize,
+        showPrintMargin: false,
+        showFoldWidgets: true,
+        foldStyle: 'markbegin',
+      });
+      outputEditorInstance.current.session.setUseWrapMode(wrapMode);
+      if (initialQuery) executeQuery(initialQuery);
+    }
+    return () => {
+      inputEditorInstance.current?.destroy();
+      inputEditorInstance.current = null;
+      outputEditorInstance.current?.destroy();
+      outputEditorInstance.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    inputEditorInstance.current?.setFontSize(fontSize);
+    inputEditorInstance.current?.session.setUseWrapMode(wrapMode);
+    outputEditorInstance.current?.setFontSize(fontSize);
+    outputEditorInstance.current?.session.setUseWrapMode(wrapMode);
+  }, [fontSize, wrapMode]);
+
+  useEffect(() => {
+    outputEditorInstance.current?.setValue(output, -1);
+  }, [output]);
+
+  const executeQuery = async (queryInput?: string) => {
+    try {
+      const queryText = queryInput !== undefined ? queryInput : inputRef.current;
+      const lines = queryText.trim().split('\n');
+      const parts = lines[0].trim().split(/\s+/);
+      const method = parts[0] || 'GET';
+      const path = parts[1] || '_search';
+      const bodyText = lines.slice(1).join('\n').trim();
+
+      if (path.includes('..') || !path.split('?')[0].endsWith('_search')) {
+        setOutput(
+          'Error: Profiler only supports search queries. Please use Dev Tools Console for other operations.'
+        );
+        return;
+      }
+
+      const { profile: _p, ...rest } = bodyText ? JSON.parse(bodyText) : {};
+      const response = await http.post('/api/profiler-proxy', {
+        body: JSON.stringify({
+          method,
+          path,
+          body: JSON.stringify({ profile: true, ...rest }),
+          dataSourceId: dataSourceIdRef.current,
+        }),
+      });
+      setOutput(typeof response === 'string' ? response : JSON.stringify(response, null, 2));
+    } catch (error) {
+      const err = error as { body?: { message?: string }; message?: string };
+      setOutput(`Error: ${err.body?.message || err.message || JSON.stringify(error, null, 2)}`);
+    }
+  };
+
+  const exportJson = () => {
+    const blob = new Blob([output], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'profile.json';
+    a.style.display = 'none';
+    document.body.appendChild(a);
+    a.click();
+    setTimeout(() => {
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    }, 100);
+  };
+
+  return (
+    <div>
+      <EuiTabs size="s">
+        <EuiTab onClick={() => setIsSettingsOpen(true)}>Settings</EuiTab>
+        <EuiTab onClick={() => setIsImportOpen(true)}>Import</EuiTab>
+        <EuiTab onClick={exportJson}>Export JSON</EuiTab>
+        <EuiTab onClick={() => setIsHelpOpen(true)}>Help</EuiTab>
+      </EuiTabs>
+
+      <div style={{ height: '400px', width: '100%', display: 'flex' }}>
+        {hideInput && (
+          <div
+            role="button"
+            tabIndex={0}
+            data-test-subj="show-input-toggle"
+            style={{
+              width: '24px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: '#f5f7fa',
+              borderRight: '1px solid #D4DAE5',
+              cursor: 'pointer',
+            }}
+            onClick={() => {
+              setHideInput(false);
+              inputEditorInstance.current?.setValue('', -1);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                setHideInput(false);
+                inputEditorInstance.current?.setValue('', -1);
+              }
+            }}
+          >
+            <EuiToolTip content="Show query editor">
+              <EuiIcon type="plus" />
+            </EuiToolTip>
+          </div>
+        )}
+        <div
+          style={{
+            display: hideInput ? 'none' : 'flex',
+            flex: 1,
+            position: 'relative',
+            borderRight: '1px solid #D4DAE5',
+          }}
+        >
+          <div style={{ position: 'relative', height: '100%', width: '100%' }}>
+            <EuiFlexGroup
+              gutterSize="none"
+              responsive={false}
+              style={{ position: 'absolute', zIndex: 1000, top: 0, right: '16px', lineHeight: 1 }}
+            >
+              <EuiFlexItem>
+                <EuiToolTip content="Generate profile">
+                  <button
+                    onClick={() => executeQuery()}
+                    className="conApp__editorActionButton conApp__editorActionButton--success"
+                    style={{ padding: '0 8px', cursor: 'pointer', lineHeight: 'inherit' }}
+                  >
+                    <EuiIcon type="play" />
+                  </button>
+                </EuiToolTip>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiToolTip content="Reset all">
+                  <button
+                    onClick={() => {
+                      inputEditorInstance.current?.setValue(DEFAULT_PROFILER_QUERY, -1);
+                      setOutput('');
+                    }}
+                    className="conApp__editorActionButton conApp__editorActionButton--success"
+                    style={{ padding: '0 8px', cursor: 'pointer', lineHeight: 'inherit' }}
+                  >
+                    <EuiIcon type="refresh" />
+                  </button>
+                </EuiToolTip>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <div ref={inputEditorRef} style={{ width: '100%', height: '100%' }} />
+          </div>
+        </div>
+        <div style={{ flex: 1, position: 'relative', background: '#FFF' }}>
+          <div ref={outputEditorRef} style={{ width: '100%', height: '100%' }} />
+        </div>
+      </div>
+
+      {isSettingsOpen && (
+        <SettingsModal
+          fontSize={fontSize}
+          wrapMode={wrapMode}
+          onSave={(newFontSize, newWrapMode) => {
+            setFontSize(newFontSize);
+            setWrapMode(newWrapMode);
+            setIsSettingsOpen(false);
+          }}
+          onCancel={() => setIsSettingsOpen(false)}
+        />
+      )}
+
+      {isImportOpen && (
+        <ImportFlyout
+          onClose={() => setIsImportOpen(false)}
+          onImportQuery={(c) => {
+            inputEditorInstance.current?.setValue(c, -1);
+            setHideInput(false);
+          }}
+          onImportResult={(c) => {
+            try {
+              setOutput(JSON.stringify(JSON.parse(c), null, 2));
+            } catch {
+              setOutput(c);
+            }
+            setHideInput(true);
+          }}
+        />
+      )}
+
+      {isHelpOpen && (
+        <EuiFlyout onClose={() => setIsHelpOpen(false)} size="s">
+          <EuiFlyoutHeader hasBorder>
+            <EuiTitle size="s">
+              <h2>Query Profiler Help</h2>
+            </EuiTitle>
+          </EuiFlyoutHeader>
+          <EuiFlyoutBody>
+            <EuiText size="s">
+              <h3>About Query Profiler</h3>
+              <p>
+                The Query Profiler helps you understand how OpenSearch executes your search queries
+                by providing detailed performance metrics and execution breakdowns.
+              </p>
+              <h3>How to Use</h3>
+              <p>
+                1. Enter your search query in the left editor panel
+                <br />
+                2. Click the play button to execute and generate profile
+                <br />
+                3. View the profiling results in the right panel
+                <br />
+                4. Use the reset button to clear both query and results
+              </p>
+              <h3>Query Format</h3>
+              <pre
+                style={{ background: '#f5f5f5', padding: '8px', borderRadius: '4px' }}
+              >{`GET _search\n{\n  "query": {\n    "match_all": {}\n  }\n}`}</pre>
+              <h3>Features</h3>
+              <dl>
+                <dt>
+                  <strong>Settings</strong>
+                </dt>
+                <dd>Customize font size and enable line wrapping</dd>
+                <dt>
+                  <strong>Import</strong>
+                </dt>
+                <dd>Load search queries or profile JSON results</dd>
+                <dt>
+                  <strong>Export JSON</strong>
+                </dt>
+                <dd>Save profiling results as profile.json</dd>
+                <dt>
+                  <strong>Auto-profiling</strong>
+                </dt>
+                <dd>Automatically adds &quot;profile&quot;: true to your queries</dd>
+                <dt>
+                  <strong>Reset All</strong>
+                </dt>
+                <dd>Clear both query input and profiling results</dd>
+              </dl>
+            </EuiText>
+          </EuiFlyoutBody>
+        </EuiFlyout>
+      )}
+    </div>
+  );
+};
+
+// Dev tools registration — kept for backward compatibility
+let coreStart: CoreStart;
+export const setCoreStart = (core: CoreStart) => {
+  coreStart = core;
+};
+
+let root: ReturnType<typeof createRoot> | null = null;
+export const renderProfiler = (element: HTMLElement, dataSourceId?: string) => {
+  const urlDataSourceId =
+    new URLSearchParams(window.location.search).get('dataSource') || undefined;
+  const storedDataSourceId = localStorage.getItem('profilerDataSourceId') || undefined;
+  localStorage.removeItem('profilerDataSourceId');
+  const effectiveDataSourceId = urlDataSourceId || dataSourceId || storedDataSourceId;
+  const initialQuery = localStorage.getItem('profilerQuery') || undefined;
+  localStorage.removeItem('profilerQuery');
+
+  if (root) {
+    root.unmount();
+    root = null;
+  }
+
+  root = createRoot(element);
+  root.render(
+    <OpenSearchDashboardsContextProvider services={coreStart}>
+      <ProfilerEditor
+        http={coreStart.http}
+        dataSourceId={effectiveDataSourceId}
+        initialQuery={initialQuery}
+      />
+    </OpenSearchDashboardsContextProvider>
+  );
+
+  return () => {
+    if (root) {
+      root.unmount();
+      root = null;
+    }
+  };
+};

--- a/public/pages/QueryDetails/QueryDetails.tsx
+++ b/public/pages/QueryDetails/QueryDetails.tsx
@@ -6,6 +6,7 @@
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import ReactECharts from 'echarts-for-react';
 import {
+  EuiButton,
   EuiInMemoryTable,
   EuiCodeBlock,
   EuiDescriptionList,
@@ -86,6 +87,7 @@ const QueryDetails = ({
     if (id && from && to && verbose != null) {
       fetchQueryDetails();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, from, to, verbose]);
 
   useEffect(() => {
@@ -286,6 +288,38 @@ const QueryDetails = ({
                     <h2>Query</h2>
                   </EuiTitle>
                 </EuiFlexItem>
+                {queryDisplay && !queryDisplay.includes('...truncated') && (
+                  <EuiFlexItem grow={false}>
+                    <EuiButton
+                      size="s"
+                      onClick={() => {
+                        try {
+                          const { profile: _p, ...rest } = JSON.parse(queryDisplay);
+                          const profilerBody = { profile: true, ...rest };
+                          const indexPath = query?.indices?.join(',') || '_search';
+                          const searchPath =
+                            indexPath === '_search' ? '_search' : `${indexPath}/_search`;
+                          const profilerQuery = `GET ${searchPath}\n${JSON.stringify(
+                            profilerBody,
+                            null,
+                            2
+                          )}`;
+                          localStorage.setItem('profilerQuery', profilerQuery);
+                          if (dataSource?.id) {
+                            localStorage.setItem('profilerDataSourceId', dataSource.id);
+                          }
+                          window.location.href = core.http.basePath.prepend(
+                            '/app/dev_tools#/queryProfiler'
+                          );
+                        } catch (e) {
+                          console.error('Failed to parse query for profiler', e);
+                        }
+                      }}
+                    >
+                      Open in Profiler
+                    </EuiButton>
+                  </EuiFlexItem>
+                )}
               </EuiFlexGroup>
               <EuiHorizontalRule margin="xs" />
               <EuiSpacer size="xs" />

--- a/public/pages/QueryDetails/__snapshots__/QueryDetails.test.tsx.snap
+++ b/public/pages/QueryDetails/__snapshots__/QueryDetails.test.tsx.snap
@@ -706,6 +706,24 @@ exports[`QueryDetails component matches snapshot 1`] = `
                   Query
                 </h2>
               </div>
+              <div
+                class="euiFlexItem euiFlexItem--flexGrowZero"
+              >
+                <button
+                  class="euiButton euiButton--primary euiButton--small"
+                  type="button"
+                >
+                  <span
+                    class="euiButtonContent euiButton__content"
+                  >
+                    <span
+                      class="euiButton__text"
+                    >
+                      Open in Profiler
+                    </span>
+                  </span>
+                </button>
+              </div>
             </div>
             <hr
               class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginXSmall"

--- a/public/plugin.test.tsx
+++ b/public/plugin.test.tsx
@@ -40,7 +40,8 @@ describe('QueryInsightsDashboardsPlugin', () => {
   });
 
   it('should register the application in setup', () => {
-    plugin.setup(coreSetupMock, {} as any);
+    const devToolsMock = { register: jest.fn() };
+    plugin.setup(coreSetupMock, { devTools: devToolsMock } as any);
 
     expect(registerMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -56,10 +57,18 @@ describe('QueryInsightsDashboardsPlugin', () => {
         description: expect.any(String),
       })
     );
+
+    expect(devToolsMock.register).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'queryProfiler',
+        title: 'Query Profiler',
+      })
+    );
   });
 
   it('should mount the application correctly', async () => {
-    plugin.setup(coreSetupMock, {} as any);
+    const devToolsMock = { register: jest.fn() };
+    plugin.setup(coreSetupMock, { devTools: devToolsMock } as any);
 
     const appRegistration = registerMock.mock.calls[0][0];
     expect(appRegistration).toBeDefined();
@@ -83,7 +92,8 @@ describe('QueryInsightsDashboardsPlugin', () => {
   });
 
   it('registers WLM when enabled', () => {
-    plugin.setup(coreSetupMock, {} as any);
+    const devToolsMock = { register: jest.fn() };
+    plugin.setup(coreSetupMock, { devTools: devToolsMock } as any);
 
     expect(registerMock).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'workloadManagement' })
@@ -91,9 +101,10 @@ describe('QueryInsightsDashboardsPlugin', () => {
   });
 
   it('does NOT register WLM when disabled', () => {
+    const devToolsMock = { register: jest.fn() };
     // override the mocked export for this test
     (WLM_CONFIG as any).enabled = false;
-    plugin.setup(coreSetupMock, {} as any);
+    plugin.setup(coreSetupMock, { devTools: devToolsMock } as any);
 
     expect(registerMock).not.toHaveBeenCalledWith(
       expect.objectContaining({ id: 'workloadManagement' })
@@ -101,8 +112,9 @@ describe('QueryInsightsDashboardsPlugin', () => {
   });
 
   it('registers only Query Insights when WLM disabled', () => {
+    const devToolsMock = { register: jest.fn() };
     (WLM_CONFIG as any).enabled = false;
-    plugin.setup(coreSetupMock, {} as any);
+    plugin.setup(coreSetupMock, { devTools: devToolsMock } as any);
 
     const calls = registerMock.mock.calls.map(([app]: any) => ({
       id: app.id,
@@ -114,8 +126,9 @@ describe('QueryInsightsDashboardsPlugin', () => {
   });
 
   it('registers Query Insights and Workload Management when WLM enabled', () => {
+    const devToolsMock = { register: jest.fn() };
     (WLM_CONFIG as any).enabled = true;
-    plugin.setup(coreSetupMock, {} as any);
+    plugin.setup(coreSetupMock, { devTools: devToolsMock } as any);
 
     const calls = registerMock.mock.calls.map(([app]: any) => ({
       id: app.id,
@@ -130,7 +143,8 @@ describe('QueryInsightsDashboardsPlugin', () => {
   });
 
   it('should add navigation links to group', () => {
-    plugin.setup(coreSetupMock, {} as any);
+    const devToolsMock = { register: jest.fn() };
+    plugin.setup(coreSetupMock, { devTools: devToolsMock } as any);
 
     expect(addNavLinksToGroupMock).toHaveBeenCalledWith(DEFAULT_NAV_GROUPS.dataAdministration, [
       {

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -31,6 +31,19 @@ export class QueryInsightsDashboardsPlugin
     core: CoreSetup,
     deps: QueryInsightsDashboardsPluginSetupDependencies
   ): QueryInsightsDashboardsPluginSetup {
+    // Register profiler dev tool - visibility will be controlled in start()
+    deps.devTools.register({
+      id: 'queryProfiler',
+      title: 'Query Profiler',
+      enableRouting: false,
+      mount: async (params) => {
+        const { renderProfiler, setCoreStart } = await import('./pages/Profiler/Profiler');
+        const [coreStart] = await core.getStartServices();
+        setCoreStart(coreStart);
+        return renderProfiler(params.element, (params as any).dataSourceId);
+      },
+    });
+
     // Register an application into the side navigation menu
     core.application.register({
       id: PLUGIN_NAME,

--- a/public/types.ts
+++ b/public/types.ts
@@ -6,6 +6,7 @@
 import { DataSourcePluginStart } from '../../../src/plugins/data_source/public';
 import { DataSourceManagementPluginSetup } from '../../../src/plugins/data_source_management/public';
 import { NavigationPublicPluginStart } from '../../../src/plugins/navigation/public';
+import { DevToolsSetup } from '../../../src/plugins/dev_tools/public';
 
 /* eslint-disable @typescript-eslint/no-empty-interface */
 export interface QueryInsightsDashboardsPluginSetup {}
@@ -15,6 +16,7 @@ export interface QueryInsightsDashboardsPluginStartDependencies {
 }
 export interface QueryInsightsDashboardsPluginSetupDependencies {
   dataSourceManagement?: DataSourceManagementPluginSetup;
+  devTools: DevToolsSetup;
 }
 /* eslint-enable @typescript-eslint/no-empty-interface */
 

--- a/server/clusters/queryInsightsPlugin.ts
+++ b/server/clusters/queryInsightsPlugin.ts
@@ -155,14 +155,19 @@ export const QueryInsightsPlugin = function (Client, config, components) {
 
   queryInsights.getSettings = ca({
     url: {
-      fmt: `_cluster/settings?include_defaults=true`,
+      fmt: `/_cluster/settings`,
+      params: {
+        include_defaults: {
+          type: 'boolean',
+        },
+      },
     },
     method: 'GET',
   });
 
   queryInsights.setSettings = ca({
     url: {
-      fmt: `_cluster/settings`,
+      fmt: `/_cluster/settings`,
     },
     method: 'PUT',
     needBody: true,

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -71,7 +71,7 @@ export class QueryInsightsDashboardsPlugin
     });
 
     // Register server side APIs
-    defineRoutes(router, dataSourceEnabled);
+    defineRoutes(router, dataSourceEnabled, this.logger);
     defineWlmRoutes(router, dataSourceEnabled);
 
     return {};

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -4,10 +4,10 @@
  */
 
 import { schema } from '@osd/config-schema';
-import { IRouter } from '../../../../src/core/server';
+import { IRouter, Logger } from '../../../../src/core/server';
 import { EXPORTER_TYPE } from '../../common/constants';
 
-export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
+export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger: Logger) {
   router.get(
     {
       path: '/api/top_queries',
@@ -239,7 +239,7 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
         if (!dataSourceEnabled || !request.query?.dataSourceId) {
           const client = context.queryInsights_plugin.queryInsightsClient.asScoped(request)
             .callAsCurrentUser;
-          const res = await client('queryInsights.getSettings');
+          const res = await client('queryInsights.getSettings', { include_defaults: true });
           return response.ok({
             body: {
               ok: true,
@@ -250,7 +250,7 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
           const client = context.dataSource.opensearch.legacy.getClient(
             request.query?.dataSourceId
           );
-          const res = await client.callAPI('queryInsights.getSettings', {});
+          const res = await client.callAPI('queryInsights.getSettings', { include_defaults: true });
           return response.ok({
             body: {
               ok: true,
@@ -460,6 +460,80 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
             ok: false,
             error: error.message,
           },
+        });
+      }
+    }
+  );
+
+  router.post(
+    {
+      path: '/api/profiler-proxy',
+      validate: {
+        body: schema.object({
+          method: schema.string({ defaultValue: 'GET' }),
+          path: schema.string({ defaultValue: '_search' }),
+          body: schema.maybe(schema.string()),
+          dataSourceId: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      try {
+        const { method, path, body, dataSourceId } = request.body;
+
+        const ALLOWED_METHODS = ['GET', 'POST'];
+        const normalizedMethod = (method || 'GET').toUpperCase();
+        if (!ALLOWED_METHODS.includes(normalizedMethod)) {
+          return response.badRequest({ body: 'Invalid HTTP method' });
+        }
+        if (!path || path.includes('..') || !path.split('?')[0].endsWith('_search')) {
+          return response.badRequest({ body: 'Only _search paths are allowed' });
+        }
+
+        let parsedBody;
+        if (body) {
+          try {
+            parsedBody = JSON.parse(body);
+          } catch (e) {
+            return response.badRequest({ body: 'Invalid JSON body' });
+          }
+        }
+
+        // OpenSearch supports POST for _search; use POST when body is present to avoid GET-with-body errors
+        const effectiveMethod = parsedBody !== undefined ? 'POST' : normalizedMethod;
+        const effectivePath = path.startsWith('/') ? path : `/${path}`;
+
+        let result;
+
+        if (!dataSourceEnabled || !dataSourceId) {
+          const esClient = context.core.opensearch.client.asCurrentUser;
+          const res = await esClient.transport.request({
+            method: effectiveMethod,
+            path: effectivePath,
+            body: parsedBody,
+          });
+          result = res.body;
+        } else {
+          const client = context.dataSource.opensearch.legacy.getClient(dataSourceId);
+          result = await client.callAPI('transport.request', {
+            method: effectiveMethod,
+            path: effectivePath,
+            body: parsedBody ? JSON.stringify(parsedBody) : undefined,
+          });
+        }
+
+        return response.ok({ body: JSON.stringify(result, null, 2) });
+      } catch (error) {
+        logger.error(`Profiler proxy error: ${error.message}`);
+        // Extract meaningful message from OpenSearch/DataSource error
+        const cause = error.body || error.meta?.body;
+        const osError = cause?.error;
+        const message = osError
+          ? `[${osError.type}] ${osError.reason}`
+          : error.message || 'An error occurred while processing the request';
+        return response.customError({
+          statusCode: error.statusCode || 500,
+          body: { message },
         });
       }
     }

--- a/test/aceSetup.ts
+++ b/test/aceSetup.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Set window.ace before react-ace loads to prevent "window is not defined" error
+global.ace = {
+  edit: () => ({
+    setTheme: () => {},
+    session: { setMode: () => {}, setUseWrapMode: () => {} },
+    setValue: () => {},
+    setOptions: () => {},
+    setReadOnly: () => {},
+    on: () => {},
+    destroy: () => {},
+    setFontSize: () => {},
+    getValue: () => '',
+  }),
+  acequire: () => ({ Range: () => {} }),
+  require: () => ({ Range: () => {} }),
+};

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -5,7 +5,7 @@
 
 module.exports = {
   rootDir: '../',
-  setupFiles: ['<rootDir>/test/setupTests.ts'],
+  setupFiles: ['<rootDir>/test/setupTests.ts', '<rootDir>/test/aceSetup.ts'],
   setupFilesAfterEnv: ['<rootDir>/test/setup.jest.ts'],
   roots: ['<rootDir>'],
   coverageDirectory: './coverage',
@@ -16,10 +16,14 @@ module.exports = {
     '^monaco-editor/esm/vs/editor/editor.api$': '<rootDir>/test/mocks/monaco-editor.ts',
     '^monaco-editor$': '<rootDir>/test/mocks/monaco-editor.ts',
     '^@osd/monaco$': '<rootDir>/test/mocks/monaco-editor.ts',
+    '^brace$': '<rootDir>/test/mocks/brace.js',
+    '^brace/(.*)': '<rootDir>/test/mocks/brace.js',
+    '^react-ace$': '<rootDir>/test/mocks/brace.js',
+    '^react-ace/(.*)': '<rootDir>/test/mocks/brace.js',
+    '^@elastic/eui/lib/components/code_editor(.*)': '<rootDir>/test/mocks/brace.js',
     '^react$': '<rootDir>/../../node_modules/react',
     '^react-dom$': '<rootDir>/../../node_modules/react-dom',
   },
-  transformIgnorePatterns: ['node_modules/(?!(monaco-editor)/)'],
   coverageReporters: ['lcov', 'text', 'cobertura'],
   testMatch: ['**/*.test.js', '**/*.test.jsx', '**/*.test.ts', '**/*.test.tsx'],
   collectCoverageFrom: [
@@ -51,6 +55,6 @@ module.exports = {
     '^.+\\.(js|tsx?)$': '<rootDir>/../../src/dev/jest/babel_transform.js',
   },
   transformIgnorePatterns: [
-    '[/\\\\]node_modules(?![\\/\\\\](monaco-editor|react-monaco-editor))[/\\\\].+\\.js$',
+    '[/\\\\]node_modules(?![\\/\\\\](monaco-editor|react-monaco-editor|react-ace))[/\\\\].+\\.(js|ts|tsx)$',
   ],
 };

--- a/test/mocks/brace.js
+++ b/test/mocks/brace.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const mockEditor = {
+  setTheme: jest.fn(),
+  session: {
+    setMode: jest.fn(),
+    setUseWrapMode: jest.fn(),
+    setUseWorker: jest.fn(),
+  },
+  setValue: jest.fn(),
+  setOptions: jest.fn(),
+  setReadOnly: jest.fn(),
+  on: jest.fn(),
+  destroy: jest.fn(),
+  setFontSize: jest.fn(),
+  getValue: jest.fn(() => ''),
+};
+
+const ace = {
+  edit: jest.fn(() => mockEditor),
+  acequire: jest.fn(() => ({ Range: jest.fn() })),
+  require: jest.fn(() => ({ Range: jest.fn() })),
+  Range: jest.fn(),
+};
+
+Object.defineProperty(exports, '__esModule', { value: true });
+exports.default = ace;

--- a/test/setup.jest.ts
+++ b/test/setup.jest.ts
@@ -14,6 +14,7 @@ window.URL = {
   createObjectURL: () => {
     return '';
   },
+  revokeObjectURL: (_url: string) => {},
 };
 
 // Mock matchMedia for Monaco editor


### PR DESCRIPTION
### Description
Adds a Query Profiler tool to the Query Insights Dashboards plugin, integrated as a Dev Tools tab. The profiler allows users to execute search queries and view detailed OpenSearch profiling output side-by-side in a split-pane editor.

## Changes
**Query Profiler (public/pages/Profiler/Profiler.tsx)**

- Split-pane ACE editor UI — left pane for query input, right pane for profile JSON output
- Play button to execute and profile the query
- Reset button to clear both panes
- Settings flyout: configurable font size and line wrap
- Import flyout: load a query or profile JSON from a .json/.txt file
- Export JSON: download profile output as profile.json

Collapsible input pane when viewing imported profile results

**"Open in Profiler" button (public/pages/QueryDetails/QueryDetails.tsx)**

- Adds a button on the Query Details page that pre-loads the query into the profiler and opens it

**Server-side proxy route (server/routes/index.ts)**

- POST /api/profiler-proxy — proxies _search requests to OpenSearch with profile enabled; supports multi-data-source

**Plugin wiring (public/plugin.ts, public/types.ts)**

- Registers the profiler as a Dev Tools app under the queryProfiler route

Tests & infra

Jest unit tests (public/pages/Profiler/Profiler.test.tsx)

Cypress E2E tests (cypress/e2e/qi/6_profiler.cy.js)

ACE editor mock for Jest (test/mocks/brace.ts, test/aceSetup.ts)

### Screenshots

<img width="1706" height="854" alt="Screenshot 2026-02-25 at 1 48 50 PM" src="https://github.com/user-attachments/assets/1f1107bf-2a63-4974-9ee9-253698e4ee98" />
<img width="1706" height="854" alt="Screenshot 2026-02-25 at 1 48 54 PM" src="https://github.com/user-attachments/assets/e15cbd0f-13b6-4eda-8b04-2c9dc30270b1" />
<img width="1706" height="854" alt="Screenshot 2026-02-25 at 1 49 10 PM" src="https://github.com/user-attachments/assets/fb4f3853-32eb-4e8b-b45a-c640b71c7fae" />
<img width="1706" height="854" alt="Screenshot 2026-02-25 at 1 49 18 PM" src="https://github.com/user-attachments/assets/a3640089-26c8-4f93-8001-a2627ff55117" />
<img width="1706" height="854" alt="Screenshot 2026-02-25 at 1 49 35 PM" src="https://github.com/user-attachments/assets/89b11c53-e2d2-4007-85b0-3dcb6b5c3ec0" />
<img width="1706" height="854" alt="Screenshot 2026-02-25 at 11 47 03 AM" src="https://github.com/user-attachments/assets/fa9e1362-9ef5-4b69-a22b-1a9e4d312594" />
<img width="1706" height="854" alt="Screenshot 2026-02-25 at 11 47 09 AM" src="https://github.com/user-attachments/assets/2dd4c98c-9d27-47a5-86e0-d449119f26ca" />
<img width="1706" height="854" alt="Screenshot 2026-02-25 at 11 47 14 AM" src="https://github.com/user-attachments/assets/46cfc1a9-7d90-4abf-bd3e-5df019e444f9" />

<img width="1702" height="1042" alt="Screenshot 2026-03-09 at 3 13 21 AM" src="https://github.com/user-attachments/assets/a94542b3-7960-44f4-8cdd-b9c2eb2cfbd0" />
<img width="1702" height="1042" alt="Screenshot 2026-03-09 at 3 16 58 AM" src="https://github.com/user-attachments/assets/1bafa9ad-65b6-4484-b1f4-935bc22f3226" />
<img width="1702" height="1042" alt="Screenshot 2026-03-09 at 8 48 32 AM" src="https://github.com/user-attachments/assets/2b13b91e-cbad-4ce0-b8d0-e25a5785e8d7" />


### Issues Resolved
Closes [#104]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
