### PR TITLE
fix: Prefix unused caught error variables with underscore to satisfy lint

### DIFF
--- a/public/pages/Profiler/Profiler.tsx
+++ b/public/pages/Profiler/Profiler.tsx
@@ -75,7 +75,7 @@ const ImportFlyout: React.FC<{
         if (importType === 'query') onImportQuery(content);
         else onImportResult(content);
         onClose();
-      } catch (err) {
+      } catch (_err) {
         setError('Failed to read file');
       }
     };

--- a/public/pages/QueryInsights/QueryInsights.test.tsx
+++ b/public/pages/QueryInsights/QueryInsights.test.tsx
@@ -282,7 +282,7 @@ describe('QueryInsights Component', () => {
         ];
         expect(headerTexts).toEqual(expectedHeaders);
       });
-    } catch (error) {
+    } catch (_error) {
       console.log('Skipping filter test - Type filter not available');
     }
   });
@@ -313,7 +313,7 @@ describe('QueryInsights Component', () => {
         ];
         expect(headerTexts).toEqual(expectedHeaders);
       });
-    } catch (error) {
+    } catch (_error) {
       console.log('Skipping filter test - Type filter not available');
     }
   });
@@ -346,7 +346,7 @@ describe('QueryInsights Component', () => {
         ];
         expect(headerTexts).toEqual(expectedHeaders);
       });
-    } catch (error) {
+    } catch (_error) {
       console.log('Skipping filter test - Type filter not available');
     }
   });

--- a/public/pages/QueryInsights/QueryInsights.tsx
+++ b/public/pages/QueryInsights/QueryInsights.tsx
@@ -265,7 +265,7 @@ const QueryInsights = ({
         } else {
           setWlmAvailable(false);
         }
-      } catch (e) {
+      } catch (_e) {
         setQueryInsightWlmNavigationSupported(false);
         setWlmAvailable(false);
       }

--- a/public/pages/WorkloadManagement/WLMMain/WLMMain.tsx
+++ b/public/pages/WorkloadManagement/WLMMain/WLMMain.tsx
@@ -183,7 +183,7 @@ export const WorkloadManagementMain = ({
       const hasValidStructure =
         res && typeof res === 'object' && res.response && Array.isArray(res.response.live_queries);
       setIsQueryInsightsAvailable(hasValidStructure);
-    } catch (error) {
+    } catch (_error) {
       setQueryInsightWlmNavigationSupported(false);
       setIsQueryInsightsAvailable(false);
     }

--- a/public/utils/datasource-utils.ts
+++ b/public/utils/datasource-utils.ts
@@ -63,7 +63,7 @@ export function getDataSourceFromUrl(): DataSourceOption {
   // following block is needed if the dataSource param is set to non-JSON value, say 'undefined'
   try {
     return JSON.parse(dataSourceParam);
-  } catch (e) {
+  } catch (_e) {
     return JSON.parse('{}'); // Return an empty object or some default value if parsing fails
   }
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -494,7 +494,7 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
         if (body) {
           try {
             parsedBody = JSON.parse(body);
-          } catch (e) {
+          } catch (_e) {
             return response.badRequest({ body: 'Invalid JSON body' });
           }
         }


### PR DESCRIPTION
### Description

Prefix unused caught error variables with _ to fix @typescript-eslint/no-unused-vars lint errors.

The .eslintrc.js config requires caughtErrorsIgnorePattern: '^_', but several catch blocks used error or e without referencing them.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
