### PR TITLE
[FIX] pin Gradle wrapper version in cypress workflows to prevent Gradle 9.x download

### DIFF
--- a/.github/workflows/cypress-tests-qi-wlm-interaction.yml
+++ b/.github/workflows/cypress-tests-qi-wlm-interaction.yml
@@ -188,7 +188,7 @@ jobs:
         run: |
           cd OpenSearch-Dashboards
           echo "Waiting for HTTP server..."
-          max_wait=1800
+          max_wait=300
           elapsed=0
           while [ $elapsed -lt $max_wait ]; do
             if curl -s -f http://localhost:5601/api/status > /dev/null 2>&1; then

--- a/.github/workflows/cypress-tests-wlm-no-security.yml
+++ b/.github/workflows/cypress-tests-wlm-no-security.yml
@@ -186,7 +186,7 @@ jobs:
         run: |
           cd OpenSearch-Dashboards
           echo "Waiting for HTTP server..."
-          max_wait=1800
+          max_wait=300
           elapsed=0
           while [ $elapsed -lt $max_wait ]; do
             if curl -s -f http://localhost:5601/api/status > /dev/null 2>&1; then

--- a/.github/workflows/cypress-tests-wlm.yml
+++ b/.github/workflows/cypress-tests-wlm.yml
@@ -187,7 +187,7 @@ jobs:
         run: |
           cd OpenSearch-Dashboards
           echo "Waiting for OpenSearch-Dashboards HTTP server..."
-          max_attempts=150
+          max_attempts=30
           attempt=0
           while [ $attempt -lt $max_attempts ]; do
             code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:5601/api/status || echo "000")

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -229,7 +229,7 @@ jobs:
         run: |
           cd OpenSearch-Dashboards
           echo "Waiting for HTTP server..."
-          max_wait=1800
+          max_wait=300
           elapsed=0
           while [ $elapsed -lt $max_wait ]; do
             if curl -s -f http://localhost:5601/api/status > /dev/null 2>&1; then


### PR DESCRIPTION


### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
