### PR TITLE
Dynamic search bar

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,4 +1,4 @@
-const { defineConfig } = require('cypress')
+const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
   video: false,
@@ -13,7 +13,7 @@ module.exports = defineConfig({
   // Retry configuration for flaky tests
   retries: {
     runMode: 2,
-    openMode: 0
+    openMode: 0,
   },
   env: {
     openSearchUrl: 'http://localhost:9200',
@@ -32,10 +32,10 @@ module.exports = defineConfig({
         config.responseTimeout = 90000;
         config.pageLoadTimeout = 180000;
       }
-      return require('./cypress/plugins/index.js')(on, config)
+      return require('./cypress/plugins/index.js')(on, config);
     },
     baseUrl: 'http://localhost:5601',
     // Slow down tests slightly to reduce race conditions
     slowTestThreshold: 30000,
   },
-})
+});

--- a/cypress/e2e/qi-wlm-interaction/10_topN_queries_wlm.cy.js
+++ b/cypress/e2e/qi-wlm-interaction/10_topN_queries_wlm.cy.js
@@ -5,16 +5,16 @@
 
 describe('Top N Queries - WLM Available', () => {
   beforeEach(() => {
-    cy.intercept('GET', '/api/top_queries/latency**', {
+    cy.intercept('GET', '**/api/top_queries/latency**', {
       fixture: 'stub_top_queries_query_only.json',
     }).as('latency');
-    cy.intercept('GET', '/api/top_queries/cpu**', {
+    cy.intercept('GET', '**/api/top_queries/cpu**', {
       fixture: 'stub_top_queries_query_only.json',
     }).as('cpu');
-    cy.intercept('GET', '/api/top_queries/memory**', {
+    cy.intercept('GET', '**/api/top_queries/memory**', {
       fixture: 'stub_top_queries_query_only.json',
     }).as('memory');
-    cy.intercept('GET', '/api/_wlm/workload_group', {
+    cy.intercept('GET', '**/api/_wlm/workload_group**', {
       statusCode: 200,
       body: {
         workload_groups: [
@@ -33,7 +33,8 @@ describe('Top N Queries - WLM Available', () => {
   });
 
   it('shows WLM Group column with correct values', () => {
-    cy.contains('WLM Group').should('be.visible');
+    // WLM Group column exists in the table
+    cy.get('.euiBasicTable').last().should('contain.text', 'WLM Group');
     cy.get('.euiBasicTable')
       .last()
       .find('tbody tr')
@@ -43,22 +44,16 @@ describe('Top N Queries - WLM Available', () => {
     cy.get('.euiBasicTable').last().find('tbody tr').eq(2).should('contain', 'Search Team');
   });
 
-  it('has WLM group filter button with options', () => {
-    cy.contains('button.euiFilterButton', 'WLM Group').should('be.visible').click({ force: true });
-    cy.get('.euiSelectableListItem', { timeout: 10000 }).should('exist');
-    cy.contains('.euiSelectableListItem', 'DEFAULT_WORKLOAD_GROUP').should('be.visible');
-    cy.contains('.euiSelectableListItem', 'Analytics Team').should('be.visible');
-    cy.contains('.euiSelectableListItem', 'Search Team').should('be.visible');
-    cy.get('body').click(0, 0);
-  });
-
-  it('filters by DEFAULT_WORKLOAD_GROUP', () => {
-    cy.contains('button.euiFilterButton', 'WLM Group').should('be.visible').click({ force: true });
-    cy.get('.euiSelectableListItem', { timeout: 10000 }).should('exist');
-    cy.contains('.euiSelectableListItem', 'DEFAULT_WORKLOAD_GROUP').click({ force: true });
-    cy.get('body').click(0, 0);
+  it('filters by WLM group using search bar', () => {
+    const searchInput = 'input[placeholder="e.g. latency >= 100 AND type = query"]';
+    cy.get(searchInput).clear({ force: true }).type('wlm_group_id = DEFAULT_WORKLOAD_GROUP');
     cy.wait(300);
     cy.get('.euiBasicTable').last().find('tbody tr').should('have.length', 1);
+    cy.get('.euiBasicTable')
+      .last()
+      .find('tbody tr')
+      .eq(0)
+      .should('contain', 'DEFAULT_WORKLOAD_GROUP');
   });
 
   it('shows WLM group links when mapped', () => {
@@ -81,8 +76,9 @@ describe('Top N Queries - WLM Available', () => {
       .find('button')
       .should('contain', 'Search Team');
   });
+
   it('shows dash for group type records', () => {
-    cy.intercept('GET', '/api/top_queries/latency**', {
+    cy.intercept('GET', '**/api/top_queries/latency**', {
       body: {
         ok: true,
         response: {
@@ -97,7 +93,7 @@ describe('Top N Queries - WLM Available', () => {
         },
       },
     }).as('groupData');
-    cy.intercept('GET', '/api/_wlm/workload_group', {
+    cy.intercept('GET', '**/api/_wlm/workload_group**', {
       statusCode: 200,
       body: { workload_groups: [] },
     }).as('wlmGroups2');
@@ -107,7 +103,7 @@ describe('Top N Queries - WLM Available', () => {
   });
 
   it('shows dash for unmapped wlm_group_id', () => {
-    cy.intercept('GET', '/api/_wlm/workload_group', {
+    cy.intercept('GET', '**/api/_wlm/workload_group**', {
       statusCode: 200,
       body: { workload_groups: [] },
     }).as('wlmGroups3');

--- a/cypress/e2e/qi-wlm-interaction/9_inflight_queries_wlm.cy.js
+++ b/cypress/e2e/qi-wlm-interaction/9_inflight_queries_wlm.cy.js
@@ -45,10 +45,9 @@ describe('Inflight Queries Dashboard - WLM Enabled', () => {
       });
   });
 
-  it('calls different API when WLM group selection changes', () => {
-    cy.get('[aria-label="Workload group selector"]').select('ANALYTICS_WORKLOAD_GROUP');
+  it('filters by WLM group using the dynamic search bar', () => {
+    cy.get('[aria-label="Dynamic search bar"]').type('ANALYTICS_WORKLOAD_GROUP');
     cy.wait('@liveQueries');
-    cy.wait('@wlmStats');
   });
 
   it('displays finished query stats panels', () => {
@@ -72,9 +71,27 @@ describe('Inflight Queries Dashboard - WLM Enabled', () => {
       });
   });
 
-  it('shows workload group selector with mapped names', () => {
-    cy.contains('.euiBadge', 'Workload group').should('be.visible');
-    cy.get('[aria-label="Workload group selector"]').should('be.visible');
+  it('shows dynamic search bar for filtering', () => {
+    cy.get('[aria-label="Dynamic search bar"]').should('be.visible');
+  });
+
+  it('filters by WLM group using structured expression', () => {
+    cy.get('[aria-label="Dynamic search bar"]')
+      .clear()
+      .type('wlm_group = ANALYTICS_WORKLOAD_GROUP');
+    cy.get('tbody tr').each(($row) => {
+      cy.wrap($row).should('contain.text', 'ANALYTICS_WORKLOAD_GROUP');
+    });
+  });
+
+  it('WLM group column links navigate to WLM details', () => {
+    cy.get('table tbody tr')
+      .first()
+      .within(() => {
+        cy.get('button')
+          .contains(/ANALYTICS_WORKLOAD_GROUP|SEARCH_WORKLOAD_GROUP/)
+          .should('exist');
+      });
   });
 
   it('displays status badges in the table', () => {

--- a/cypress/e2e/qi/1_top_queries.cy.js
+++ b/cypress/e2e/qi/1_top_queries.cy.js
@@ -72,171 +72,22 @@ const expectSortedBy = (label) => {
     });
 };
 
-const norm = (s) => (s || '').replace(/\s+/g, ' ').trim().toLowerCase();
-
-const findFilterButton = (labels) => {
-  const candidates = (Array.isArray(labels) ? labels : [labels]).map(norm);
-
-  return cy.get('button.euiFilterButton').then(($btns) => {
-    const found = [...$btns].find((btn) => {
-      const txt = norm(btn.innerText);
-      const aria = norm(btn.getAttribute('aria-label'));
-      const title = norm(btn.getAttribute('title'));
-      const subj = norm(btn.getAttribute('data-test-subj'));
-      return candidates.some(
-        (lab) =>
-          txt.includes(lab) || aria.includes(lab) || title.includes(lab) || subj.includes(lab)
-      );
-    });
-
-    if (!found) {
-      const dump = [...$btns]
-        .map(
-          (el) =>
-            norm(el.innerText) ||
-            norm(el.getAttribute('aria-label')) ||
-            norm(el.getAttribute('title')) ||
-            norm(el.getAttribute('data-test-subj'))
-        )
-        .join(' | ');
-      throw new Error(
-        `Filter button not found. Tried [${candidates.join(', ')}]. Buttons seen: ${dump}`
-      );
-    }
-
-    return cy.wrap(found);
-  });
-};
-
-const openFilter = (labels) => {
-  findFilterButton(labels).scrollIntoView().click();
-  cy.get('.euiSelectableListItem', { timeout: 10000 }).should('exist');
-};
-
-const clearAllOpenFilterOptions = () => {
-  cy.get('.euiSelectableListItem').each(($item) => {
-    // Check if item is selected by looking for the check icon or euiSelectableListItem-isChecked class
-    const hasCheck =
-      $item.find('[data-euiicon-type="check"]').length > 0 ||
-      $item.hasClass('euiSelectableListItem-isChecked') ||
-      $item.attr('aria-checked') === 'true';
-    if (hasCheck) {
-      cy.wrap($item).click();
-    }
-  });
-};
-
-const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-const setListFilter = (buttonLabels, values = []) => {
-  openFilter(buttonLabels);
-  clearAllOpenFilterOptions();
-  values.forEach((label) => {
-    const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    cy.contains('.euiSelectableListItem', new RegExp(`^${esc(label)}$`, 'i'))
-      .scrollIntoView()
-      .click();
-  });
-  cy.get('body').click(0, 0);
-  cy.wait(300);
-};
-
-const setNodeIdFilter = (nodeIds = []) => setListFilter(['Coordinator Node ID'], nodeIds);
-const setSearchTypeFilter = (types = []) => setListFilter(['Search Type'], types);
-const setIndicesFilter = (indices = []) => setListFilter(['Indices'], indices);
-
 const setTypeFilter = (mode /* 'query' | 'group' | 'both' */) => {
-  // Click the Type filter button (in the filter group, not visualization toggle)
-  findFilterButton(['Type']).click();
-  cy.get('.euiSelectableListItem', { timeout: 10000 }).should('exist');
-
-  const ensureToggle = (label, shouldBeOn) => {
-    cy.contains('.euiSelectableListItem', new RegExp(`^${esc(label)}$`, 'i')).then(($item) => {
-      // SVG with path = checked, empty SVG = unchecked
-      const isOn = $item.find('svg path').length > 0;
-      if (isOn !== shouldBeOn) {
-        cy.wrap($item).click();
-      }
-    });
-  };
-
+  const searchInput = `input[placeholder="e.g. latency >= 100 AND type = query"]`;
+  cy.get(searchInput).clear({ force: true });
   if (mode === 'query') {
-    ensureToggle('query', true);
-    ensureToggle('group', false);
+    cy.get(searchInput).type('type = query', { force: true });
   } else if (mode === 'group') {
-    ensureToggle('query', false);
-    ensureToggle('group', true);
-  } else {
-    ensureToggle('query', true);
-    ensureToggle('group', true);
+    cy.get(searchInput).type('type = group', { force: true });
   }
-  cy.get('body').click(0, 0);
   cy.wait(300);
 };
 
 const resetTypeFilterToNone = () => {
-  // Click the Type filter button to open the popover
-  findFilterButton(['Type']).click();
-  cy.get('.euiSelectableListItem', { timeout: 10000 }).should('exist');
-
-  // Only click items where SVG has content (path element = checked)
-  cy.contains('.euiSelectableListItem', /^query$/i).then(($item) => {
-    if ($item.find('svg path').length > 0) {
-      cy.wrap($item).click();
-    }
-  });
-
-  cy.contains('.euiSelectableListItem', /^group$/i).then(($item) => {
-    if ($item.find('svg path').length > 0) {
-      cy.wrap($item).click();
-    }
-  });
-
-  cy.get('body').click(0, 0);
-  cy.wait(500);
+  const searchInput = `input[placeholder="e.g. latency >= 100 AND type = query"]`;
+  cy.get(searchInput).clear({ force: true });
+  cy.wait(300);
 };
-
-const deriveExpectations = (payload, type = 'all') => {
-  const allRows = getRowsFromRaw(payload);
-
-  let rows = allRows;
-  if (type === 'query') {
-    rows = allRows.filter((r) => String(r.group_by).toUpperCase() === 'NONE');
-  } else if (type === 'group') {
-    rows = allRows.filter((r) => String(r.group_by).toUpperCase() !== 'NONE');
-  }
-
-  const uniq = (arr) => [...new Set(arr)];
-  const countBy = (items, keyFn) =>
-    items.reduce((acc, item) => {
-      const k = keyFn(item);
-      if (Array.isArray(k)) {
-        k.filter(Boolean).forEach((kk) => {
-          acc[kk] = (acc[kk] || 0) + 1;
-        });
-      } else if (k) {
-        acc[k] = (acc[k] || 0) + 1;
-      }
-      return acc;
-    }, {});
-
-  const nodeIds = uniq(rows.map((r) => r.node_id).filter(Boolean));
-  const indexNames = uniq(rows.flatMap((r) => r.indices || []).filter(Boolean));
-  const searchTypes = uniq(rows.map((r) => r.search_type).filter(Boolean));
-
-  return {
-    appliedType: type,
-    rows,
-    totalRowCount: rows.length,
-    nodeIds,
-    nodeIdCounts: countBy(rows, (r) => r.node_id),
-    indexNames,
-    indexCounts: countBy(rows, (r) => r.indices || []),
-    searchTypes,
-    searchTypeCounts: countBy(rows, (r) => r.search_type),
-  };
-};
-
 const indexName = 'sample_index';
 
 /**
@@ -539,150 +390,6 @@ describe('Query Insights — Dynamic Columns (GROUP ONLY fixture)', () => {
   });
 });
 
-describe('Query Insights — Filters and Search', () => {
-  let expected;
-  let expectingAll;
-  let primaryNodeId;
-  let secondaryNodeId;
-  let primaryIndexName;
-  let secondaryIndexName;
-  let defaultSearchType;
-
-  before(() => {
-    // derive expectations from query-only payload
-    expected = deriveExpectations(MIXED, 'query');
-    expectingAll = deriveExpectations(MIXED);
-    [primaryNodeId, secondaryNodeId] = expected.nodeIds;
-    [primaryIndexName, secondaryIndexName] = expected.indexNames;
-    [defaultSearchType] = expected.searchTypes;
-  });
-
-  beforeEach(() => {
-    // intercept with ONLY query rows, plus fresh timestamps
-    cy.intercept('GET', '**/api/top_queries/**', (req) => {
-      req.reply({ statusCode: 200, body: makeTimestampedBody(MIXED) });
-    }).as('topQueries');
-
-    cy.waitForQueryInsightsPlugin();
-    cy.wait('@topQueries');
-  });
-
-  it('filters by Node ID', () => {
-    if (primaryNodeId) {
-      setNodeIdFilter([primaryNodeId]);
-      assertRowCountEquals(expected.nodeIdCounts[primaryNodeId]);
-      cy.get('.euiBasicTable')
-        .last()
-        .find('.euiTableRow')
-        .each(($r) => cy.wrap($r).contains('td', primaryNodeId));
-    }
-    setNodeIdFilter([primaryNodeId]); // clear
-
-    if (secondaryNodeId) {
-      setNodeIdFilter([secondaryNodeId]);
-      assertRowCountEquals(expected.nodeIdCounts[secondaryNodeId]);
-      cy.get('.euiBasicTable')
-        .last()
-        .find('.euiTableRow')
-        .each(($r) => cy.wrap($r).contains('td', secondaryNodeId));
-    }
-    setNodeIdFilter([secondaryNodeId]); // clear
-    assertRowCountEquals(expectingAll.totalRowCount);
-  });
-
-  it('filters by Search Type', () => {
-    if (defaultSearchType) {
-      setSearchTypeFilter([defaultSearchType]);
-      assertRowCountEquals(expected.searchTypeCounts[defaultSearchType]);
-      cy.get('.euiBasicTable')
-        .last()
-        .find('.euiTableRow')
-        .each(($r) => cy.wrap($r).contains('td', 'query then fetch'));
-    }
-    setSearchTypeFilter([defaultSearchType]);
-
-    assertRowCountEquals(expectingAll.totalRowCount);
-  });
-
-  it('filters by Indices', () => {
-    if (primaryIndexName) {
-      setIndicesFilter([primaryIndexName]);
-      assertRowCountEquals(expected.indexCounts[primaryIndexName]);
-      cy.get('.euiBasicTable')
-        .last()
-        .find('.euiTableRow')
-        .each(($r) => cy.wrap($r).contains('td', primaryIndexName));
-    }
-    setIndicesFilter([primaryIndexName]);
-
-    if (secondaryIndexName) {
-      setIndicesFilter([secondaryIndexName]);
-      assertRowCountEquals(expected.indexCounts[secondaryIndexName]);
-      cy.get('.euiBasicTable')
-        .last()
-        .find('.euiTableRow')
-        .each(($r) => cy.wrap($r).contains('td', secondaryIndexName));
-    }
-    setIndicesFilter([secondaryIndexName]);
-
-    const both = [primaryIndexName, secondaryIndexName].filter(Boolean);
-    if (both.length > 1) {
-      setIndicesFilter(both);
-      assertRowCountEquals(expected.totalRowCount);
-    }
-
-    setIndicesFilter([]); // clear
-    assertRowCountEquals(expected.totalRowCount);
-  });
-
-  it('updates search box when filter is selected', () => {
-    resetTypeFilterToNone();
-    cy.get('.euiFieldSearch').should('have.value', '');
-    setTypeFilter('query');
-    cy.get('.euiFieldSearch').should('contain.value', 'group_by');
-  });
-
-  it('clears search box when filters are cleared', () => {
-    setTypeFilter('query');
-    cy.get('.euiFieldSearch').should('not.have.value', '');
-    resetTypeFilterToNone();
-    cy.get('.euiFieldSearch').should('have.value', '');
-  });
-
-  it('filters by query ID in free-text search', () => {
-    // a2e1c822 matches 2 queries in fixture
-    cy.get('.euiFieldSearch').clear({ force: true }).type('a2e1c822');
-    cy.get('.euiBasicTable').last().find('.euiTableRow').should('have.length', 2);
-  });
-
-  it('filters by index name in free-text search', () => {
-    // my-index only appears in one query (group_by: NONE)
-    cy.get('.euiFieldSearch').clear({ force: true }).type('my-index');
-    cy.get('.euiBasicTable').last().find('.euiTableRow').should('have.length', 1);
-    cy.get('.euiBasicTable').last().find('.euiTableRow').should('contain', 'my-index');
-  });
-
-  it('filters by node ID in free-text search', () => {
-    // UYKFun8 appears in 2 queries (1 NONE, 1 SIMILARITY) - free-text filters to NONE only
-    cy.get('.euiFieldSearch').clear({ force: true }).type('UYKFun8');
-    cy.get('.euiBasicTable').last().find('.euiTableRow').should('have.length', 2);
-  });
-
-  it('shows no results for non-matching free-text search', () => {
-    cy.get('.euiFieldSearch').clear({ force: true }).type('nonexistent_xyz_123');
-    cy.get('.euiBasicTable').last().contains('No items found').should('be.visible');
-  });
-
-  it('combines free-text search with filter selection', () => {
-    setTypeFilter('query');
-    // .kibana appears in all queries
-    cy.get('.euiFieldSearch').type(' kibana', { force: true });
-    cy.get('.euiBasicTable').last().find('.euiTableRow').should('have.length.greaterThan', 0);
-    cy.get('.euiFieldSearch').should('contain.value', 'group_by');
-    cy.get('.euiFieldSearch').should('contain.value', 'kibana');
-  });
-});
-
 describe('Query Insights — Stats & Visualizations Panel', () => {
   beforeEach(() => {
     cy.intercept('GET', '**/api/top_queries/**', (req) => {
@@ -850,5 +557,114 @@ describe('Query Insights — Stats & Visualizations Panel', () => {
       cy.get('@perfPanel').find('.euiButtonGroup').contains('Line Chart').click();
       cy.get('@perfPanel').find('select').should('have.length', 1);
     });
+  });
+});
+
+describe('Query Insights — DynamicSearchBar', () => {
+  const SEARCH_PLACEHOLDER = 'e.g. latency >= 100 AND type = query';
+
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/top_queries/**', (req) => {
+      req.reply({ statusCode: 200, body: makeTimestampedBody(MIXED) });
+    }).as('topQueries');
+
+    cy.waitForQueryInsightsPlugin();
+    cy.wait('@topQueries');
+  });
+
+  it('renders the search bar with correct placeholder', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`).should('be.visible');
+  });
+
+  it('shows field suggestions when focused', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`).click();
+    cy.get('[role="option"]').should('have.length.greaterThan', 0);
+    cy.get('[role="option"]').first().should('contain.text', 'id');
+  });
+
+  it('shows operator suggestions after typing a field name and space', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`).clear().type('latency ');
+    cy.get('[role="option"]').should('have.length.greaterThan', 0);
+    cy.get('[role="option"]').should('contain.text', '=');
+    cy.get('[role="option"]').should('contain.text', '>=');
+    cy.get('[role="option"]').should('contain.text', 'between');
+  });
+
+  it('shows string operators for string fields', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`).clear().type('search_type ');
+    cy.get('[role="option"]').should('contain.text', '=');
+    cy.get('[role="option"]').should('contain.text', 'starts_with');
+    cy.get('[role="option"]').should('contain.text', 'ends_with');
+    cy.get('[role="option"]').should('contain.text', 'contains');
+  });
+
+  it('shows value suggestions after typing field and operator', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`).clear().type('search_type = ');
+    cy.get('[role="option"]').should('have.length.greaterThan', 0);
+  });
+
+  it('shows conjunction suggestions after a complete condition', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`)
+      .clear()
+      .type('search_type = query_then_fetch ');
+    cy.get('[role="option"]').should('contain.text', 'AND');
+    cy.get('[role="option"]').should('contain.text', 'OR');
+  });
+
+  it('filters table by free text search', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`).clear().type('a2e1c822');
+    cy.get('.euiBasicTable').last().find('.euiTableRow').should('have.length.greaterThan', 0);
+  });
+
+  it('filters table by field = value expression', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`)
+      .clear()
+      .type('search_type = query_then_fetch');
+    cy.get('.euiBasicTable').last().find('.euiTableRow').should('have.length.greaterThan', 0);
+    cy.get('.euiBasicTable')
+      .last()
+      .find('.euiTableRow')
+      .first()
+      .should('contain.text', 'query then fetch');
+  });
+
+  it('shows filter badges for active conditions', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`)
+      .clear()
+      .type('search_type = query_then_fetch ');
+    cy.get('.euiBadge').contains('search_type').should('exist');
+  });
+
+  it('removes filter when badge X is clicked', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`)
+      .clear()
+      .type('search_type = query_then_fetch ');
+    cy.get('.euiBadge')
+      .contains('search_type')
+      .closest('.euiBadge')
+      .find('button, [role="img"], svg')
+      .last()
+      .click({ force: true });
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`).should('have.value', '');
+  });
+
+  it('supports AND conjunction between conditions', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`)
+      .clear()
+      .type('search_type = query_then_fetch AND node_id = ');
+    cy.get('[role="option"]').should('have.length.greaterThan', 0);
+  });
+
+  it('auto-formats between expression with parentheses', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`).clear().type('latency between 100 500 ');
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`).should(
+      'have.value',
+      'latency between (100, 500) '
+    );
+  });
+
+  it('shows no items when filter matches nothing', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`).clear().type('id = nonexistent_xyz_123');
+    cy.get('.euiBasicTable').last().contains('No items found').should('be.visible');
   });
 });

--- a/cypress/e2e/qi/5_live_queries.cy.js
+++ b/cypress/e2e/qi/5_live_queries.cy.js
@@ -202,13 +202,13 @@ describe('Inflight Queries Dashboard', () => {
     cy.contains('p', 'Active Queries by Node')
       .closest('.euiPanel')
       .within(() => {
-        cy.contains('No data available').should('be.visible');
+        cy.contains('No Visualization Available').should('be.visible');
       });
 
     cy.contains('p', 'Active Queries by Index')
       .closest('.euiPanel')
       .within(() => {
-        cy.contains('No data available').should('be.visible');
+        cy.contains('No Visualization Available').should('be.visible');
       });
   });
 
@@ -235,9 +235,8 @@ describe('Inflight Queries Dashboard', () => {
     });
   });
 
-  it('filters table to show only "opensearch" index queries', () => {
-    cy.contains('button', 'Index').click();
-    cy.contains('[role="option"]', 'opensearch').click();
+  it('filters table using the dynamic search bar', () => {
+    cy.get('[aria-label="Dynamic search bar"]').type('opensearch');
     cy.get('tbody tr').should('have.length', 1);
     cy.get('tbody tr')
       .first()
@@ -246,13 +245,75 @@ describe('Inflight Queries Dashboard', () => {
       });
   });
 
-  it('shows a grey "Workload group" badge with a dropdown next to it', () => {
-    cy.contains('.euiBadge', 'Workload group').should('be.visible');
-    cy.contains('.euiBadge', 'Workload group')
-      .parent()
-      .next()
-      .find('select, .euiSelect')
-      .should('exist');
+  it('filters table by task ID using structured expression', () => {
+    cy.fixture('stub_live_queries.json').then((data) => {
+      const firstRunningQuery = data.response.live_queries.find((q) => !q.is_cancelled);
+      cy.get('[aria-label="Dynamic search bar"]').clear().type(`id = ${firstRunningQuery.id}`);
+      cy.get('tbody tr').should('have.length', 1);
+      cy.get('tbody tr').first().contains(firstRunningQuery.id);
+    });
+  });
+
+  it('renders the search bar with correct placeholder', () => {
+    cy.get('input[placeholder="e.g. latency >= 1 AND status = Running"]').should('be.visible');
+  });
+
+  it('shows field suggestions when search bar is focused', () => {
+    cy.get('[aria-label="Dynamic search bar"]').click();
+    cy.get('[role="option"]').should('have.length.greaterThan', 0);
+    cy.get('[role="option"]').first().should('contain.text', 'id');
+  });
+
+  it('shows operator suggestions after typing a field name and space', () => {
+    cy.get('[aria-label="Dynamic search bar"]').clear().type('latency ');
+    cy.get('[role="option"]').should('have.length.greaterThan', 0);
+    cy.get('[role="option"]').should('contain.text', '=');
+    cy.get('[role="option"]').should('contain.text', '>=');
+    cy.get('[role="option"]').should('contain.text', 'between');
+  });
+
+  it('shows string operators for string fields', () => {
+    cy.get('[aria-label="Dynamic search bar"]').clear().type('search_type ');
+    cy.get('[role="option"]').should('contain.text', '=');
+    cy.get('[role="option"]').should('contain.text', 'starts_with');
+    cy.get('[role="option"]').should('contain.text', 'contains');
+  });
+
+  it('shows value suggestions after typing field and operator', () => {
+    cy.get('[aria-label="Dynamic search bar"]').clear().type('search_type = ');
+    cy.get('[role="option"]').should('have.length.greaterThan', 0);
+  });
+
+  it('shows conjunction suggestions after a complete condition', () => {
+    cy.get('[aria-label="Dynamic search bar"]').clear().type('id = somevalue ');
+    cy.get('[role="option"]').should('contain.text', 'AND');
+    cy.get('[role="option"]').should('contain.text', 'OR');
+  });
+
+  it('shows filter badges for active conditions', () => {
+    cy.get('[aria-label="Dynamic search bar"]').clear().type('status = Running ');
+    cy.get('.euiBadge').contains('status').should('exist');
+  });
+
+  it('removes filter when badge X is clicked', () => {
+    cy.get('[aria-label="Dynamic search bar"]').clear().type('status = Running ');
+    cy.get('.euiBadge')
+      .contains('status')
+      .closest('.euiBadge')
+      .find('button, [role="img"], svg')
+      .last()
+      .click({ force: true });
+    cy.get('[aria-label="Dynamic search bar"]').should('have.value', '');
+  });
+
+  it('auto-formats between expression with parentheses', () => {
+    cy.get('[aria-label="Dynamic search bar"]').clear().type('latency between 1 10 ');
+    cy.get('[aria-label="Dynamic search bar"]').should('have.value', 'latency between (1, 10) ');
+  });
+
+  it('shows no items when filter matches nothing', () => {
+    cy.get('[aria-label="Dynamic search bar"]').clear().type('id = nonexistent_xyz_123');
+    cy.contains('No items found').should('be.visible');
   });
 
   it('displays WLM group as text when WLM is disabled', () => {

--- a/public/components/DynamicSearchBar.tsx
+++ b/public/components/DynamicSearchBar.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useRef, useCallback, useMemo } from 'react';
-import { EuiFieldSearch, EuiText, EuiBadge } from '@elastic/eui';
+import { EuiFieldSearch, EuiText, EuiBadge, EuiPanel } from '@elastic/eui';
 import { SearchQueryRecord } from '../../types/types';
 
 // --- Field definitions ---
@@ -176,7 +176,7 @@ function compareValues(
     const target = targetStr.toLowerCase();
     if (operator === '=') return arr.some((v: any) => String(v).toLowerCase() === target);
     if (operator === '!=') return !arr.some((v: any) => String(v).toLowerCase() === target);
-    return true;
+    return false;
   }
 
   if (fieldType === 'number') {
@@ -212,7 +212,7 @@ function compareValues(
         return false;
       }
       default:
-        return true;
+        return false;
     }
   }
 
@@ -223,7 +223,7 @@ function compareValues(
       targetStr.toLowerCase() === 'true' || targetStr.toLowerCase() === 'completed';
     if (operator === '=') return boolVal === boolTarget;
     if (operator === '!=') return boolVal !== boolTarget;
-    return true;
+    return false;
   }
 
   // string comparison
@@ -234,7 +234,7 @@ function compareValues(
   if (operator === 'starts_with') return strVal.startsWith(strTarget);
   if (operator === 'ends_with') return strVal.endsWith(strTarget);
   if (operator === 'contains') return strVal.includes(strTarget);
-  return true;
+  return false;
 }
 
 // --- Autocomplete state machine ---
@@ -508,7 +508,6 @@ export const DynamicSearchBar: React.FC<DynamicSearchBarProps> = ({
         onChange={(e) => handleChange(e.target.value)}
         onFocus={handleFocus}
         onBlur={() => setTimeout(() => setIsOpen(false), 200)}
-        compressed
         fullWidth
         aria-label="Dynamic search bar"
       />
@@ -524,26 +523,37 @@ export const DynamicSearchBar: React.FC<DynamicSearchBarProps> = ({
                 iconType="cross"
                 iconSide="right"
                 iconOnClick={() => {
-                  // Remove this condition from the expression
+                  // Remove this condition and its adjacent conjunction from the expression.
+                  // Split into alternating [cond, conj, cond, conj, cond, ...] tokens.
                   const parts = value.split(/\s+(AND|OR)\s+/i);
-                  const newParts: string[] = [];
-                  let condIdx = 0;
+                  const conditions: string[] = [];
+                  const conjunctions: string[] = [];
                   for (const part of parts) {
                     if (/^(AND|OR)$/i.test(part)) {
-                      newParts.push(part);
+                      conjunctions.push(part);
                     } else {
-                      if (condIdx !== i) newParts.push(part);
-                      condIdx++;
+                      conditions.push(part);
                     }
                   }
-                  // Clean up dangling conjunctions
-                  const cleaned = newParts.filter((p, idx) => {
-                    if (/^(AND|OR)$/i.test(p)) {
-                      return idx > 0 && idx < newParts.length - 1;
+                  // Remove the condition at index i
+                  conditions.splice(i, 1);
+                  // Remove the adjacent conjunction:
+                  // - If removing a middle/last condition, remove the conjunction before it
+                  // - If removing the first condition, remove the conjunction after it
+                  if (i > 0) {
+                    conjunctions.splice(i - 1, 1);
+                  } else if (conjunctions.length > 0) {
+                    conjunctions.splice(0, 1);
+                  }
+                  // Rebuild: interleave conditions with conjunctions
+                  const result: string[] = [];
+                  conditions.forEach((cond, idx) => {
+                    if (idx > 0 && conjunctions[idx - 1]) {
+                      result.push(conjunctions[idx - 1]);
                     }
-                    return true;
+                    result.push(cond);
                   });
-                  onChange(cleaned.join(' ').trim());
+                  onChange(result.join(' ').trim());
                 }}
                 iconOnClickAriaLabel={`Remove filter ${c.field} ${c.operator} ${c.value}`}
               >
@@ -561,19 +571,16 @@ export const DynamicSearchBar: React.FC<DynamicSearchBarProps> = ({
         </div>
       )}
       {isOpen && suggestions.length > 0 && (
-        <div
+        <EuiPanel
+          paddingSize="none"
           style={{
             position: 'absolute',
             top: '100%',
             left: 0,
             right: 0,
             zIndex: 9999,
-            background: '#fff',
-            border: '1px solid #D4DAE5',
-            borderRadius: 4,
             maxHeight: 200,
             overflowY: 'auto',
-            boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
           }}
         >
           {suggestions.map((s, idx) => (
@@ -585,7 +592,6 @@ export const DynamicSearchBar: React.FC<DynamicSearchBarProps> = ({
               style={{
                 padding: '6px 12px',
                 cursor: 'pointer',
-                borderBottom: idx < suggestions.length - 1 ? '1px solid #f0f0f0' : 'none',
               }}
               onMouseDown={(e) => {
                 e.preventDefault();
@@ -598,14 +604,14 @@ export const DynamicSearchBar: React.FC<DynamicSearchBarProps> = ({
               <EuiText size="s">
                 <span>{s.label}</span>
                 {s.description && (
-                  <span style={{ color: '#98A2B3', marginLeft: 8, fontSize: '0.85em' }}>
+                  <EuiText size="xs" color="subdued" component="span" style={{ marginLeft: 8 }}>
                     {s.description}
-                  </span>
+                  </EuiText>
                 )}
               </EuiText>
             </div>
           ))}
-        </div>
+        </EuiPanel>
       )}
     </div>
   );

--- a/public/components/DynamicSearchBar.tsx
+++ b/public/components/DynamicSearchBar.tsx
@@ -1,0 +1,612 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useRef, useCallback, useMemo } from 'react';
+import { EuiFieldSearch, EuiText, EuiBadge } from '@elastic/eui';
+import { SearchQueryRecord } from '../../types/types';
+
+// --- Field definitions ---
+export interface FieldDef {
+  /** Display label shown in autocomplete */
+  label: string;
+  /** Internal key used in the expression */
+  key: string;
+  /** How to extract the value from a SearchQueryRecord */
+  accessor: (q: SearchQueryRecord) => any;
+  /** Field type determines available operators */
+  type: 'string' | 'number' | 'array' | 'boolean';
+  /** Unit label for display (e.g., 'ms', 'B') */
+  unit?: string;
+}
+
+const OPERATORS_BY_TYPE: Record<string, Array<{ label: string; description: string }>> = {
+  number: [
+    { label: '=', description: 'equals' },
+    { label: '!=', description: 'not equals' },
+    { label: '>', description: 'greater than' },
+    { label: '<', description: 'less than' },
+    { label: '>=', description: 'greater or equal' },
+    { label: '<=', description: 'less or equal' },
+    { label: 'between', description: 'between two values e.g. (10, 100)' },
+  ],
+  string: [
+    { label: '=', description: 'equals' },
+    { label: '!=', description: 'not equals' },
+    { label: 'starts_with', description: 'starts with' },
+    { label: 'ends_with', description: 'ends with' },
+    { label: 'contains', description: 'contains substring' },
+  ],
+  array: [
+    { label: '=', description: 'contains' },
+    { label: '!=', description: 'does not contain' },
+  ],
+  boolean: [
+    { label: '=', description: 'equals' },
+    { label: '!=', description: 'not equals' },
+  ],
+};
+
+// --- Expression parser ---
+export interface FilterCondition {
+  field: string;
+  operator: string;
+  value: string;
+}
+
+export interface ParsedExpression {
+  conditions: FilterCondition[];
+  conjunctions: Array<'AND' | 'OR'>;
+  freeText: string;
+}
+
+export function parseExpression(input: string): ParsedExpression {
+  const conditions: FilterCondition[] = [];
+  const conjunctions: Array<'AND' | 'OR'> = [];
+  let freeText = '';
+
+  if (!input.trim()) return { conditions, conjunctions, freeText };
+
+  // Split by AND/OR (case-insensitive), keeping the conjunction
+  const parts = input.split(/\s+(AND|OR)\s+/i);
+  const tokens: string[] = [];
+  const conjs: Array<'AND' | 'OR'> = [];
+
+  for (let i = 0; i < parts.length; i++) {
+    const p = parts[i].trim();
+    if (/^(AND|OR)$/i.test(p)) {
+      conjs.push(p.toUpperCase() as 'AND' | 'OR');
+    } else if (p) {
+      tokens.push(p);
+    }
+  }
+
+  const opRegex = /^(.+?)\s*(!=|>=|<=|>|<|=|starts_with|ends_with|contains|between)\s+(.+)$/i;
+  const freeTextParts: string[] = [];
+
+  for (const token of tokens) {
+    const match = opRegex.exec(token);
+    if (match) {
+      conditions.push({
+        field: match[1].trim(),
+        operator: match[2].toLowerCase(),
+        value: match[3].trim(),
+      });
+    } else {
+      // Try simple operator pattern (=, !=, etc. without space)
+      const simpleMatch = /^(.+?)\s*(!=|>=|<=|>|<|=)\s*(.+)$/.exec(token);
+      if (simpleMatch) {
+        conditions.push({
+          field: simpleMatch[1].trim(),
+          operator: simpleMatch[2],
+          value: simpleMatch[3].trim(),
+        });
+      } else {
+        freeTextParts.push(token);
+      }
+    }
+  }
+
+  // Align conjunctions with conditions (there should be one fewer conjunction than conditions)
+  for (let i = 0; i < conditions.length - 1 && i < conjs.length; i++) {
+    conjunctions.push(conjs[i]);
+  }
+
+  freeText = freeTextParts.join(' ').trim();
+  return { conditions, conjunctions, freeText };
+}
+
+export function evaluateExpression(
+  query: SearchQueryRecord,
+  parsed: ParsedExpression,
+  fieldMap: Map<string, FieldDef>
+): boolean {
+  if (parsed.conditions.length === 0 && !parsed.freeText) return true;
+
+  // Evaluate free text
+  if (parsed.freeText) {
+    const text = parsed.freeText.toLowerCase();
+    const searchable = Object.values(query)
+      .map((v) => {
+        if (v == null) return '';
+        if (typeof v === 'string') return v;
+        if (typeof v === 'number') return String(v);
+        if (Array.isArray(v)) return v.join(' ');
+        if (typeof v === 'object') return JSON.stringify(v);
+        return '';
+      })
+      .join(' ')
+      .toLowerCase();
+    if (!searchable.includes(text)) return false;
+  }
+
+  if (parsed.conditions.length === 0) return true;
+
+  // Evaluate conditions
+  const results = parsed.conditions.map((cond) => {
+    const fieldDef = fieldMap.get(cond.field.toLowerCase());
+    if (!fieldDef) return true; // unknown field, skip
+
+    const rawValue = fieldDef.accessor(query);
+    return compareValues(rawValue, cond.operator, cond.value, fieldDef.type);
+  });
+
+  // Combine with conjunctions (default AND)
+  let result = results[0];
+  for (let i = 1; i < results.length; i++) {
+    const conj = parsed.conjunctions[i - 1] || 'AND';
+    if (conj === 'AND') result = result && results[i];
+    else result = result || results[i];
+  }
+
+  return result;
+}
+
+function compareValues(
+  rawValue: any,
+  operator: string,
+  targetStr: string,
+  fieldType: string
+): boolean {
+  if (rawValue == null) return operator === '!=';
+
+  if (fieldType === 'array') {
+    const arr = Array.isArray(rawValue) ? rawValue : [rawValue];
+    const target = targetStr.toLowerCase();
+    if (operator === '=') return arr.some((v: any) => String(v).toLowerCase() === target);
+    if (operator === '!=') return !arr.some((v: any) => String(v).toLowerCase() === target);
+    return true;
+  }
+
+  if (fieldType === 'number') {
+    const numVal = typeof rawValue === 'number' ? rawValue : parseFloat(String(rawValue));
+    const numTarget = parseFloat(targetStr);
+    switch (operator) {
+      case '=':
+        return numVal === numTarget;
+      case '!=':
+        return numVal !== numTarget;
+      case '>':
+        return numVal > numTarget;
+      case '<':
+        return numVal < numTarget;
+      case '>=':
+        return numVal >= numTarget;
+      case '<=':
+        return numVal <= numTarget;
+      case 'between': {
+        // Format: "(10, 100)" or "10..100" or "10,100" or "10 100"
+        const cleaned = targetStr.replace(/[()]/g, '').trim();
+        const parts = cleaned
+          .split(/\.\.|,|\s+/)
+          .map((s) => s.trim())
+          .filter((s) => s);
+        if (parts.length === 2) {
+          const low = parseFloat(parts[0]);
+          const high = parseFloat(parts[1]);
+          if (!isNaN(low) && !isNaN(high)) {
+            return numVal >= low && numVal <= high;
+          }
+        }
+        return false;
+      }
+      default:
+        return true;
+    }
+  }
+
+  if (fieldType === 'boolean') {
+    const boolVal =
+      typeof rawValue === 'boolean' ? rawValue : String(rawValue).toLowerCase() === 'true';
+    const boolTarget =
+      targetStr.toLowerCase() === 'true' || targetStr.toLowerCase() === 'completed';
+    if (operator === '=') return boolVal === boolTarget;
+    if (operator === '!=') return boolVal !== boolTarget;
+    return true;
+  }
+
+  // string comparison
+  const strVal = String(rawValue).toLowerCase();
+  const strTarget = targetStr.toLowerCase();
+  if (operator === '=') return strVal === strTarget;
+  if (operator === '!=') return strVal !== strTarget;
+  if (operator === 'starts_with') return strVal.startsWith(strTarget);
+  if (operator === 'ends_with') return strVal.endsWith(strTarget);
+  if (operator === 'contains') return strVal.includes(strTarget);
+  return true;
+}
+
+// --- Autocomplete state machine ---
+type SuggestionPhase = 'field' | 'operator' | 'value' | 'conjunction' | 'none';
+
+function detectPhase(
+  input: string,
+  fieldMap: Map<string, FieldDef>
+): {
+  phase: SuggestionPhase;
+  currentField?: FieldDef;
+  partial: string;
+} {
+  if (!input.trim()) return { phase: 'field', partial: '' };
+
+  // After a complete condition, suggest conjunction
+  const lastConjMatch = input.match(/\s+(AND|OR)\s*$/i);
+  if (lastConjMatch) return { phase: 'field', partial: '' };
+
+  // Check if we just finished a value (has field op value pattern at end)
+  // First check for conditions after the last AND/OR
+  const lastConjIdx = input.search(/\s+(AND|OR)\s+(?!.*\s+(AND|OR)\s+)/i);
+  const relevantInput =
+    lastConjIdx >= 0 ? input.substring(lastConjIdx).replace(/^\s*(AND|OR)\s+/i, '') : input;
+
+  const condPattern = /^(.+?)\s*(!=|>=|<=|>|<|=|starts_with|ends_with|contains|between)\s+(.+?)\s*$/i;
+  const condMatch = condPattern.exec(relevantInput.trim());
+  if (condMatch) {
+    const val = condMatch[3].trim();
+    const op = condMatch[2].toLowerCase();
+    const fieldName = condMatch[1].trim().split(/\s+/).pop()?.toLowerCase() || '';
+    // For between, check if we have two numbers
+    if (op === 'between') {
+      const cleaned = val.replace(/[()]/g, '').trim();
+      const nums = cleaned.split(/\.\.|,|\s+/).filter((s) => s && !isNaN(Number(s)));
+      if (nums.length >= 2) {
+        return { phase: 'conjunction', partial: '' };
+      }
+      // Only one number typed — suggest second value
+      const fieldDef = fieldMap.get(fieldName);
+      return { phase: 'value', currentField: fieldDef, partial: '' };
+    }
+    // Full condition exists at end — suggest conjunction
+    return { phase: 'conjunction', partial: '' };
+  }
+
+  // Check if we have field + operator but no value yet
+  const opPattern = /(\S+)\s*(!=|>=|<=|>|<|=|starts_with|ends_with|contains|between)\s*$/i;
+  const opMatch = opPattern.exec(input);
+  if (opMatch) {
+    // Walk back to find the actual field name (might be after AND/OR)
+    const parts = opMatch[1].split(/\s+/);
+    const actualField = parts[parts.length - 1].toLowerCase();
+    const fieldDef = fieldMap.get(actualField);
+    return { phase: 'value', currentField: fieldDef, partial: '' };
+  }
+
+  // Check if we're typing a field name (possibly after AND/OR)
+  const parts = input.split(/\s+/);
+  const lastToken = parts[parts.length - 1];
+
+  // If input ends with a space, check if the previous token is a field name → suggest operators
+  if (input.endsWith(' ')) {
+    const nonEmptyParts = parts.filter((p) => p.length > 0);
+    const prevToken = nonEmptyParts[nonEmptyParts.length - 1] || '';
+    if (prevToken && !/^(AND|OR)$/i.test(prevToken)) {
+      const fieldDef = fieldMap.get(prevToken.toLowerCase());
+      if (fieldDef) {
+        return { phase: 'operator', currentField: fieldDef, partial: '' };
+      }
+    }
+  }
+
+  if (lastToken && !/^(!=|>=|<=|>|<|=)$/.test(lastToken)) {
+    // Check if previous token was AND/OR or this is the start
+    const prevToken = parts.length >= 2 ? parts[parts.length - 2] : '';
+    if (/^(AND|OR)$/i.test(prevToken) || parts.length === 1) {
+      return { phase: 'field', partial: lastToken };
+    }
+    // Could be typing a field name after space
+    const fieldDef = fieldMap.get(lastToken.toLowerCase());
+    if (fieldDef) {
+      return { phase: 'operator', currentField: fieldDef, partial: '' };
+    }
+    return { phase: 'field', partial: lastToken };
+  }
+
+  return { phase: 'none', partial: '' };
+}
+
+// --- Component ---
+interface DynamicSearchBarProps {
+  fields: FieldDef[];
+  queries: SearchQueryRecord[];
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+export const DynamicSearchBar: React.FC<DynamicSearchBarProps> = ({
+  fields,
+  queries,
+  value,
+  onChange,
+  placeholder = 'e.g. latency >= 100 AND type = query',
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [suggestions, setSuggestions] = useState<Array<{ label: string; description?: string }>>(
+    []
+  );
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const fieldMap = useMemo(() => {
+    const map = new Map<string, FieldDef>();
+    fields.forEach((f) => map.set(f.key.toLowerCase(), f));
+    // Also map by label for user convenience
+    fields.forEach((f) => map.set(f.label.toLowerCase(), f));
+    return map;
+  }, [fields]);
+
+  // Collect unique values for a field from the data
+  const getFieldValues = useCallback(
+    (fieldDef: FieldDef): string[] => {
+      const set = new Set<string>();
+      for (const q of queries) {
+        const val = fieldDef.accessor(q);
+        if (val == null) continue;
+        if (Array.isArray(val)) {
+          val.forEach((v) => v != null && set.add(String(v)));
+        } else {
+          set.add(String(val));
+        }
+      }
+      return Array.from(set).sort();
+    },
+    [queries]
+  );
+
+  const updateSuggestions = useCallback(
+    (text: string) => {
+      const { phase, currentField, partial } = detectPhase(text, fieldMap);
+
+      switch (phase) {
+        case 'field': {
+          const filtered = fields.filter(
+            (f) =>
+              !partial ||
+              f.label.toLowerCase().includes(partial.toLowerCase()) ||
+              f.key.toLowerCase().includes(partial.toLowerCase())
+          );
+          setSuggestions(
+            filtered.map((f) => ({
+              label: f.key,
+              description: `${f.label} (${f.type})`,
+            }))
+          );
+          break;
+        }
+        case 'operator': {
+          if (currentField) {
+            const ops = OPERATORS_BY_TYPE[currentField.type] || OPERATORS_BY_TYPE.string;
+            setSuggestions(ops.map((op) => ({ label: op.label, description: op.description })));
+          }
+          break;
+        }
+        case 'value': {
+          if (currentField) {
+            if (currentField.type === 'boolean') {
+              setSuggestions([{ label: 'true' }, { label: 'false' }]);
+            } else {
+              const values = getFieldValues(currentField);
+              const unit = currentField.unit || '';
+              setSuggestions(
+                values.slice(0, 20).map((v) => ({
+                  label: v,
+                  description: unit ? `${v} ${unit}` : undefined,
+                }))
+              );
+            }
+          }
+          break;
+        }
+        case 'conjunction': {
+          setSuggestions([{ label: 'AND' }, { label: 'OR' }]);
+          break;
+        }
+        default:
+          setSuggestions([]);
+      }
+    },
+    [fields, fieldMap, getFieldValues]
+  );
+
+  const handleChange = (text: string) => {
+    // Auto-format between expressions: "... between 2 26 " → "... between (2, 26) "
+    // Only triggers when there's a trailing space after the second number
+    const betweenMatch = text.match(/^(.*\s+between)\s+(\d+(?:\.\d+)?)\s+(\d+(?:\.\d+)?)\s$/i);
+    if (betweenMatch) {
+      const formatted = `${betweenMatch[1]} (${betweenMatch[2]}, ${betweenMatch[3]}) `;
+      onChange(formatted);
+      updateSuggestions(formatted);
+      if (formatted.trim()) {
+        setIsOpen(true);
+      }
+      return;
+    }
+    onChange(text);
+    updateSuggestions(text);
+    if (text.trim()) {
+      setIsOpen(true);
+    } else {
+      setIsOpen(false);
+    }
+  };
+
+  const handleSelect = (selectedLabel: string) => {
+    const { phase, partial } = detectPhase(value, fieldMap);
+    let newValue = value;
+
+    switch (phase) {
+      case 'field': {
+        // Replace the partial field name with the selected one
+        if (partial) {
+          const lastIdx = newValue.lastIndexOf(partial);
+          newValue = newValue.substring(0, lastIdx) + selectedLabel + ' ';
+        } else {
+          newValue = (newValue.trimEnd() + ' ' + selectedLabel + ' ').trimStart();
+        }
+        break;
+      }
+      case 'operator': {
+        newValue = newValue.trimEnd() + ' ' + selectedLabel + ' ';
+        break;
+      }
+      case 'value': {
+        // If value contains spaces, wrap in quotes
+        const val = selectedLabel.includes(' ') ? `"${selectedLabel}"` : selectedLabel;
+        // Ensure space between operator and value
+        newValue = newValue.endsWith(' ') ? newValue + val + ' ' : newValue + ' ' + val + ' ';
+        break;
+      }
+      case 'conjunction': {
+        newValue = newValue.trimEnd() + ' ' + selectedLabel + ' ';
+        break;
+      }
+    }
+
+    onChange(newValue);
+    updateSuggestions(newValue);
+    inputRef.current?.focus();
+  };
+
+  const handleFocus = () => {
+    updateSuggestions(value);
+    if (suggestions.length > 0 || !value.trim()) {
+      setIsOpen(true);
+    }
+  };
+
+  // Parse the current expression to show active filter badges
+  const parsed = useMemo(() => parseExpression(value), [value]);
+
+  return (
+    <div style={{ position: 'relative', minWidth: 400 }}>
+      <EuiFieldSearch
+        inputRef={(ref) => {
+          (inputRef as any).current = ref;
+        }}
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => handleChange(e.target.value)}
+        onFocus={handleFocus}
+        onBlur={() => setTimeout(() => setIsOpen(false), 200)}
+        compressed
+        fullWidth
+        aria-label="Dynamic search bar"
+      />
+      {parsed.conditions.length > 0 && (
+        <div style={{ marginTop: 4, display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+          {parsed.conditions.map((c, i) => (
+            <React.Fragment key={i}>
+              {i > 0 && parsed.conjunctions[i - 1] && (
+                <EuiBadge color="hollow">{parsed.conjunctions[i - 1]}</EuiBadge>
+              )}
+              <EuiBadge
+                color="primary"
+                iconType="cross"
+                iconSide="right"
+                iconOnClick={() => {
+                  // Remove this condition from the expression
+                  const parts = value.split(/\s+(AND|OR)\s+/i);
+                  const newParts: string[] = [];
+                  let condIdx = 0;
+                  for (const part of parts) {
+                    if (/^(AND|OR)$/i.test(part)) {
+                      newParts.push(part);
+                    } else {
+                      if (condIdx !== i) newParts.push(part);
+                      condIdx++;
+                    }
+                  }
+                  // Clean up dangling conjunctions
+                  const cleaned = newParts.filter((p, idx) => {
+                    if (/^(AND|OR)$/i.test(p)) {
+                      return idx > 0 && idx < newParts.length - 1;
+                    }
+                    return true;
+                  });
+                  onChange(cleaned.join(' ').trim());
+                }}
+                iconOnClickAriaLabel={`Remove filter ${c.field} ${c.operator} ${c.value}`}
+              >
+                {c.field} {c.operator}{' '}
+                {c.operator === 'between'
+                  ? `(${c.value
+                      .replace(/[()]/g, '')
+                      .trim()
+                      .split(/\.\.|,|\s+/)
+                      .join(', ')})`
+                  : c.value}
+              </EuiBadge>
+            </React.Fragment>
+          ))}
+        </div>
+      )}
+      {isOpen && suggestions.length > 0 && (
+        <div
+          style={{
+            position: 'absolute',
+            top: '100%',
+            left: 0,
+            right: 0,
+            zIndex: 9999,
+            background: '#fff',
+            border: '1px solid #D4DAE5',
+            borderRadius: 4,
+            maxHeight: 200,
+            overflowY: 'auto',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+          }}
+        >
+          {suggestions.map((s, idx) => (
+            <div
+              key={idx}
+              role="option"
+              aria-selected={false}
+              tabIndex={0}
+              style={{
+                padding: '6px 12px',
+                cursor: 'pointer',
+                borderBottom: idx < suggestions.length - 1 ? '1px solid #f0f0f0' : 'none',
+              }}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                handleSelect(s.label);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleSelect(s.label);
+              }}
+            >
+              <EuiText size="s">
+                <span>{s.label}</span>
+                {s.description && (
+                  <span style={{ color: '#98A2B3', marginLeft: 8, fontSize: '0.85em' }}>
+                    {s.description}
+                  </span>
+                )}
+              </EuiText>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/public/pages/InflightQueries/InflightQueries.test.tsx
+++ b/public/pages/InflightQueries/InflightQueries.test.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import { CoreStart } from 'opensearch-dashboards/public';
-import { render, screen, waitFor, act, cleanup } from '@testing-library/react';
+import { render, screen, waitFor, act, cleanup, fireEvent } from '@testing-library/react';
 import { MemoryRouter, useLocation } from 'react-router-dom';
 import { DataSourceContext } from '../TopNQueries/TopNQueries';
 import { InflightQueries } from './InflightQueries';
@@ -176,7 +176,6 @@ describe('InflightQueries', () => {
     await waitFor(
       () => {
         expect(screen.getByText('Active queries')).toBeInTheDocument();
-        expect(screen.getByLabelText('Workload group selector')).toBeInTheDocument();
       },
       { timeout: 5000 }
     );
@@ -415,7 +414,7 @@ describe('InflightQueries', () => {
     await waitFor(
       () => {
         expect(retrieveLiveQueries).toHaveBeenCalled();
-        expect(screen.getByLabelText('Workload group selector')).toBeInTheDocument();
+        expect(screen.getByText('Active queries')).toBeInTheDocument();
       },
       { timeout: 1000 }
     );
@@ -674,8 +673,8 @@ describe('InflightQueries', () => {
       { timeout: 5000 }
     );
 
-    // Should not show WLM selector
-    expect(screen.queryByLabelText('Workload group selector')).not.toBeInTheDocument();
+    // Should not show WLM selector or WLM Group column
+    expect(screen.queryByText('WLM Group')).not.toBeInTheDocument();
   });
 });
 
@@ -1260,6 +1259,295 @@ describe('InflightQueries - additional coverage', () => {
       // Should show coordinator and shard tasks from old format
       expect(screen.getAllByText('Coordinator Task').length).toBeGreaterThanOrEqual(1);
       expect(screen.getByText('Query Source')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('InflightQueries - DynamicSearchBar filtering', () => {
+  const multiQueryPayload = {
+    ok: true,
+    response: {
+      live_queries: [
+        {
+          id: 'task-node1:100',
+          timestamp: 1640995200000,
+          node_id: 'nodeAlpha',
+          description: 'indices[orders-2024] search_type[query_then_fetch]',
+          measurements: {
+            latency: { number: 5e9 },
+            cpu: { number: 2e6 },
+            memory: { number: 4096 },
+          },
+          is_cancelled: false,
+          wlm_group_id: 'ANALYTICS_GROUP',
+        },
+        {
+          id: 'task-node2:200',
+          timestamp: 1640995201000,
+          node_id: 'nodeBeta',
+          description: 'indices[logs-2024] search_type[dfs_query_then_fetch]',
+          measurements: {
+            latency: { number: 10e9 },
+            cpu: { number: 5e6 },
+            memory: { number: 8192 },
+          },
+          is_cancelled: false,
+          wlm_group_id: 'SEARCH_GROUP',
+        },
+        {
+          id: 'task-node1:300',
+          timestamp: 1640995202000,
+          node_id: 'nodeAlpha',
+          description: 'indices[orders-2024] search_type[query_then_fetch]',
+          measurements: {
+            latency: { number: 1e9 },
+            cpu: { number: 1e6 },
+            memory: { number: 2048 },
+          },
+          is_cancelled: true,
+          wlm_group_id: 'ANALYTICS_GROUP',
+        },
+      ],
+    },
+  };
+
+  it('filters by task ID using the search bar', async () => {
+    const core = makeCore();
+    mockLiveQueries(multiQueryPayload);
+
+    render(
+      withDataSource(
+        <InflightQueries
+          core={core}
+          depsStart={
+            { data: { dataSources: { get: jest.fn().mockReturnValue(core.http) } } } as any
+          }
+          params={{} as any}
+          dataSourceManagement={undefined}
+        />
+      )
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('task-node1:100')).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByLabelText('Dynamic search bar');
+
+    await act(async () => {
+      fireEvent.change(searchInput, { target: { value: 'id = task-node2:200' } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('task-node2:200').length).toBeGreaterThanOrEqual(1);
+      expect(screen.queryByText('task-node1:100')).not.toBeInTheDocument();
+      expect(screen.queryByText('task-node1:300')).not.toBeInTheDocument();
+    });
+  });
+
+  it('filters by index in free-text search', async () => {
+    const core = makeCore();
+    mockLiveQueries(multiQueryPayload);
+
+    render(
+      withDataSource(
+        <InflightQueries
+          core={core}
+          depsStart={
+            { data: { dataSources: { get: jest.fn().mockReturnValue(core.http) } } } as any
+          }
+          params={{} as any}
+          dataSourceManagement={undefined}
+        />
+      )
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('task-node1:100').length).toBeGreaterThanOrEqual(1);
+    });
+
+    const searchInput = screen.getByLabelText('Dynamic search bar');
+
+    await act(async () => {
+      fireEvent.change(searchInput, { target: { value: 'logs-2024' } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('task-node2:200').length).toBeGreaterThanOrEqual(1);
+      expect(screen.queryByText('task-node1:100')).not.toBeInTheDocument();
+    });
+  });
+
+  it('filters by status', async () => {
+    const core = makeCore();
+    mockLiveQueries(multiQueryPayload);
+
+    render(
+      withDataSource(
+        <InflightQueries
+          core={core}
+          depsStart={
+            { data: { dataSources: { get: jest.fn().mockReturnValue(core.http) } } } as any
+          }
+          params={{} as any}
+          dataSourceManagement={undefined}
+        />
+      )
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('task-node1:100').length).toBeGreaterThanOrEqual(1);
+    });
+
+    const searchInput = screen.getByLabelText('Dynamic search bar');
+
+    // Use structured id search to filter to a specific task
+    await act(async () => {
+      fireEvent.change(searchInput, { target: { value: 'id = task-node1:300' } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('task-node1:300').length).toBeGreaterThanOrEqual(1);
+      expect(screen.queryByText('task-node1:100')).not.toBeInTheDocument();
+    });
+  });
+
+  it('filters by coordinator node', async () => {
+    const core = makeCore();
+    mockLiveQueries(multiQueryPayload);
+
+    render(
+      withDataSource(
+        <InflightQueries
+          core={core}
+          depsStart={
+            { data: { dataSources: { get: jest.fn().mockReturnValue(core.http) } } } as any
+          }
+          params={{} as any}
+          dataSourceManagement={undefined}
+        />
+      )
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('task-node1:100').length).toBeGreaterThanOrEqual(1);
+    });
+
+    const searchInput = screen.getByLabelText('Dynamic search bar');
+
+    await act(async () => {
+      fireEvent.change(searchInput, { target: { value: 'nodeBeta' } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('task-node2:200').length).toBeGreaterThanOrEqual(1);
+      expect(screen.queryByText('task-node1:100')).not.toBeInTheDocument();
+    });
+  });
+
+  it('filters by wlm_group', async () => {
+    const core = makeCore();
+    mockLiveQueries(multiQueryPayload);
+
+    render(
+      withDataSource(
+        <InflightQueries
+          core={core}
+          depsStart={
+            { data: { dataSources: { get: jest.fn().mockReturnValue(core.http) } } } as any
+          }
+          params={{} as any}
+          dataSourceManagement={undefined}
+        />
+      )
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('task-node1:100').length).toBeGreaterThanOrEqual(1);
+    });
+
+    const searchInput = screen.getByLabelText('Dynamic search bar');
+
+    await act(async () => {
+      fireEvent.change(searchInput, { target: { value: 'SEARCH_GROUP' } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('task-node2:200').length).toBeGreaterThanOrEqual(1);
+      expect(screen.queryByText('task-node1:100')).not.toBeInTheDocument();
+    });
+  });
+
+  it('filters with compound expression (AND)', async () => {
+    const core = makeCore();
+    mockLiveQueries(multiQueryPayload);
+
+    render(
+      withDataSource(
+        <InflightQueries
+          core={core}
+          depsStart={
+            { data: { dataSources: { get: jest.fn().mockReturnValue(core.http) } } } as any
+          }
+          params={{} as any}
+          dataSourceManagement={undefined}
+        />
+      )
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('task-node1:100').length).toBeGreaterThanOrEqual(1);
+    });
+
+    const searchInput = screen.getByLabelText('Dynamic search bar');
+
+    // Use free-text AND: both terms must appear in the stringified row
+    await act(async () => {
+      fireEvent.change(searchInput, {
+        target: { value: 'id = task-node2:200 AND search_type = dfs query then fetch' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('task-node2:200').length).toBeGreaterThanOrEqual(1);
+      expect(screen.queryByText('task-node1:100')).not.toBeInTheDocument();
+      expect(screen.queryByText('task-node1:300')).not.toBeInTheDocument();
     });
   });
 });

--- a/public/pages/InflightQueries/InflightQueries.tsx
+++ b/public/pages/InflightQueries/InflightQueries.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect, useState, useRef, useCallback, useContext } from 'react';
+import React, { useEffect, useState, useRef, useCallback, useContext, useMemo } from 'react';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -18,9 +18,9 @@ import {
   EuiInMemoryTable,
   EuiButton,
   EuiLink,
-  EuiFormRow,
   EuiSelect,
   EuiBadge,
+  EuiAccordion,
 } from '@elastic/eui';
 import {
   RadialChart,
@@ -44,7 +44,6 @@ import {
   DEFAULT_REFRESH_INTERVAL,
   TOP_N_DISPLAY_LIMIT,
   WLM_GROUP_ID_PARAM,
-  ALL_WORKLOAD_GROUPS_TEXT,
   CHART_COLORS,
   REFRESH_INTERVAL_OPTIONS,
 } from '../../../common/constants';
@@ -56,6 +55,13 @@ import {
   isVersion33OrHigher,
   isVersion37OrHigher,
 } from '../../utils/version-utils';
+import {
+  DynamicSearchBar,
+  FieldDef,
+  parseExpression,
+  evaluateExpression,
+} from '../../components/DynamicSearchBar';
+import { SearchQueryRecord } from '../../../types/types';
 
 type LiveQueryRaw = NonNullable<LiveSearchQueryResponse['response']>['live_queries'][number];
 
@@ -114,9 +120,7 @@ export const InflightQueries = ({
   const urlSearchParams = new URLSearchParams(location.search);
   const initialWlmGroup = urlSearchParams.get(WLM_GROUP_ID_PARAM) || '';
 
-  const [wlmGroupId, setWlmGroupId] = useState<string | undefined>(
-    initialWlmGroup !== '' ? initialWlmGroup : undefined
-  );
+  const wlmGroupId = initialWlmGroup !== '' ? initialWlmGroup : undefined;
   const wlmIdToNameMap = React.useMemo(
     () => Object.fromEntries(wlmGroupOptions.map((g) => [g.id, g.name])),
     [wlmGroupOptions]
@@ -175,11 +179,13 @@ export const InflightQueries = ({
     checkWlmSupport();
   }, [detectWlm, dataSource?.id]);
 
-  const [_workloadGroupStats, setWorkloadGroupStats] = useState<{
-    total_completions: number;
-    total_cancellations: number;
-    total_rejections: number;
-  }>({ total_completions: 0, total_cancellations: 0, total_rejections: 0 });
+  // Clean URL after extracting wlmGroupId
+  useEffect(() => {
+    const urlParams = new URLSearchParams(location.search);
+    if (urlParams.get(WLM_GROUP_ID_PARAM)) {
+      history.replace(location.pathname);
+    }
+  }, [location.search, history, location.pathname]);
 
   const [finishedQueryStats, setFinishedQueryStats] = useState<{
     total_completions: number;
@@ -195,15 +201,11 @@ export const InflightQueries = ({
       statsBody = statsRes as WlmStatsBody;
     } catch (e) {
       console.warn('[LiveQueries] Failed to fetch WLM stats', e);
-      setWorkloadGroupStats({ total_completions: 0, total_cancellations: 0, total_rejections: 0 });
       setWlmGroupOptions([]);
       return {};
     }
 
     const activeGroupIds = new Set<string>();
-    let completions = 0;
-    let cancellations = 0;
-    let rejections = 0;
 
     // Sample WLM stats response:
     // {
@@ -233,22 +235,10 @@ export const InflightQueries = ({
       if (key === '_nodes' || key === 'cluster_name') continue;
       const nodeStats = maybeNode as WlmNodeStats;
       const workloadGroups = nodeStats.workload_groups ?? {};
-      for (const [groupId, groupStats] of Object.entries(workloadGroups)) {
+      for (const [groupId] of Object.entries(workloadGroups)) {
         activeGroupIds.add(groupId);
-        if (!wlmGroupId || wlmGroupId === groupId) {
-          const s = groupStats;
-          completions += s.total_completions ?? 0;
-          cancellations += s.total_cancellations ?? 0;
-          rejections += s.total_rejections ?? 0;
-        }
       }
     }
-
-    setWorkloadGroupStats({
-      total_completions: completions,
-      total_cancellations: cancellations,
-      total_rejections: rejections,
-    });
 
     // fetch group NAMES only if plugin exists and version supported
     const idToNameMap: Record<string, string> = {};
@@ -485,8 +475,89 @@ export const InflightQueries = ({
   ]);
 
   const [pagination, setPagination] = useState({ pageIndex: 0 });
-  const [tableQuery, setTableQuery] = useState('');
-  const [_tableFilters, setTableFilters] = useState([]);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // --- Field definitions for DynamicSearchBar ---
+  const searchFields = useMemo<FieldDef[]>(() => {
+    const fields: FieldDef[] = [
+      { label: 'Task ID', key: 'id', accessor: (q) => (q as any).id, type: 'string' },
+      { label: 'Index', key: 'index', accessor: (q) => (q as any).index, type: 'string' },
+      {
+        label: 'Search Type',
+        key: 'search_type',
+        accessor: (q) => (q as any).search_type,
+        type: 'string',
+      },
+      {
+        label: 'Coordinator Node',
+        key: 'coordinator_node',
+        accessor: (q) => (q as any).coordinator_node,
+        type: 'string',
+      },
+      {
+        label: 'Latency',
+        key: 'latency',
+        accessor: (q) => {
+          const val = (q as any).measurements?.latency?.number;
+          return val != null ? val / 1e9 : undefined;
+        },
+        type: 'number',
+        unit: 's',
+      },
+      {
+        label: 'CPU',
+        key: 'cpu',
+        accessor: (q) => {
+          const val = (q as any).measurements?.cpu?.number;
+          return val != null ? val / 1e9 : undefined;
+        },
+        type: 'number',
+        unit: 's',
+      },
+      {
+        label: 'Memory',
+        key: 'memory',
+        accessor: (q) => (q as any).measurements?.memory?.number,
+        type: 'number',
+        unit: 'B',
+      },
+      {
+        label: 'Status',
+        key: 'status',
+        accessor: (q) => {
+          if ((q as any)._finished) return (q as any)._status || 'Completed';
+          if ((q as any).is_cancelled) return 'Cancelled';
+          return 'Running';
+        },
+        type: 'string',
+      },
+      {
+        label: 'WLM Group',
+        key: 'wlm_group',
+        accessor: (q) => (q as any).wlm_group,
+        type: 'string',
+      },
+    ];
+    return fields;
+  }, []);
+
+  const fieldMap = useMemo(() => {
+    const map = new Map<string, FieldDef>();
+    searchFields.forEach((f) => {
+      map.set(f.key.toLowerCase(), f);
+      map.set(f.label.toLowerCase(), f);
+    });
+    return map;
+  }, [searchFields]);
+
+  // Filter live queries based on the dynamic search expression
+  const filteredQueries = useMemo(() => {
+    if (!searchQuery.trim()) return liveQueries;
+    const parsed = parseExpression(searchQuery);
+    return liveQueries.filter((q) =>
+      evaluateExpression((q as unknown) as SearchQueryRecord, parsed, fieldMap)
+    );
+  }, [liveQueries, searchQuery, fieldMap]);
 
   const formatTime = (seconds: number): string => {
     if (isNaN(seconds) || seconds == null) return '-';
@@ -626,50 +697,27 @@ export const InflightQueries = ({
         dataSourcePickerReadOnly={false}
       />
       <EuiSpacer size="m" />
-      <EuiFlexGroup alignItems="center" gutterSize="m" justifyContent="spaceBetween">
-        {/* LEFT: WLM status + optional selector */}
-        {queryInsightWlmNavigationSupported ? (
-          <EuiFlexGroup gutterSize="none" alignItems="center">
-            <EuiBadge
-              color="default"
-              style={{
-                padding: '6px 12px',
-                height: 32,
-                display: 'flex',
-                alignItems: 'center',
-                fontWeight: 'bold',
-              }}
-            >
-              Workload group
-            </EuiBadge>
-            <EuiFlexItem grow={false}>
-              <EuiSelect
-                id="wlm-group-select"
-                options={[
-                  { value: '', text: ALL_WORKLOAD_GROUPS_TEXT },
-                  ...wlmGroupOptions.map((g) => ({ value: g.id, text: g.name })),
-                ]}
-                value={wlmGroupId ?? ''}
-                onChange={(e) => {
-                  const value = e.target.value || undefined;
-                  setWlmGroupId(value);
-                }}
-                aria-label="Workload group selector"
-                compressed
-              />
-            </EuiFlexItem>
-          </EuiFlexGroup>
-        ) : (
-          <EuiFlexItem />
-        )}
-
-        {/* RIGHT: refresh / auto-refresh */}
+      <EuiFlexGroup alignItems="flexStart" gutterSize="m">
+        <EuiFlexItem grow>
+          <DynamicSearchBar
+            fields={searchFields}
+            queries={(liveQueries as unknown) as SearchQueryRecord[]}
+            value={searchQuery}
+            onChange={setSearchQuery}
+            placeholder="e.g. latency >= 1 AND status = Running"
+          />
+        </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+          <EuiFlexGroup
+            alignItems="center"
+            gutterSize="s"
+            responsive={false}
+            style={{ minHeight: 40 }}
+          >
             {taskDetailSupported && (
               <EuiFlexItem grow={false}>
                 <EuiSwitch
-                  label="Show finished queries"
+                  label={<span style={{ fontSize: '16px' }}>Show finished queries</span>}
                   checked={showFinishedQueries}
                   onChange={(e) => setShowFinishedQueries(e.target.checked)}
                   data-test-subj="live-queries-show-finished-toggle"
@@ -678,24 +726,21 @@ export const InflightQueries = ({
             )}
             <EuiFlexItem grow={false}>
               <EuiSwitch
-                label="Auto-refresh"
+                label={<span style={{ fontSize: '16px' }}>Auto-refresh</span>}
                 checked={autoRefreshEnabled}
                 onChange={(e) => setAutoRefreshEnabled(e.target.checked)}
                 data-test-subj="live-queries-autorefresh-toggle"
               />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiFormRow display="columnCompressed">
-                <EuiSelect
-                  value={String(refreshInterval)}
-                  onChange={(e) => setRefreshInterval(parseInt(e.target.value, 10))}
-                  options={REFRESH_INTERVAL_OPTIONS}
-                  disabled={!autoRefreshEnabled}
-                  data-test-subj="live-queries-refresh-interval"
-                  compressed
-                  style={{ minWidth: 140 }}
-                />
-              </EuiFormRow>
+              <EuiSelect
+                value={String(refreshInterval)}
+                onChange={(e) => setRefreshInterval(parseInt(e.target.value, 10))}
+                options={REFRESH_INTERVAL_OPTIONS}
+                disabled={!autoRefreshEnabled}
+                data-test-subj="live-queries-refresh-interval"
+                style={{ minWidth: 140 }}
+              />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiButton
@@ -713,382 +758,347 @@ export const InflightQueries = ({
       </EuiFlexGroup>
       <EuiSpacer size="m" />
 
-      <EuiFlexGroup>
-        {/* Active Queries */}
-        <EuiFlexItem>
-          <EuiPanel paddingSize="m" data-test-subj="panel-active-queries">
+      <EuiPanel>
+        <EuiAccordion
+          id="live-queries-visualizations"
+          buttonContent={
+            <EuiTitle size="s">
+              <h3>Stats & Visualizations</h3>
+            </EuiTitle>
+          }
+          initialIsOpen={true}
+        >
+          <EuiSpacer size="m" />
+          <EuiFlexGroup>
+            {/* Active Queries */}
             <EuiFlexItem>
-              <EuiTextAlign textAlign="center">
-                <EuiText size="s">
-                  <p>Active queries</p>
-                </EuiText>
-                <EuiTitle size="l">
-                  <h2>
-                    <b>{metrics?.activeQueries ?? 0}</b>
-                  </h2>
-                </EuiTitle>
-                <EuiIcon type="visGauge" />
-              </EuiTextAlign>
+              <EuiPanel paddingSize="m" data-test-subj="panel-active-queries">
+                <EuiFlexItem>
+                  <EuiTextAlign textAlign="center">
+                    <EuiText size="s">
+                      <p>Active queries</p>
+                    </EuiText>
+                    <EuiTitle size="l">
+                      <h2>
+                        <b>{metrics?.activeQueries ?? 0}</b>
+                      </h2>
+                    </EuiTitle>
+                    <EuiIcon type="visGauge" />
+                  </EuiTextAlign>
+                </EuiFlexItem>
+              </EuiPanel>
             </EuiFlexItem>
-          </EuiPanel>
-        </EuiFlexItem>
 
-        {/* Avg. elapsed time */}
-        <EuiFlexItem>
-          <EuiPanel paddingSize="m" data-test-subj="panel-avg-elapsed-time">
+            {/* Avg. elapsed time */}
             <EuiFlexItem>
-              <EuiTextAlign textAlign="center">
-                <EuiText size="s">
-                  <p>Avg. elapsed time</p>
-                </EuiText>
-                <EuiTitle size="l">
-                  <h2>
-                    <b>{metrics ? formatTime(metrics.avgElapsedSec) : 0}</b>
-                  </h2>
-                </EuiTitle>
-                <EuiText size="s">
-                  <p>(Avg. across {metrics?.activeQueries ?? 0} active queries)</p>
-                </EuiText>
-              </EuiTextAlign>
+              <EuiPanel paddingSize="m" data-test-subj="panel-avg-elapsed-time">
+                <EuiFlexItem>
+                  <EuiTextAlign textAlign="center">
+                    <EuiText size="s">
+                      <p>Avg. elapsed time</p>
+                    </EuiText>
+                    <EuiTitle size="l">
+                      <h2>
+                        <b>{metrics ? formatTime(metrics.avgElapsedSec) : 0}</b>
+                      </h2>
+                    </EuiTitle>
+                    <EuiText size="s">
+                      <p>(Avg. across {metrics?.activeQueries ?? 0} active queries)</p>
+                    </EuiText>
+                  </EuiTextAlign>
+                </EuiFlexItem>
+              </EuiPanel>
             </EuiFlexItem>
-          </EuiPanel>
-        </EuiFlexItem>
 
-        {/* Longest running query */}
-        <EuiFlexItem>
-          <EuiPanel paddingSize="m" data-test-subj="panel-longest-query">
+            {/* Longest running query */}
             <EuiFlexItem>
-              <EuiTextAlign textAlign="center">
-                <EuiText size="s">
-                  <p>Longest running query</p>
-                </EuiText>
-                <EuiTitle size="l">
-                  <h2>
-                    <b>{metrics ? formatTime(metrics.longestElapsedSec) : 0}</b>
-                  </h2>
-                </EuiTitle>
-                {metrics?.longestQueryId && (
-                  <EuiText size="s">
-                    <p>
-                      ID:{' '}
-                      {taskDetailSupported ? (
-                        <EuiLink onClick={() => setSelectedTaskId(metrics.longestQueryId)}>
-                          {metrics.longestQueryId}
-                        </EuiLink>
-                      ) : (
-                        metrics.longestQueryId
-                      )}
-                    </p>
-                  </EuiText>
+              <EuiPanel paddingSize="m" data-test-subj="panel-longest-query">
+                <EuiFlexItem>
+                  <EuiTextAlign textAlign="center">
+                    <EuiText size="s">
+                      <p>Longest running query</p>
+                    </EuiText>
+                    <EuiTitle size="l">
+                      <h2>
+                        <b>{metrics ? formatTime(metrics.longestElapsedSec) : 0}</b>
+                      </h2>
+                    </EuiTitle>
+                    {metrics?.longestQueryId && (
+                      <EuiText size="s">
+                        <p>
+                          ID:{' '}
+                          {taskDetailSupported ? (
+                            <EuiLink onClick={() => setSelectedTaskId(metrics.longestQueryId)}>
+                              {metrics.longestQueryId}
+                            </EuiLink>
+                          ) : (
+                            metrics.longestQueryId
+                          )}
+                        </p>
+                      </EuiText>
+                    )}
+                  </EuiTextAlign>
+                </EuiFlexItem>
+              </EuiPanel>
+            </EuiFlexItem>
+
+            {/* Total CPU usage */}
+            <EuiFlexItem>
+              <EuiPanel paddingSize="m" data-test-subj="panel-total-cpu">
+                <EuiFlexItem>
+                  <EuiTextAlign textAlign="center">
+                    <EuiText size="s">
+                      <p>Total CPU usage</p>
+                    </EuiText>
+                    <EuiTitle size="l">
+                      <h2>
+                        <b>{metrics ? formatTime(metrics.totalCPUSec) : 0}</b>
+                      </h2>
+                    </EuiTitle>
+                    <EuiText size="s">
+                      <p>(Sum across {metrics?.activeQueries ?? 0} active queries)</p>
+                    </EuiText>
+                  </EuiTextAlign>
+                </EuiFlexItem>
+              </EuiPanel>
+            </EuiFlexItem>
+
+            {/* Total memory usage */}
+            <EuiFlexItem>
+              <EuiPanel paddingSize="m" data-test-subj="panel-total-memory">
+                <EuiFlexItem>
+                  <EuiTextAlign textAlign="center">
+                    <EuiText size="s">
+                      <p>Total memory usage</p>
+                    </EuiText>
+                    <EuiTitle size="l">
+                      <h2>
+                        <b>{metrics ? formatMemory(metrics.totalMemoryBytes) : 0}</b>
+                      </h2>
+                    </EuiTitle>
+                    <EuiText size="s">
+                      <p>(Sum across {metrics?.activeQueries ?? 0} active queries)</p>
+                    </EuiText>
+                  </EuiTextAlign>
+                </EuiFlexItem>
+              </EuiPanel>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiFlexGroup>
+            {/* Queries by Node */}
+            <EuiFlexItem>
+              <EuiPanel paddingSize="m">
+                <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+                  <EuiTitle size="xs">
+                    <p>Active Queries by Node</p>
+                  </EuiTitle>
+                  <EuiButtonGroup
+                    legend="Chart Type"
+                    options={chartOptions}
+                    idSelected={selectedChartIdByNode}
+                    onChange={onChartChangeByNode}
+                    color="primary"
+                  />
+                </EuiFlexGroup>
+                <EuiSpacer size="l" />
+                {Object.keys(nodeCounts).length > 0 ? (
+                  selectedChartIdByNode === 'donut' ? (
+                    <>
+                      <RadialChart
+                        data={getReactVisChartData(nodeCounts)}
+                        width={300}
+                        height={300}
+                        innerRadius={80}
+                        radius={140}
+                        colorType="literal"
+                        data-test-subj="chart-node-donut"
+                      />
+                      <EuiSpacer size="s" />
+                      <Legend data={nodeCounts} />
+                    </>
+                  ) : (
+                    <XYPlot
+                      yType="ordinal"
+                      width={400}
+                      height={300}
+                      margin={{ left: 180 }}
+                      colorType="literal"
+                      data-test-subj="chart-node-bar"
+                    >
+                      <HorizontalGridLines />
+                      <XAxis />
+                      <YAxis />
+                      <HorizontalBarSeries
+                        data={getReactVisChartData(nodeCounts)}
+                        getColor={(d) => d.color}
+                      />
+                    </XYPlot>
+                  )
+                ) : (
+                  <EuiTextAlign textAlign="center">
+                    <EuiSpacer size="xl" />
+                    <EuiIcon type="visPie" size="xxl" color="subdued" />
+                    <EuiSpacer size="s" />
+                    <EuiTitle size="s">
+                      <h3>No Visualization Available</h3>
+                    </EuiTitle>
+                    <EuiText color="subdued" size="s">
+                      <p>No active queries to display</p>
+                    </EuiText>
+                    <EuiSpacer size="xl" />
+                  </EuiTextAlign>
                 )}
-              </EuiTextAlign>
+              </EuiPanel>
             </EuiFlexItem>
-          </EuiPanel>
-        </EuiFlexItem>
 
-        {/* Total CPU usage */}
-        <EuiFlexItem>
-          <EuiPanel paddingSize="m" data-test-subj="panel-total-cpu">
+            {/* Queries by Index */}
             <EuiFlexItem>
-              <EuiTextAlign textAlign="center">
-                <EuiText size="s">
-                  <p>Total CPU usage</p>
-                </EuiText>
-                <EuiTitle size="l">
-                  <h2>
-                    <b>{metrics ? formatTime(metrics.totalCPUSec) : 0}</b>
-                  </h2>
-                </EuiTitle>
-                <EuiText size="s">
-                  <p>(Sum across {metrics?.activeQueries ?? 0} active queries)</p>
-                </EuiText>
-              </EuiTextAlign>
+              <EuiPanel paddingSize="m">
+                <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+                  <EuiTitle size="xs">
+                    <p>Active Queries by Index</p>
+                  </EuiTitle>
+                  <EuiButtonGroup
+                    legend="Chart Type"
+                    options={chartOptions}
+                    idSelected={selectedChartIdByIndex}
+                    onChange={onChartChangeByIndex}
+                    color="primary"
+                  />
+                </EuiFlexGroup>
+                <EuiSpacer size="l" />
+                {Object.keys(indexCounts).length > 0 ? (
+                  selectedChartIdByIndex === 'donut' ? (
+                    <>
+                      <RadialChart
+                        data={getReactVisChartData(indexCounts)}
+                        width={300}
+                        height={300}
+                        innerRadius={80}
+                        radius={140}
+                        colorType="literal"
+                        data-test-subj="chart-index-donut"
+                      />
+                      <EuiSpacer size="s" />
+                      <Legend data={indexCounts} />
+                    </>
+                  ) : (
+                    <XYPlot
+                      yType="ordinal"
+                      width={500}
+                      height={300}
+                      margin={{ left: 180 }}
+                      data-test-subj="chart-index-bar"
+                    >
+                      <HorizontalGridLines />
+                      <XAxis />
+                      <YAxis />
+                      <HorizontalBarSeries
+                        data={getReactVisChartData(indexCounts)}
+                        colorType="literal"
+                        getColor={(d) => d.color}
+                      />
+                    </XYPlot>
+                  )
+                ) : (
+                  <EuiTextAlign textAlign="center">
+                    <EuiSpacer size="xl" />
+                    <EuiIcon type="visPie" size="xxl" color="subdued" />
+                    <EuiSpacer size="s" />
+                    <EuiTitle size="s">
+                      <h3>No Visualization Available</h3>
+                    </EuiTitle>
+                    <EuiText color="subdued" size="s">
+                      <p>No index data to display</p>
+                    </EuiText>
+                    <EuiSpacer size="xl" />
+                  </EuiTextAlign>
+                )}
+              </EuiPanel>
             </EuiFlexItem>
-          </EuiPanel>
-        </EuiFlexItem>
+          </EuiFlexGroup>
+          {taskDetailSupported && showFinishedQueries && (
+            <EuiFlexGroup>
+              {/* Finished Query Stats Panels */}
+              <EuiFlexItem>
+                <EuiPanel paddingSize="m">
+                  <EuiTextAlign textAlign="center">
+                    <EuiText size="s">
+                      <p>Total completions</p>
+                    </EuiText>
+                    <EuiTitle size="l">
+                      <h2>{finishedQueryStats.total_completions}</h2>
+                    </EuiTitle>
+                  </EuiTextAlign>
+                </EuiPanel>
+              </EuiFlexItem>
 
-        {/* Total memory usage */}
-        <EuiFlexItem>
-          <EuiPanel paddingSize="m" data-test-subj="panel-total-memory">
-            <EuiFlexItem>
-              <EuiTextAlign textAlign="center">
-                <EuiText size="s">
-                  <p>Total memory usage</p>
-                </EuiText>
-                <EuiTitle size="l">
-                  <h2>
-                    <b>{metrics ? formatMemory(metrics.totalMemoryBytes) : 0}</b>
-                  </h2>
-                </EuiTitle>
-                <EuiText size="s">
-                  <p>(Sum across {metrics?.activeQueries ?? 0} active queries)</p>
-                </EuiText>
-              </EuiTextAlign>
-            </EuiFlexItem>
-          </EuiPanel>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      <EuiFlexGroup>
-        {/* Queries by Node */}
-        <EuiFlexItem>
-          <EuiPanel paddingSize="m">
-            <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
-              <EuiTitle size="xs">
-                <p>Active Queries by Node</p>
-              </EuiTitle>
-              <EuiButtonGroup
-                legend="Chart Type"
-                options={chartOptions}
-                idSelected={selectedChartIdByNode}
-                onChange={onChartChangeByNode}
-                color="primary"
-              />
+              <EuiFlexItem>
+                <EuiPanel paddingSize="m">
+                  <EuiTextAlign textAlign="center">
+                    <EuiText size="s">
+                      <p>Total cancellations</p>
+                    </EuiText>
+                    <EuiTitle size="l">
+                      <h2>{finishedQueryStats.total_cancellations}</h2>
+                    </EuiTitle>
+                  </EuiTextAlign>
+                </EuiPanel>
+              </EuiFlexItem>
+
+              <EuiFlexItem>
+                <EuiPanel paddingSize="m">
+                  <EuiTextAlign textAlign="center">
+                    <EuiText size="s">
+                      <p>Total failures</p>
+                    </EuiText>
+                    <EuiTitle size="l">
+                      <h2>{finishedQueryStats.total_failures}</h2>
+                    </EuiTitle>
+                  </EuiTextAlign>
+                </EuiPanel>
+              </EuiFlexItem>
             </EuiFlexGroup>
-            <EuiSpacer size="l" />
-            {Object.keys(nodeCounts).length > 0 ? (
-              selectedChartIdByNode === 'donut' ? (
-                <>
-                  <RadialChart
-                    data={getReactVisChartData(nodeCounts)}
-                    width={300}
-                    height={300}
-                    innerRadius={80}
-                    radius={140}
-                    colorType="literal"
-                    data-test-subj="chart-node-donut"
-                  />
-                  <EuiSpacer size="s" />
-                  <Legend data={nodeCounts} />
-                </>
-              ) : (
-                <XYPlot
-                  yType="ordinal"
-                  width={400}
-                  height={300}
-                  margin={{ left: 180 }}
-                  colorType="literal"
-                  data-test-subj="chart-node-bar"
-                >
-                  <HorizontalGridLines />
-                  <XAxis />
-                  <YAxis />
-                  <HorizontalBarSeries
-                    data={getReactVisChartData(nodeCounts)}
-                    getColor={(d) => d.color}
-                  />
-                </XYPlot>
-              )
-            ) : (
-              <EuiTextAlign textAlign="center">
-                <EuiSpacer size="xl" />
-                <EuiText color="subdued">
-                  <p>No data available</p>
-                </EuiText>
-                <EuiSpacer size="xl" />
-              </EuiTextAlign>
-            )}
-          </EuiPanel>
-        </EuiFlexItem>
-
-        {/* Queries by Index */}
-        <EuiFlexItem>
-          <EuiPanel paddingSize="m">
-            <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
-              <EuiTitle size="xs">
-                <p>Active Queries by Index</p>
-              </EuiTitle>
-              <EuiButtonGroup
-                legend="Chart Type"
-                options={chartOptions}
-                idSelected={selectedChartIdByIndex}
-                onChange={onChartChangeByIndex}
-                color="primary"
-              />
-            </EuiFlexGroup>
-            <EuiSpacer size="l" />
-            {Object.keys(indexCounts).length > 0 ? (
-              selectedChartIdByIndex === 'donut' ? (
-                <>
-                  <RadialChart
-                    data={getReactVisChartData(indexCounts)}
-                    width={300}
-                    height={300}
-                    innerRadius={80}
-                    radius={140}
-                    colorType="literal"
-                    data-test-subj="chart-index-donut"
-                  />
-                  <EuiSpacer size="s" />
-                  <Legend data={indexCounts} />
-                </>
-              ) : (
-                <XYPlot
-                  yType="ordinal"
-                  width={500}
-                  height={300}
-                  margin={{ left: 180 }}
-                  data-test-subj="chart-index-bar"
-                >
-                  <HorizontalGridLines />
-                  <XAxis />
-                  <YAxis />
-                  <HorizontalBarSeries
-                    data={getReactVisChartData(indexCounts)}
-                    colorType="literal"
-                    getColor={(d) => d.color}
-                  />
-                </XYPlot>
-              )
-            ) : (
-              <EuiTextAlign textAlign="center">
-                <EuiSpacer size="xl" />
-                <EuiText color="subdued">
-                  <p>No data available</p>
-                </EuiText>
-                <EuiSpacer size="xl" />
-              </EuiTextAlign>
-            )}
-          </EuiPanel>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      {taskDetailSupported && showFinishedQueries && (
-        <EuiFlexGroup>
-          {/* Finished Query Stats Panels */}
-          <EuiFlexItem>
-            <EuiPanel paddingSize="m">
-              <EuiTextAlign textAlign="center">
-                <EuiText size="s">
-                  <p>Total completions</p>
-                </EuiText>
-                <EuiTitle size="l">
-                  <h2>{finishedQueryStats.total_completions}</h2>
-                </EuiTitle>
-              </EuiTextAlign>
-            </EuiPanel>
-          </EuiFlexItem>
-
-          <EuiFlexItem>
-            <EuiPanel paddingSize="m">
-              <EuiTextAlign textAlign="center">
-                <EuiText size="s">
-                  <p>Total cancellations</p>
-                </EuiText>
-                <EuiTitle size="l">
-                  <h2>{finishedQueryStats.total_cancellations}</h2>
-                </EuiTitle>
-              </EuiTextAlign>
-            </EuiPanel>
-          </EuiFlexItem>
-
-          <EuiFlexItem>
-            <EuiPanel paddingSize="m">
-              <EuiTextAlign textAlign="center">
-                <EuiText size="s">
-                  <p>Total failures</p>
-                </EuiText>
-                <EuiTitle size="l">
-                  <h2>{finishedQueryStats.total_failures}</h2>
-                </EuiTitle>
-              </EuiTextAlign>
-            </EuiPanel>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      )}
+          )}
+        </EuiAccordion>
+      </EuiPanel>
 
       <EuiSpacer size="m" />
       <EuiPanel paddingSize="m">
-        <EuiInMemoryTable
-          items={liveQueries}
-          search={{
-            query: tableQuery,
-            onChange: ({ queryText }) => {
-              setTableQuery(queryText || '');
-            },
-            box: {
-              placeholder: 'Search queries',
-              schema: false,
-            },
-            toolsLeft:
-              selectedItems.length > 0
-                ? [
-                    <EuiButton
-                      key="delete-button"
-                      color="danger"
-                      iconType="trash"
-                      disabled={selectedItems.length === 0}
-                      onClick={async () => {
-                        const httpClient = dataSource?.id
-                          ? depsStart.data.dataSources.get(dataSource.id)
-                          : core.http;
+        {selectedItems.length > 0 && (
+          <>
+            <EuiFlexGroup alignItems="center" gutterSize="m">
+              <EuiFlexItem grow={false}>
+                <EuiButton
+                  color="danger"
+                  iconType="trash"
+                  onClick={async () => {
+                    const httpClient = dataSource?.id
+                      ? depsStart.data.dataSources.get(dataSource.id)
+                      : core.http;
 
-                        await Promise.allSettled(
-                          selectedItems.map((item) =>
-                            httpClient.post(API_ENDPOINTS.CANCEL_TASK(item.id)).then(
-                              () => ({ status: 'fulfilled', id: item.id }),
-                              (err) => ({ status: 'rejected', id: item.id, error: err })
-                            )
-                          )
-                        );
-                        setSelectedItems([]);
-                      }}
-                    >
-                      Cancel {selectedItems.length}{' '}
-                      {selectedItems.length !== 1 ? 'queries' : 'query'}
-                    </EuiButton>,
-                  ]
-                : undefined,
-            toolsRight: [
-              <EuiButton
-                key="refresh-button"
-                iconType="refresh"
-                onClick={async () => {
-                  await fetchLiveQueriesSafe();
-                }}
-              >
-                Refresh
-              </EuiButton>,
-            ],
-            filters: [
-              {
-                type: 'field_value_selection',
-                field: 'index',
-                name: 'Index',
-                multiSelect: 'or',
-                options: [...new Set(liveQueries.map((q) => q.index))].map((val) => ({
-                  value: val,
-                  name: val,
-                  view: val,
-                })),
-              },
-              {
-                type: 'field_value_selection',
-                field: 'search_type',
-                name: 'Search type',
-                multiSelect: 'or',
-                options: [...new Set(liveQueries.map((q) => q.search_type))].map((val) => ({
-                  value: val,
-                  name: val,
-                  view: val,
-                })),
-              },
-              {
-                type: 'field_value_selection',
-                field: 'coordinator_node',
-                name: 'Coordinator Node ID',
-                multiSelect: 'or',
-                options: [...new Set(liveQueries.map((q) => q.node_id))].map((val) => ({
-                  value: val,
-                  name: val,
-                  view: val,
-                })),
-              },
-            ],
-            onFiltersChange: (filters) => {
-              setTableFilters(filters);
-            },
-          }}
+                    await Promise.allSettled(
+                      selectedItems.map((item) =>
+                        httpClient.post(API_ENDPOINTS.CANCEL_TASK(item.id)).then(
+                          () => ({ status: 'fulfilled', id: item.id }),
+                          (err: any) => ({ status: 'rejected', id: item.id, error: err })
+                        )
+                      )
+                    );
+                    setSelectedItems([]);
+                  }}
+                >
+                  Cancel {selectedItems.length} {selectedItems.length !== 1 ? 'queries' : 'query'}
+                </EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size="m" />
+          </>
+        )}
+        <EuiInMemoryTable
+          items={filteredQueries}
           columns={[
-            { name: 'Timestamp', render: (item) => convertTime(item.timestamp) },
+            { name: 'Timestamp', render: (item: any) => convertTime(item.timestamp) },
             {
               field: 'id',
               name: 'Task ID',
@@ -1100,21 +1110,21 @@ export const InflightQueries = ({
             { field: 'coordinator_node', name: 'Coordinator node' },
             {
               name: 'Time elapsed',
-              render: (item) => formatTime(item.measurements?.latency?.number / 1e9),
+              render: (item: any) => formatTime(item.measurements?.latency?.number / 1e9),
             },
             {
               name: 'CPU usage',
-              render: (item) => formatTime(item.measurements?.cpu?.number / 1e9),
+              render: (item: any) => formatTime(item.measurements?.cpu?.number / 1e9),
             },
             {
               name: 'Memory usage',
-              render: (item) => formatMemory(item.measurements?.memory?.number),
+              render: (item: any) => formatMemory(item.measurements?.memory?.number),
             },
             { field: 'search_type', name: 'Search type' },
 
             {
               name: 'Status',
-              render: (item) =>
+              render: (item: any) =>
                 (item as any)._finished ? (
                   <EuiBadge
                     color={

--- a/public/pages/InflightQueries/__snapshots__/InflightQueries.test.tsx.snap
+++ b/public/pages/InflightQueries/__snapshots__/InflightQueries.test.tsx.snap
@@ -7,55 +7,36 @@ exports[`InflightQueries matches snapshot 1`] = `
       class="euiSpacer euiSpacer--m"
     />
     <div
-      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsFlexStart euiFlexGroup--directionRow euiFlexGroup--responsive"
     >
       <div
-        class="euiFlexGroup euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+        class="euiFlexItem"
       >
-        <span
-          class="euiBadge euiBadge--iconLeft"
-          style="background-color: rgb(211, 218, 230); color: rgb(0, 0, 0); padding: 6px 12px; height: 32px; display: flex; align-items: center; font-weight: bold;"
-          title="Workload group"
-        >
-          <span
-            class="euiBadge__content"
-          >
-            <span
-              class="euiBadge__text"
-            >
-              Workload group
-            </span>
-          </span>
-        </span>
         <div
-          class="euiFlexItem euiFlexItem--flexGrowZero"
+          style="position: relative; min-width: 400px;"
         >
           <div
-            class="euiFormControlLayout euiFormControlLayout--compressed"
+            class="euiFormControlLayout euiFormControlLayout--fullWidth"
           >
             <div
               class="euiFormControlLayout__childrenWrapper"
             >
-              <select
-                aria-label="Workload group selector"
-                class="euiSelect euiSelect--compressed"
-                id="wlm-group-select"
-              >
-                <option
-                  value=""
-                >
-                  All workload groups
-                </option>
-              </select>
+              <input
+                aria-label="Dynamic search bar"
+                class="euiFieldSearch euiFieldSearch--fullWidth"
+                placeholder="e.g. latency >= 1 AND status = Running"
+                type="search"
+                value=""
+              />
               <div
-                class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                class="euiFormControlLayoutIcons"
               >
                 <span
                   class="euiFormControlLayoutCustomIcon"
                 >
                   <svg
                     aria-hidden="true"
-                    class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                    class="euiIcon euiIcon--medium euiIcon-isLoaded euiFormControlLayoutCustomIcon__icon"
                     focusable="false"
                     height="16"
                     role="img"
@@ -64,8 +45,7 @@ exports[`InflightQueries matches snapshot 1`] = `
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
-                      d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                      fill-rule="non-zero"
+                      d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
                     />
                   </svg>
                 </span>
@@ -79,6 +59,7 @@ exports[`InflightQueries matches snapshot 1`] = `
       >
         <div
           class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+          style="min-height: 40px;"
         >
           <div
             class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -140,7 +121,11 @@ exports[`InflightQueries matches snapshot 1`] = `
                 class="euiSwitch__label"
                 id="random_html_id"
               >
-                Show finished queries
+                <span
+                  style="font-size: 16px;"
+                >
+                  Show finished queries
+                </span>
               </span>
             </div>
           </div>
@@ -204,7 +189,11 @@ exports[`InflightQueries matches snapshot 1`] = `
                 class="euiSwitch__label"
                 id="random_html_id"
               >
-                Auto-refresh
+                <span
+                  style="font-size: 16px;"
+                >
+                  Auto-refresh
+                </span>
               </span>
             </div>
           </div>
@@ -212,69 +201,59 @@ exports[`InflightQueries matches snapshot 1`] = `
             class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <div
-              class="euiFormRow euiFormRow--compressed euiFormRow--horizontal"
-              id="random_html_id-row"
+              class="euiFormControlLayout"
             >
               <div
-                class="euiFormRow__fieldWrapper"
+                class="euiFormControlLayout__childrenWrapper"
               >
-                <div
-                  class="euiFormControlLayout euiFormControlLayout--compressed"
+                <select
+                  class="euiSelect"
+                  data-test-subj="live-queries-refresh-interval"
+                  style="min-width: 140px;"
                 >
-                  <div
-                    class="euiFormControlLayout__childrenWrapper"
+                  <option
+                    value="5000"
                   >
-                    <select
-                      class="euiSelect euiSelect--compressed"
-                      data-test-subj="live-queries-refresh-interval"
-                      id="random_html_id"
-                      style="min-width: 140px;"
+                    5 seconds
+                  </option>
+                  <option
+                    value="10000"
+                  >
+                    10 seconds
+                  </option>
+                  <option
+                    value="30000"
+                  >
+                    30 seconds
+                  </option>
+                  <option
+                    value="60000"
+                  >
+                    1 minute
+                  </option>
+                </select>
+                <div
+                  class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                >
+                  <span
+                    class="euiFormControlLayoutCustomIcon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="euiIcon euiIcon--medium euiIcon-isLoaded euiFormControlLayoutCustomIcon__icon"
+                      focusable="false"
+                      height="16"
+                      role="img"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <option
-                        value="5000"
-                      >
-                        5 seconds
-                      </option>
-                      <option
-                        value="10000"
-                      >
-                        10 seconds
-                      </option>
-                      <option
-                        value="30000"
-                      >
-                        30 seconds
-                      </option>
-                      <option
-                        value="60000"
-                      >
-                        1 minute
-                      </option>
-                    </select>
-                    <div
-                      class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                    >
-                      <span
-                        class="euiFormControlLayoutCustomIcon"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="euiIcon euiIcon--small euiIcon-isLoaded euiFormControlLayoutCustomIcon__icon"
-                          focusable="false"
-                          height="16"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                            fill-rule="non-zero"
-                          />
-                        </svg>
-                      </span>
-                    </div>
-                  </div>
+                      <path
+                        d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                        fill-rule="non-zero"
+                      />
+                    </svg>
+                  </span>
                 </div>
               </div>
             </div>
@@ -319,38 +298,27 @@ exports[`InflightQueries matches snapshot 1`] = `
       class="euiSpacer euiSpacer--m"
     />
     <div
-      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+      class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
     >
       <div
-        class="euiFlexItem"
+        class="euiAccordion euiAccordion-isOpen"
       >
         <div
-          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-          data-test-subj="panel-active-queries"
+          class="euiAccordion__triggerWrapper"
         >
-          <div
-            class="euiFlexItem"
+          <button
+            aria-controls="live-queries-visualizations"
+            aria-expanded="true"
+            class="euiAccordion__button"
+            id="random_html_id"
+            type="button"
           >
-            <div
-              class="euiTextAlign euiTextAlign--center"
+            <span
+              class="euiAccordion__iconWrapper"
             >
-              <div
-                class="euiText euiText--small"
-              >
-                <p>
-                  Active queries
-                </p>
-              </div>
-              <h2
-                class="euiTitle euiTitle--large"
-              >
-                <b>
-                  7
-                </b>
-              </h2>
               <svg
                 aria-hidden="true"
-                class="euiIcon euiIcon--medium euiIcon-isLoaded"
+                class="euiIcon euiIcon--medium euiIcon-isLoaded euiAccordion__icon euiAccordion__icon-isOpen"
                 focusable="false"
                 height="16"
                 role="img"
@@ -359,683 +327,759 @@ exports[`InflightQueries matches snapshot 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="m12.877 5.847-1.02 1.02a.5.5 0 0 1-.708-.707l1.1-1.099c-.05-.053-.1-.106-.152-.157A6.471 6.471 0 0 0 8 3.019V4.5a.5.5 0 0 1-1 0V3.019a6.47 6.47 0 0 0-4.261 2.055l1.07 1.071a.5.5 0 0 1-.706.707l-.99-.99A6.46 6.46 0 0 0 1.018 10H2.5a.5.5 0 1 1 0 1H1.174c.083.353.196.697.337 1.03a.5.5 0 1 1-.922.39A7.487 7.487 0 0 1 0 9.5a7.483 7.483 0 0 1 2.197-5.304A7.487 7.487 0 0 1 7.5 2a7.487 7.487 0 0 1 5.304 2.197A7.483 7.483 0 0 1 15 9.5a7.487 7.487 0 0 1-.59 2.92.5.5 0 0 1-.92-.39c.14-.333.253-.677.336-1.03H12.5a.5.5 0 1 1 0-1h1.481a6.483 6.483 0 0 0-1.104-4.153Zm-6.041 5.317a.993.993 0 0 1-.01-1.404c.384-.385 2.882-2.002 3.149-1.735.267.267-1.35 2.765-1.735 3.15a.993.993 0 0 1-1.404-.01Z"
+                  d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
+                  fill-rule="nonzero"
                 />
               </svg>
-            </div>
-          </div>
+            </span>
+            <span
+              class="euiIEFlexWrapFix"
+            >
+              <h3
+                class="euiTitle euiTitle--small"
+              >
+                Stats & Visualizations
+              </h3>
+            </span>
+          </button>
         </div>
-      </div>
-      <div
-        class="euiFlexItem"
-      >
         <div
-          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-          data-test-subj="panel-avg-elapsed-time"
+          aria-labelledby="random_html_id"
+          class="euiAccordion__childWrapper"
+          id="live-queries-visualizations"
+          role="region"
+          tabindex="-1"
         >
-          <div
-            class="euiFlexItem"
-          >
+          <div>
             <div
-              class="euiTextAlign euiTextAlign--center"
+              class=""
             >
               <div
-                class="euiText euiText--small"
-              >
-                <p>
-                  Avg. elapsed time
-                </p>
-              </div>
-              <h2
-                class="euiTitle euiTitle--large"
-              >
-                <b>
-                  8.25 s
-                </b>
-              </h2>
+                class="euiSpacer euiSpacer--m"
+              />
               <div
-                class="euiText euiText--small"
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
               >
-                <p>
-                  (Avg. across 
-                  7
-                   active queries)
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="euiFlexItem"
-      >
-        <div
-          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-          data-test-subj="panel-longest-query"
-        >
-          <div
-            class="euiFlexItem"
-          >
-            <div
-              class="euiTextAlign euiTextAlign--center"
-            >
-              <div
-                class="euiText euiText--small"
-              >
-                <p>
-                  Longest running query
-                </p>
-              </div>
-              <h2
-                class="euiTitle euiTitle--large"
-              >
-                <b>
-                  9.69 s
-                </b>
-              </h2>
-              <div
-                class="euiText euiText--small"
-              >
-                <p>
-                  ID:
-                   
-                  <button
-                    class="euiLink euiLink--primary"
-                    type="button"
-                  >
-                    node-A1B2C4E5:3614
-                  </button>
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="euiFlexItem"
-      >
-        <div
-          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-          data-test-subj="panel-total-cpu"
-        >
-          <div
-            class="euiFlexItem"
-          >
-            <div
-              class="euiTextAlign euiTextAlign--center"
-            >
-              <div
-                class="euiText euiText--small"
-              >
-                <p>
-                  Total CPU usage
-                </p>
-              </div>
-              <h2
-                class="euiTitle euiTitle--large"
-              >
-                <b>
-                  576.76 µs
-                </b>
-              </h2>
-              <div
-                class="euiText euiText--small"
-              >
-                <p>
-                  (Sum across 
-                  7
-                   active queries)
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="euiFlexItem"
-      >
-        <div
-          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-          data-test-subj="panel-total-memory"
-        >
-          <div
-            class="euiFlexItem"
-          >
-            <div
-              class="euiTextAlign euiTextAlign--center"
-            >
-              <div
-                class="euiText euiText--small"
-              >
-                <p>
-                  Total memory usage
-                </p>
-              </div>
-              <h2
-                class="euiTitle euiTitle--large"
-              >
-                <b>
-                  23.53 KB
-                </b>
-              </h2>
-              <div
-                class="euiText euiText--small"
-              >
-                <p>
-                  (Sum across 
-                  7
-                   active queries)
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-    >
-      <div
-        class="euiFlexItem"
-      >
-        <div
-          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <div
-            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-          >
-            <p
-              class="euiTitle euiTitle--xsmall"
-            >
-              Active Queries by Node
-            </p>
-            <fieldset
-              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--primary"
-            >
-              <legend
-                class="euiScreenReaderOnly"
-              >
-                Chart Type
-              </legend>
-              <div
-                class="euiButtonGroup__buttons"
-              >
-                <label
-                  class="euiButtonGroupButton euiButtonGroupButton--primary euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                  for="random_html_id"
+                <div
+                  class="euiFlexItem"
                 >
-                  <span
-                    class="euiButtonContent euiButton__content"
+                  <div
+                    class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                    data-test-subj="panel-active-queries"
                   >
-                    <svg
-                      aria-labelledby="random_html_id"
-                      class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonContent__icon"
-                      focusable="false"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <div
+                      class="euiFlexItem"
                     >
-                      <title
-                        id="random_html_id"
+                      <div
+                        class="euiTextAlign euiTextAlign--center"
                       >
-                        Donut
-                      </title>
-                      <path
-                        d="M6.5 9a.5.5 0 0 1-.5-.5V3.023A5.5 5.5 0 1 0 11.978 9H6.5ZM7 8h5.5a.5.5 0 0 1 .5.5A6.5 6.5 0 1 1 6.5 2a.5.5 0 0 1 .5.5V8Zm2-6.972V6h4.972C13.696 3.552 11.448 1.304 9 1.028ZM14.5 7h-6a.5.5 0 0 1-.5-.5v-6a.5.5 0 0 1 .5-.5C11.853 0 15 3.147 15 6.5a.5.5 0 0 1-.5.5ZM6.146 8.854a.5.5 0 1 1 .708-.708l4 4a.5.5 0 0 1-.708.708l-4-4Z"
-                      />
-                    </svg>
-                    <span
-                      class="euiButton__text euiButtonGroupButton__textShift"
-                      data-text="Donut"
-                      title="Donut"
-                    >
-                      <input
-                        checked=""
-                        class="euiScreenReaderOnly"
-                        data-test-subj="donut"
-                        id="random_html_id"
-                        name="random_html_id"
-                        type="radio"
-                        value=""
-                      />
-                      Donut
-                    </span>
-                  </span>
-                </label>
-                <label
-                  class="euiButtonGroupButton euiButtonGroupButton--primary euiButtonGroupButton--small"
-                  for="random_html_id"
+                        <div
+                          class="euiText euiText--small"
+                        >
+                          <p>
+                            Active queries
+                          </p>
+                        </div>
+                        <h2
+                          class="euiTitle euiTitle--large"
+                        >
+                          <b>
+                            7
+                          </b>
+                        </h2>
+                        <svg
+                          aria-hidden="true"
+                          class="euiIcon euiIcon--medium euiIcon-isLoaded"
+                          focusable="false"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="m12.877 5.847-1.02 1.02a.5.5 0 0 1-.708-.707l1.1-1.099c-.05-.053-.1-.106-.152-.157A6.471 6.471 0 0 0 8 3.019V4.5a.5.5 0 0 1-1 0V3.019a6.47 6.47 0 0 0-4.261 2.055l1.07 1.071a.5.5 0 0 1-.706.707l-.99-.99A6.46 6.46 0 0 0 1.018 10H2.5a.5.5 0 1 1 0 1H1.174c.083.353.196.697.337 1.03a.5.5 0 1 1-.922.39A7.487 7.487 0 0 1 0 9.5a7.483 7.483 0 0 1 2.197-5.304A7.487 7.487 0 0 1 7.5 2a7.487 7.487 0 0 1 5.304 2.197A7.483 7.483 0 0 1 15 9.5a7.487 7.487 0 0 1-.59 2.92.5.5 0 0 1-.92-.39c.14-.333.253-.677.336-1.03H12.5a.5.5 0 1 1 0-1h1.481a6.483 6.483 0 0 0-1.104-4.153Zm-6.041 5.317a.993.993 0 0 1-.01-1.404c.384-.385 2.882-2.002 3.149-1.735.267.267-1.35 2.765-1.735 3.15a.993.993 0 0 1-1.404-.01Z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiFlexItem"
                 >
-                  <span
-                    class="euiButtonContent euiButton__content"
+                  <div
+                    class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                    data-test-subj="panel-avg-elapsed-time"
                   >
-                    <svg
-                      aria-labelledby="random_html_id"
-                      class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonContent__icon"
-                      focusable="false"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <div
+                      class="euiFlexItem"
                     >
-                      <title
-                        id="random_html_id"
+                      <div
+                        class="euiTextAlign euiTextAlign--center"
                       >
-                        Bar
-                      </title>
-                      <path
-                        d="M8.5 10h-6a.5.5 0 0 1 0-1H8V6H2.5a.5.5 0 0 1 0-1H13V2H2.5a.5.5 0 0 1 0-1h11a.5.5 0 0 1 .5.5v4a.5.5 0 0 1-.5.5H9v3h2.5a.5.5 0 0 1 .5.5v4a.5.5 0 0 1-.5.5h-9a.5.5 0 1 1 0-1H11v-3H8.5ZM0 .5a.5.5 0 1 1 1 0v14a.5.5 0 1 1-1 0V.5Z"
-                      />
-                    </svg>
-                    <span
-                      class="euiButton__text euiButtonGroupButton__textShift"
-                      data-text="Bar"
-                      title="Bar"
-                    >
-                      <input
-                        class="euiScreenReaderOnly"
-                        data-test-subj="bar"
-                        id="random_html_id"
-                        name="random_html_id"
-                        type="radio"
-                        value=""
-                      />
-                      Bar
-                    </span>
-                  </span>
-                </label>
-              </div>
-            </fieldset>
-          </div>
-          <div
-            class="euiSpacer euiSpacer--l"
-          />
-          <div
-            data-testid="chart-node-donut"
-          />
-          <div
-            class="euiSpacer euiSpacer--s"
-          />
-          <div
-            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--wrap"
-          >
-            <div
-              class="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <div
-                class="euiText euiText--extraSmall"
-              >
-                <span
-                  style="display: inline-block; width: 12px; height: 12px; background-color: rgb(31, 119, 180); margin-right: 6px;"
-                />
-                node-A1B2C3D4E5
-                : 
-                2
-              </div>
-            </div>
-            <div
-              class="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <div
-                class="euiText euiText--extraSmall"
-              >
-                <span
-                  style="display: inline-block; width: 12px; height: 12px; background-color: rgb(255, 127, 14); margin-right: 6px;"
-                />
-                4W2VTHIgQY-oB7dSrYz4B
-                : 
-                1
-              </div>
-            </div>
-            <div
-              class="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <div
-                class="euiText euiText--extraSmall"
-              >
-                <span
-                  style="display: inline-block; width: 12px; height: 12px; background-color: rgb(44, 160, 44); margin-right: 6px;"
-                />
-                node-X9Y8Z7W6
-                : 
-                1
-              </div>
-            </div>
-            <div
-              class="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <div
-                class="euiText euiText--extraSmall"
-              >
-                <span
-                  style="display: inline-block; width: 12px; height: 12px; background-color: rgb(214, 39, 40); margin-right: 6px;"
-                />
-                node-P0Q9R8S7
-                : 
-                1
-              </div>
-            </div>
-            <div
-              class="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <div
-                class="euiText euiText--extraSmall"
-              >
-                <span
-                  style="display: inline-block; width: 12px; height: 12px; background-color: rgb(148, 103, 189); margin-right: 6px;"
-                />
-                4W2VTHIgQY-oB7dSrYz4
-                : 
-                1
-              </div>
-            </div>
-            <div
-              class="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <div
-                class="euiText euiText--extraSmall"
-              >
-                <span
-                  style="display: inline-block; width: 12px; height: 12px; background-color: rgb(140, 86, 75); margin-right: 6px;"
-                />
-                node-M2O3P4Q5
-                : 
-                1
-              </div>
-            </div>
-            <div
-              class="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <div
-                class="euiText euiText--extraSmall"
-              >
-                <span
-                  style="display: inline-block; width: 12px; height: 12px; background-color: rgb(227, 119, 194); margin-right: 6px;"
-                />
-                node-B2C3D4E5
-                : 
-                1
-              </div>
-            </div>
-            <div
-              class="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <div
-                class="euiText euiText--extraSmall"
-              >
-                <span
-                  style="display: inline-block; width: 12px; height: 12px; background-color: rgb(127, 127, 127); margin-right: 6px;"
-                />
-                node-N2O3P4Q5
-                : 
-                1
-              </div>
-            </div>
-            <div
-              class="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <div
-                class="euiText euiText--extraSmall"
-              >
-                <span
-                  style="display: inline-block; width: 12px; height: 12px; background-color: rgb(188, 189, 34); margin-right: 6px;"
-                />
-                2VTHIgQY-oB7dSrYz4BQ
-                : 
-                1
-              </div>
-            </div>
-            <div
-              class="euiFlexItem euiFlexItem--flexGrowZero"
-            >
-              <div
-                class="euiText euiText--extraSmall"
-              >
-                <span
-                  style="display: inline-block; width: 12px; height: 12px; background-color: rgb(23, 190, 207); margin-right: 6px;"
-                />
-                others
-                : 
-                10
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="euiFlexItem"
-      >
-        <div
-          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <div
-            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-          >
-            <p
-              class="euiTitle euiTitle--xsmall"
-            >
-              Active Queries by Index
-            </p>
-            <fieldset
-              class="euiButtonGroup euiButtonGroup--small euiButtonGroup--primary"
-            >
-              <legend
-                class="euiScreenReaderOnly"
-              >
-                Chart Type
-              </legend>
-              <div
-                class="euiButtonGroup__buttons"
-              >
-                <label
-                  class="euiButtonGroupButton euiButtonGroupButton--primary euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
-                  for="random_html_id"
+                        <div
+                          class="euiText euiText--small"
+                        >
+                          <p>
+                            Avg. elapsed time
+                          </p>
+                        </div>
+                        <h2
+                          class="euiTitle euiTitle--large"
+                        >
+                          <b>
+                            8.25 s
+                          </b>
+                        </h2>
+                        <div
+                          class="euiText euiText--small"
+                        >
+                          <p>
+                            (Avg. across 
+                            7
+                             active queries)
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiFlexItem"
                 >
-                  <span
-                    class="euiButtonContent euiButton__content"
+                  <div
+                    class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                    data-test-subj="panel-longest-query"
                   >
-                    <svg
-                      aria-labelledby="random_html_id"
-                      class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonContent__icon"
-                      focusable="false"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <div
+                      class="euiFlexItem"
                     >
-                      <title
-                        id="random_html_id"
+                      <div
+                        class="euiTextAlign euiTextAlign--center"
                       >
-                        Donut
-                      </title>
-                      <path
-                        d="M6.5 9a.5.5 0 0 1-.5-.5V3.023A5.5 5.5 0 1 0 11.978 9H6.5ZM7 8h5.5a.5.5 0 0 1 .5.5A6.5 6.5 0 1 1 6.5 2a.5.5 0 0 1 .5.5V8Zm2-6.972V6h4.972C13.696 3.552 11.448 1.304 9 1.028ZM14.5 7h-6a.5.5 0 0 1-.5-.5v-6a.5.5 0 0 1 .5-.5C11.853 0 15 3.147 15 6.5a.5.5 0 0 1-.5.5ZM6.146 8.854a.5.5 0 1 1 .708-.708l4 4a.5.5 0 0 1-.708.708l-4-4Z"
-                      />
-                    </svg>
-                    <span
-                      class="euiButton__text euiButtonGroupButton__textShift"
-                      data-text="Donut"
-                      title="Donut"
-                    >
-                      <input
-                        checked=""
-                        class="euiScreenReaderOnly"
-                        data-test-subj="donut"
-                        id="random_html_id"
-                        name="random_html_id"
-                        type="radio"
-                        value=""
-                      />
-                      Donut
-                    </span>
-                  </span>
-                </label>
-                <label
-                  class="euiButtonGroupButton euiButtonGroupButton--primary euiButtonGroupButton--small"
-                  for="random_html_id"
+                        <div
+                          class="euiText euiText--small"
+                        >
+                          <p>
+                            Longest running query
+                          </p>
+                        </div>
+                        <h2
+                          class="euiTitle euiTitle--large"
+                        >
+                          <b>
+                            9.69 s
+                          </b>
+                        </h2>
+                        <div
+                          class="euiText euiText--small"
+                        >
+                          <p>
+                            ID:
+                             
+                            <button
+                              class="euiLink euiLink--primary"
+                              type="button"
+                            >
+                              node-A1B2C4E5:3614
+                            </button>
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiFlexItem"
                 >
-                  <span
-                    class="euiButtonContent euiButton__content"
+                  <div
+                    class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                    data-test-subj="panel-total-cpu"
                   >
-                    <svg
-                      aria-labelledby="random_html_id"
-                      class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonContent__icon"
-                      focusable="false"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <div
+                      class="euiFlexItem"
                     >
-                      <title
-                        id="random_html_id"
+                      <div
+                        class="euiTextAlign euiTextAlign--center"
                       >
-                        Bar
-                      </title>
-                      <path
-                        d="M8.5 10h-6a.5.5 0 0 1 0-1H8V6H2.5a.5.5 0 0 1 0-1H13V2H2.5a.5.5 0 0 1 0-1h11a.5.5 0 0 1 .5.5v4a.5.5 0 0 1-.5.5H9v3h2.5a.5.5 0 0 1 .5.5v4a.5.5 0 0 1-.5.5h-9a.5.5 0 1 1 0-1H11v-3H8.5ZM0 .5a.5.5 0 1 1 1 0v14a.5.5 0 1 1-1 0V.5Z"
-                      />
-                    </svg>
-                    <span
-                      class="euiButton__text euiButtonGroupButton__textShift"
-                      data-text="Bar"
-                      title="Bar"
+                        <div
+                          class="euiText euiText--small"
+                        >
+                          <p>
+                            Total CPU usage
+                          </p>
+                        </div>
+                        <h2
+                          class="euiTitle euiTitle--large"
+                        >
+                          <b>
+                            576.76 µs
+                          </b>
+                        </h2>
+                        <div
+                          class="euiText euiText--small"
+                        >
+                          <p>
+                            (Sum across 
+                            7
+                             active queries)
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                    data-test-subj="panel-total-memory"
+                  >
+                    <div
+                      class="euiFlexItem"
                     >
-                      <input
-                        class="euiScreenReaderOnly"
-                        data-test-subj="bar"
-                        id="random_html_id"
-                        name="random_html_id"
-                        type="radio"
-                        value=""
-                      />
-                      Bar
-                    </span>
-                  </span>
-                </label>
+                      <div
+                        class="euiTextAlign euiTextAlign--center"
+                      >
+                        <div
+                          class="euiText euiText--small"
+                        >
+                          <p>
+                            Total memory usage
+                          </p>
+                        </div>
+                        <h2
+                          class="euiTitle euiTitle--large"
+                        >
+                          <b>
+                            23.53 KB
+                          </b>
+                        </h2>
+                        <div
+                          class="euiText euiText--small"
+                        >
+                          <p>
+                            (Sum across 
+                            7
+                             active queries)
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </div>
-            </fieldset>
-          </div>
-          <div
-            class="euiSpacer euiSpacer--l"
-          />
-          <div
-            data-testid="chart-index-donut"
-          />
-          <div
-            class="euiSpacer euiSpacer--s"
-          />
-          <div
-            class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--wrap"
-          >
-            <div
-              class="euiFlexItem euiFlexItem--flexGrowZero"
-            >
               <div
-                class="euiText euiText--extraSmall"
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
               >
-                <span
-                  style="display: inline-block; width: 12px; height: 12px; background-color: rgb(31, 119, 180); margin-right: 6px;"
-                />
-                top_queries-2025.06.06-11009
-                : 
-                19
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                  >
+                    <div
+                      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <p
+                        class="euiTitle euiTitle--xsmall"
+                      >
+                        Active Queries by Node
+                      </p>
+                      <fieldset
+                        class="euiButtonGroup euiButtonGroup--small euiButtonGroup--primary"
+                      >
+                        <legend
+                          class="euiScreenReaderOnly"
+                        >
+                          Chart Type
+                        </legend>
+                        <div
+                          class="euiButtonGroup__buttons"
+                        >
+                          <label
+                            class="euiButtonGroupButton euiButtonGroupButton--primary euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                            for="random_html_id"
+                          >
+                            <span
+                              class="euiButtonContent euiButton__content"
+                            >
+                              <svg
+                                aria-labelledby="random_html_id"
+                                class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonContent__icon"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <title
+                                  id="random_html_id"
+                                >
+                                  Donut
+                                </title>
+                                <path
+                                  d="M6.5 9a.5.5 0 0 1-.5-.5V3.023A5.5 5.5 0 1 0 11.978 9H6.5ZM7 8h5.5a.5.5 0 0 1 .5.5A6.5 6.5 0 1 1 6.5 2a.5.5 0 0 1 .5.5V8Zm2-6.972V6h4.972C13.696 3.552 11.448 1.304 9 1.028ZM14.5 7h-6a.5.5 0 0 1-.5-.5v-6a.5.5 0 0 1 .5-.5C11.853 0 15 3.147 15 6.5a.5.5 0 0 1-.5.5ZM6.146 8.854a.5.5 0 1 1 .708-.708l4 4a.5.5 0 0 1-.708.708l-4-4Z"
+                                />
+                              </svg>
+                              <span
+                                class="euiButton__text euiButtonGroupButton__textShift"
+                                data-text="Donut"
+                                title="Donut"
+                              >
+                                <input
+                                  checked=""
+                                  class="euiScreenReaderOnly"
+                                  data-test-subj="donut"
+                                  id="random_html_id"
+                                  name="random_html_id"
+                                  type="radio"
+                                  value=""
+                                />
+                                Donut
+                              </span>
+                            </span>
+                          </label>
+                          <label
+                            class="euiButtonGroupButton euiButtonGroupButton--primary euiButtonGroupButton--small"
+                            for="random_html_id"
+                          >
+                            <span
+                              class="euiButtonContent euiButton__content"
+                            >
+                              <svg
+                                aria-labelledby="random_html_id"
+                                class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonContent__icon"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <title
+                                  id="random_html_id"
+                                >
+                                  Bar
+                                </title>
+                                <path
+                                  d="M8.5 10h-6a.5.5 0 0 1 0-1H8V6H2.5a.5.5 0 0 1 0-1H13V2H2.5a.5.5 0 0 1 0-1h11a.5.5 0 0 1 .5.5v4a.5.5 0 0 1-.5.5H9v3h2.5a.5.5 0 0 1 .5.5v4a.5.5 0 0 1-.5.5h-9a.5.5 0 1 1 0-1H11v-3H8.5ZM0 .5a.5.5 0 1 1 1 0v14a.5.5 0 1 1-1 0V.5Z"
+                                />
+                              </svg>
+                              <span
+                                class="euiButton__text euiButtonGroupButton__textShift"
+                                data-text="Bar"
+                                title="Bar"
+                              >
+                                <input
+                                  class="euiScreenReaderOnly"
+                                  data-test-subj="bar"
+                                  id="random_html_id"
+                                  name="random_html_id"
+                                  type="radio"
+                                  value=""
+                                />
+                                Bar
+                              </span>
+                            </span>
+                          </label>
+                        </div>
+                      </fieldset>
+                    </div>
+                    <div
+                      class="euiSpacer euiSpacer--l"
+                    />
+                    <div
+                      data-testid="chart-node-donut"
+                    />
+                    <div
+                      class="euiSpacer euiSpacer--s"
+                    />
+                    <div
+                      class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--wrap"
+                    >
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                      >
+                        <div
+                          class="euiText euiText--extraSmall"
+                        >
+                          <span
+                            style="display: inline-block; width: 12px; height: 12px; background-color: rgb(31, 119, 180); margin-right: 6px;"
+                          />
+                          node-A1B2C3D4E5
+                          : 
+                          2
+                        </div>
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                      >
+                        <div
+                          class="euiText euiText--extraSmall"
+                        >
+                          <span
+                            style="display: inline-block; width: 12px; height: 12px; background-color: rgb(255, 127, 14); margin-right: 6px;"
+                          />
+                          4W2VTHIgQY-oB7dSrYz4B
+                          : 
+                          1
+                        </div>
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                      >
+                        <div
+                          class="euiText euiText--extraSmall"
+                        >
+                          <span
+                            style="display: inline-block; width: 12px; height: 12px; background-color: rgb(44, 160, 44); margin-right: 6px;"
+                          />
+                          node-X9Y8Z7W6
+                          : 
+                          1
+                        </div>
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                      >
+                        <div
+                          class="euiText euiText--extraSmall"
+                        >
+                          <span
+                            style="display: inline-block; width: 12px; height: 12px; background-color: rgb(214, 39, 40); margin-right: 6px;"
+                          />
+                          node-P0Q9R8S7
+                          : 
+                          1
+                        </div>
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                      >
+                        <div
+                          class="euiText euiText--extraSmall"
+                        >
+                          <span
+                            style="display: inline-block; width: 12px; height: 12px; background-color: rgb(148, 103, 189); margin-right: 6px;"
+                          />
+                          4W2VTHIgQY-oB7dSrYz4
+                          : 
+                          1
+                        </div>
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                      >
+                        <div
+                          class="euiText euiText--extraSmall"
+                        >
+                          <span
+                            style="display: inline-block; width: 12px; height: 12px; background-color: rgb(140, 86, 75); margin-right: 6px;"
+                          />
+                          node-M2O3P4Q5
+                          : 
+                          1
+                        </div>
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                      >
+                        <div
+                          class="euiText euiText--extraSmall"
+                        >
+                          <span
+                            style="display: inline-block; width: 12px; height: 12px; background-color: rgb(227, 119, 194); margin-right: 6px;"
+                          />
+                          node-B2C3D4E5
+                          : 
+                          1
+                        </div>
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                      >
+                        <div
+                          class="euiText euiText--extraSmall"
+                        >
+                          <span
+                            style="display: inline-block; width: 12px; height: 12px; background-color: rgb(127, 127, 127); margin-right: 6px;"
+                          />
+                          node-N2O3P4Q5
+                          : 
+                          1
+                        </div>
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                      >
+                        <div
+                          class="euiText euiText--extraSmall"
+                        >
+                          <span
+                            style="display: inline-block; width: 12px; height: 12px; background-color: rgb(188, 189, 34); margin-right: 6px;"
+                          />
+                          2VTHIgQY-oB7dSrYz4BQ
+                          : 
+                          1
+                        </div>
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                      >
+                        <div
+                          class="euiText euiText--extraSmall"
+                        >
+                          <span
+                            style="display: inline-block; width: 12px; height: 12px; background-color: rgb(23, 190, 207); margin-right: 6px;"
+                          />
+                          others
+                          : 
+                          10
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                  >
+                    <div
+                      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    >
+                      <p
+                        class="euiTitle euiTitle--xsmall"
+                      >
+                        Active Queries by Index
+                      </p>
+                      <fieldset
+                        class="euiButtonGroup euiButtonGroup--small euiButtonGroup--primary"
+                      >
+                        <legend
+                          class="euiScreenReaderOnly"
+                        >
+                          Chart Type
+                        </legend>
+                        <div
+                          class="euiButtonGroup__buttons"
+                        >
+                          <label
+                            class="euiButtonGroupButton euiButtonGroupButton--primary euiButtonGroupButton--small euiButtonGroupButton--fill euiButtonGroupButton-isSelected"
+                            for="random_html_id"
+                          >
+                            <span
+                              class="euiButtonContent euiButton__content"
+                            >
+                              <svg
+                                aria-labelledby="random_html_id"
+                                class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonContent__icon"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <title
+                                  id="random_html_id"
+                                >
+                                  Donut
+                                </title>
+                                <path
+                                  d="M6.5 9a.5.5 0 0 1-.5-.5V3.023A5.5 5.5 0 1 0 11.978 9H6.5ZM7 8h5.5a.5.5 0 0 1 .5.5A6.5 6.5 0 1 1 6.5 2a.5.5 0 0 1 .5.5V8Zm2-6.972V6h4.972C13.696 3.552 11.448 1.304 9 1.028ZM14.5 7h-6a.5.5 0 0 1-.5-.5v-6a.5.5 0 0 1 .5-.5C11.853 0 15 3.147 15 6.5a.5.5 0 0 1-.5.5ZM6.146 8.854a.5.5 0 1 1 .708-.708l4 4a.5.5 0 0 1-.708.708l-4-4Z"
+                                />
+                              </svg>
+                              <span
+                                class="euiButton__text euiButtonGroupButton__textShift"
+                                data-text="Donut"
+                                title="Donut"
+                              >
+                                <input
+                                  checked=""
+                                  class="euiScreenReaderOnly"
+                                  data-test-subj="donut"
+                                  id="random_html_id"
+                                  name="random_html_id"
+                                  type="radio"
+                                  value=""
+                                />
+                                Donut
+                              </span>
+                            </span>
+                          </label>
+                          <label
+                            class="euiButtonGroupButton euiButtonGroupButton--primary euiButtonGroupButton--small"
+                            for="random_html_id"
+                          >
+                            <span
+                              class="euiButtonContent euiButton__content"
+                            >
+                              <svg
+                                aria-labelledby="random_html_id"
+                                class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonContent__icon"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <title
+                                  id="random_html_id"
+                                >
+                                  Bar
+                                </title>
+                                <path
+                                  d="M8.5 10h-6a.5.5 0 0 1 0-1H8V6H2.5a.5.5 0 0 1 0-1H13V2H2.5a.5.5 0 0 1 0-1h11a.5.5 0 0 1 .5.5v4a.5.5 0 0 1-.5.5H9v3h2.5a.5.5 0 0 1 .5.5v4a.5.5 0 0 1-.5.5h-9a.5.5 0 1 1 0-1H11v-3H8.5ZM0 .5a.5.5 0 1 1 1 0v14a.5.5 0 1 1-1 0V.5Z"
+                                />
+                              </svg>
+                              <span
+                                class="euiButton__text euiButtonGroupButton__textShift"
+                                data-text="Bar"
+                                title="Bar"
+                              >
+                                <input
+                                  class="euiScreenReaderOnly"
+                                  data-test-subj="bar"
+                                  id="random_html_id"
+                                  name="random_html_id"
+                                  type="radio"
+                                  value=""
+                                />
+                                Bar
+                              </span>
+                            </span>
+                          </label>
+                        </div>
+                      </fieldset>
+                    </div>
+                    <div
+                      class="euiSpacer euiSpacer--l"
+                    />
+                    <div
+                      data-testid="chart-index-donut"
+                    />
+                    <div
+                      class="euiSpacer euiSpacer--s"
+                    />
+                    <div
+                      class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--wrap"
+                    >
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                      >
+                        <div
+                          class="euiText euiText--extraSmall"
+                        >
+                          <span
+                            style="display: inline-block; width: 12px; height: 12px; background-color: rgb(31, 119, 180); margin-right: 6px;"
+                          />
+                          top_queries-2025.06.06-11009
+                          : 
+                          19
+                        </div>
+                      </div>
+                      <div
+                        class="euiFlexItem euiFlexItem--flexGrowZero"
+                      >
+                        <div
+                          class="euiText euiText--extraSmall"
+                        >
+                          <span
+                            style="display: inline-block; width: 12px; height: 12px; background-color: rgb(255, 127, 14); margin-right: 6px;"
+                          />
+                          opensearch
+                          : 
+                          1
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </div>
-            </div>
-            <div
-              class="euiFlexItem euiFlexItem--flexGrowZero"
-            >
               <div
-                class="euiText euiText--extraSmall"
+                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
               >
-                <span
-                  style="display: inline-block; width: 12px; height: 12px; background-color: rgb(255, 127, 14); margin-right: 6px;"
-                />
-                opensearch
-                : 
-                1
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                  >
+                    <div
+                      class="euiTextAlign euiTextAlign--center"
+                    >
+                      <div
+                        class="euiText euiText--small"
+                      >
+                        <p>
+                          Total completions
+                        </p>
+                      </div>
+                      <h2
+                        class="euiTitle euiTitle--large"
+                      >
+                        0
+                      </h2>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                  >
+                    <div
+                      class="euiTextAlign euiTextAlign--center"
+                    >
+                      <div
+                        class="euiText euiText--small"
+                      >
+                        <p>
+                          Total cancellations
+                        </p>
+                      </div>
+                      <h2
+                        class="euiTitle euiTitle--large"
+                      >
+                        13
+                      </h2>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+                  >
+                    <div
+                      class="euiTextAlign euiTextAlign--center"
+                    >
+                      <div
+                        class="euiText euiText--small"
+                      >
+                        <p>
+                          Total failures
+                        </p>
+                      </div>
+                      <h2
+                        class="euiTitle euiTitle--large"
+                      >
+                        0
+                      </h2>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-    >
-      <div
-        class="euiFlexItem"
-      >
-        <div
-          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <div
-            class="euiTextAlign euiTextAlign--center"
-          >
-            <div
-              class="euiText euiText--small"
-            >
-              <p>
-                Total completions
-              </p>
-            </div>
-            <h2
-              class="euiTitle euiTitle--large"
-            >
-              0
-            </h2>
-          </div>
-        </div>
-      </div>
-      <div
-        class="euiFlexItem"
-      >
-        <div
-          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <div
-            class="euiTextAlign euiTextAlign--center"
-          >
-            <div
-              class="euiText euiText--small"
-            >
-              <p>
-                Total cancellations
-              </p>
-            </div>
-            <h2
-              class="euiTitle euiTitle--large"
-            >
-              13
-            </h2>
-          </div>
-        </div>
-      </div>
-      <div
-        class="euiFlexItem"
-      >
-        <div
-          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
-        >
-          <div
-            class="euiTextAlign euiTextAlign--center"
-          >
-            <div
-              class="euiText euiText--small"
-            >
-              <p>
-                Total failures
-              </p>
-            </div>
-            <h2
-              class="euiTitle euiTitle--large"
-            >
-              0
-            </h2>
           </div>
         </div>
       </div>
@@ -1046,3025 +1090,2803 @@ exports[`InflightQueries matches snapshot 1`] = `
     <div
       class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
     >
-      <div>
-        <div
-          class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive euiFlexGroup--wrap"
-        >
+      <div
+        class="euiBasicTable"
+      >
+        <div>
           <div
-            class="euiFlexItem euiSearchBar__searchHolder"
+            class="euiTableHeaderMobile"
           >
             <div
-              class="euiFormControlLayout euiFormControlLayout--fullWidth"
-            >
-              <div
-                class="euiFormControlLayout__childrenWrapper"
-              >
-                <input
-                  aria-label="This is a search bar. After typing your query, hit enter to filter the results lower in the page."
-                  class="euiFieldSearch euiFieldSearch--fullWidth"
-                  placeholder="Search queries"
-                  type="search"
-                  value=""
-                />
-                <div
-                  class="euiFormControlLayoutIcons"
-                >
-                  <span
-                    class="euiFormControlLayoutCustomIcon"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="euiIcon euiIcon--medium euiIcon-isLoaded euiFormControlLayoutCustomIcon__icon"
-                      focusable="false"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                      />
-                    </svg>
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="euiFlexItem euiFlexItem--flexGrowZero euiSearchBar__filtersHolder"
-          >
-            <div
-              class="euiFilterGroup"
-            >
-              <div
-                class="euiPopover euiPopover--anchorDownCenter"
-                id="field_value_selection_0"
-              >
-                <div
-                  class="euiPopover__anchor"
-                >
-                  <button
-                    class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
-                    type="button"
-                  >
-                    <span
-                      class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonContent__icon"
-                        focusable="false"
-                        height="16"
-                        role="img"
-                        viewBox="0 0 16 16"
-                        width="16"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                          fill-rule="non-zero"
-                        />
-                      </svg>
-                      <span
-                        class="euiButtonEmpty__text"
-                      >
-                        <span
-                          class="euiFilterButton__textShift"
-                          data-text="Index"
-                          title="Index"
-                        >
-                          Index
-                        </span>
-                      </span>
-                    </span>
-                  </button>
-                </div>
-              </div>
-              <div
-                class="euiPopover euiPopover--anchorDownCenter"
-                id="field_value_selection_1"
-              >
-                <div
-                  class="euiPopover__anchor"
-                >
-                  <button
-                    class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
-                    type="button"
-                  >
-                    <span
-                      class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonContent__icon"
-                        focusable="false"
-                        height="16"
-                        role="img"
-                        viewBox="0 0 16 16"
-                        width="16"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                          fill-rule="non-zero"
-                        />
-                      </svg>
-                      <span
-                        class="euiButtonEmpty__text"
-                      >
-                        <span
-                          class="euiFilterButton__textShift"
-                          data-text="Search type"
-                          title="Search type"
-                        >
-                          Search type
-                        </span>
-                      </span>
-                    </span>
-                  </button>
-                </div>
-              </div>
-              <div
-                class="euiPopover euiPopover--anchorDownCenter"
-                id="field_value_selection_2"
-              >
-                <div
-                  class="euiPopover__anchor"
-                >
-                  <button
-                    class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
-                    type="button"
-                  >
-                    <span
-                      class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonContent__icon"
-                        focusable="false"
-                        height="16"
-                        role="img"
-                        viewBox="0 0 16 16"
-                        width="16"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                          fill-rule="non-zero"
-                        />
-                      </svg>
-                      <span
-                        class="euiButtonEmpty__text"
-                      >
-                        <span
-                          class="euiFilterButton__textShift"
-                          data-text="Coordinator Node ID"
-                          title="Coordinator Node ID"
-                        >
-                          Coordinator Node ID
-                        </span>
-                      </span>
-                    </span>
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="euiFlexItem euiFlexItem--flexGrowZero"
-          >
-            <button
-              class="euiButton euiButton--primary"
-              type="button"
-            >
-              <span
-                class="euiButtonContent euiButton__content"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonContent__icon"
-                  focusable="false"
-                  height="16"
-                  role="img"
-                  viewBox="0 0 16 16"
-                  width="16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M11.228 2.942a.5.5 0 1 1-.538.842A5 5 0 1 0 13 8a.5.5 0 1 1 1 0 6 6 0 1 1-2.772-5.058ZM14 1.5v3A1.5 1.5 0 0 1 12.5 6h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 1 1 1 0Z"
-                  />
-                </svg>
-                <span
-                  class="euiButton__text"
-                >
-                  Refresh
-                </span>
-              </span>
-            </button>
-          </div>
-        </div>
-        <div
-          class="euiSpacer euiSpacer--l"
-        />
-        <div
-          class="euiBasicTable"
-        >
-          <div>
-            <div
-              class="euiTableHeaderMobile"
-            >
-              <div
-                class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
-              >
-                <div
-                  class="euiFlexItem euiFlexItem--flexGrowZero"
-                >
-                  <div
-                    class="euiCheckbox"
-                  >
-                    <input
-                      aria-label="Select all rows"
-                      class="euiCheckbox__input"
-                      id="_selection_column-checkbox_random_html_id"
-                      type="checkbox"
-                    />
-                    <div
-                      class="euiCheckbox__square"
-                    />
-                    <label
-                      class="euiCheckbox__label"
-                      for="_selection_column-checkbox_random_html_id"
-                    >
-                      Select all rows
-                    </label>
-                  </div>
-                </div>
-                <div
-                  class="euiFlexItem euiFlexItem--flexGrowZero"
-                />
-              </div>
-            </div>
-            <table
-              class="euiTable euiTable--responsive"
-              id="random_html_id"
-              tabindex="-1"
-            >
-              <caption
-                class="euiScreenReaderOnly euiTableCaption"
-              />
-              <thead>
-                <tr>
-                  <th
-                    class="euiTableHeaderCellCheckbox"
-                    scope="col"
-                  >
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <div
-                        class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                      >
-                        <input
-                          aria-label="Select all rows"
-                          class="euiCheckbox__input"
-                          data-test-subj="checkboxSelectAll"
-                          id="_selection_column-checkbox_random_html_id"
-                          type="checkbox"
-                        />
-                        <div
-                          class="euiCheckbox__square"
-                        />
-                      </div>
-                    </div>
-                  </th>
-                  <th
-                    class="euiTableHeaderCell"
-                    data-test-subj="tableHeaderCell_Timestamp_0"
-                    role="columnheader"
-                    scope="col"
-                  >
-                    <span
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                        title="Timestamp"
-                      >
-                        Timestamp
-                      </span>
-                    </span>
-                  </th>
-                  <th
-                    class="euiTableHeaderCell"
-                    data-test-subj="tableHeaderCell_id_1"
-                    role="columnheader"
-                    scope="col"
-                  >
-                    <span
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                        title="Task ID"
-                      >
-                        Task ID
-                      </span>
-                    </span>
-                  </th>
-                  <th
-                    class="euiTableHeaderCell"
-                    data-test-subj="tableHeaderCell_index_2"
-                    role="columnheader"
-                    scope="col"
-                  >
-                    <span
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                        title="Index"
-                      >
-                        Index
-                      </span>
-                    </span>
-                  </th>
-                  <th
-                    class="euiTableHeaderCell"
-                    data-test-subj="tableHeaderCell_coordinator_node_3"
-                    role="columnheader"
-                    scope="col"
-                  >
-                    <span
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                        title="Coordinator node"
-                      >
-                        Coordinator node
-                      </span>
-                    </span>
-                  </th>
-                  <th
-                    class="euiTableHeaderCell"
-                    data-test-subj="tableHeaderCell_Time elapsed_4"
-                    role="columnheader"
-                    scope="col"
-                  >
-                    <span
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                        title="Time elapsed"
-                      >
-                        Time elapsed
-                      </span>
-                    </span>
-                  </th>
-                  <th
-                    class="euiTableHeaderCell"
-                    data-test-subj="tableHeaderCell_CPU usage_5"
-                    role="columnheader"
-                    scope="col"
-                  >
-                    <span
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                        title="CPU usage"
-                      >
-                        CPU usage
-                      </span>
-                    </span>
-                  </th>
-                  <th
-                    class="euiTableHeaderCell"
-                    data-test-subj="tableHeaderCell_Memory usage_6"
-                    role="columnheader"
-                    scope="col"
-                  >
-                    <span
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                        title="Memory usage"
-                      >
-                        Memory usage
-                      </span>
-                    </span>
-                  </th>
-                  <th
-                    class="euiTableHeaderCell"
-                    data-test-subj="tableHeaderCell_search_type_7"
-                    role="columnheader"
-                    scope="col"
-                  >
-                    <span
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                        title="Search type"
-                      >
-                        Search type
-                      </span>
-                    </span>
-                  </th>
-                  <th
-                    class="euiTableHeaderCell"
-                    data-test-subj="tableHeaderCell_Status_8"
-                    role="columnheader"
-                    scope="col"
-                  >
-                    <span
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                        title="Status"
-                      >
-                        Status
-                      </span>
-                    </span>
-                  </th>
-                  <th
-                    class="euiTableHeaderCell"
-                    data-test-subj="tableHeaderCell_WLM Group_9"
-                    role="columnheader"
-                    scope="col"
-                  >
-                    <span
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                        title="WLM Group"
-                      >
-                        WLM Group
-                      </span>
-                    </span>
-                  </th>
-                  <th
-                    class="euiTableHeaderCell"
-                    role="columnheader"
-                    scope="col"
-                  >
-                    <span
-                      class="euiTableCellContent euiTableCellContent--alignRight"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                        title="Actions"
-                      >
-                        Actions
-                      </span>
-                    </span>
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr
-                  class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
-                >
-                  <td
-                    class="euiTableRowCellCheckbox"
-                  >
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <div
-                        class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                      >
-                        <input
-                          aria-label="Select this row"
-                          class="euiCheckbox__input"
-                          data-test-subj="checkboxSelectRow-node-A1B2C3D4E5:3600-1640995200000"
-                          disabled=""
-                          id="_selection_column_node-A1B2C3D4E5:3600-1640995200000-checkbox"
-                          title="Select this row"
-                          type="checkbox"
-                        />
-                        <div
-                          class="euiCheckbox__square"
-                        />
-                      </div>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Timestamp
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      Sep 24, 2021 @ 12:00:00 AM
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Task ID
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <button
-                        class="euiLink euiLink--primary"
-                        type="button"
-                      >
-                        node-A1B2C3D4E5:3600
-                      </button>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Index
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        top_queries-2025.06.06-11009
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Coordinator node
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        node-A1B2C3D4E5
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Time elapsed
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      7.99 s
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      CPU usage
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      89.95 µs
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Memory usage
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      3.73 KB
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Search type
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        QUERY THEN FETCH
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Status
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <span
-                        class="euiBadge euiBadge--iconLeft"
-                        style="background-color: rgb(255, 126, 98); color: rgb(0, 0, 0);"
-                        title="Cancelled"
-                      >
-                        <span
-                          class="euiBadge__content"
-                        >
-                          <span
-                            class="euiBadge__text"
-                          >
-                            Cancelled
-                          </span>
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      WLM Group
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <button
-                        class="euiLink euiLink--primary"
-                        type="button"
-                      >
-                        ANALYTICS_WORKLOAD_GROUP
-                         
-                        <svg
-                          aria-hidden="true"
-                          class="euiIcon euiIcon--small euiIcon-isLoaded"
-                          focusable="false"
-                          height="16"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell euiTableRowCell--hasActions"
-                  >
-                    <div
-                      class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
-                    />
-                  </td>
-                </tr>
-                <tr
-                  class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
-                >
-                  <td
-                    class="euiTableRowCellCheckbox"
-                  >
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <div
-                        class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                      >
-                        <input
-                          aria-label="Select this row"
-                          class="euiCheckbox__input"
-                          data-test-subj="checkboxSelectRow-4W2VTHIgQY-oB7dSrYz4B:3601-1640995201000"
-                          disabled=""
-                          id="_selection_column_4W2VTHIgQY-oB7dSrYz4B:3601-1640995201000-checkbox"
-                          title="Select this row"
-                          type="checkbox"
-                        />
-                        <div
-                          class="euiCheckbox__square"
-                        />
-                      </div>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Timestamp
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      Sep 24, 2021 @ 12:00:00 AM
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Task ID
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <button
-                        class="euiLink euiLink--primary"
-                        type="button"
-                      >
-                        4W2VTHIgQY-oB7dSrYz4B:3601
-                      </button>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Index
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        top_queries-2025.06.06-11009
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Coordinator node
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        4W2VTHIgQY-oB7dSrYz4B
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Time elapsed
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      6.41 s
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      CPU usage
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      113.70 µs
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Memory usage
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      2.59 KB
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Search type
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        QUERY THEN FETCH
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Status
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <span
-                        class="euiBadge euiBadge--iconLeft"
-                        style="background-color: rgb(255, 126, 98); color: rgb(0, 0, 0);"
-                        title="Cancelled"
-                      >
-                        <span
-                          class="euiBadge__content"
-                        >
-                          <span
-                            class="euiBadge__text"
-                          >
-                            Cancelled
-                          </span>
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      WLM Group
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <button
-                        class="euiLink euiLink--primary"
-                        type="button"
-                      >
-                        DEFAULT_QUERY_GROUP
-                         
-                        <svg
-                          aria-hidden="true"
-                          class="euiIcon euiIcon--small euiIcon-isLoaded"
-                          focusable="false"
-                          height="16"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell euiTableRowCell--hasActions"
-                  >
-                    <div
-                      class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
-                    />
-                  </td>
-                </tr>
-                <tr
-                  class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
-                >
-                  <td
-                    class="euiTableRowCellCheckbox"
-                  >
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <div
-                        class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                      >
-                        <input
-                          aria-label="Select this row"
-                          class="euiCheckbox__input"
-                          data-test-subj="checkboxSelectRow-node-X9Y8Z7W6:3602-1640995202000"
-                          id="_selection_column_node-X9Y8Z7W6:3602-1640995202000-checkbox"
-                          title="Select this row"
-                          type="checkbox"
-                        />
-                        <div
-                          class="euiCheckbox__square"
-                        />
-                      </div>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Timestamp
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      Sep 24, 2021 @ 12:00:00 AM
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Task ID
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <button
-                        class="euiLink euiLink--primary"
-                        type="button"
-                      >
-                        node-X9Y8Z7W6:3602
-                      </button>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Index
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        top_queries-2025.06.06-11009
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Coordinator node
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        node-X9Y8Z7W6
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Time elapsed
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      9.63 s
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      CPU usage
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      65.78 µs
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Memory usage
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      3.9 KB
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Search type
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        QUERY THEN FETCH
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Status
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <span
-                        class="euiBadge euiBadge--iconLeft"
-                        style="background-color: rgb(121, 170, 217); color: rgb(0, 0, 0);"
-                        title="Running"
-                      >
-                        <span
-                          class="euiBadge__content"
-                        >
-                          <span
-                            class="euiBadge__text"
-                          >
-                            Running
-                          </span>
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      WLM Group
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <button
-                        class="euiLink euiLink--primary"
-                        type="button"
-                      >
-                        ANALYTICS_WORKLOAD_GROUP
-                         
-                        <svg
-                          aria-hidden="true"
-                          class="euiIcon euiIcon--small euiIcon-isLoaded"
-                          focusable="false"
-                          height="16"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell euiTableRowCell--hasActions"
-                  >
-                    <div
-                      class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
-                    >
-                      <span
-                        class="euiToolTipAnchor"
-                      >
-                        <button
-                          aria-labelledby="random_html_id"
-                          class="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
-                          type="button"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonIcon__icon"
-                            focusable="false"
-                            height="16"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 3h5v1H0V3h5V1a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2Zm-7.056 8H7v1H4.1l.392 2.519c.042.269.254.458.493.458h6.03c.239 0 .451-.189.493-.458l1.498-9.576H14l-1.504 9.73c-.116.747-.74 1.304-1.481 1.304h-6.03c-.741 0-1.365-.557-1.481-1.304l-1.511-9.73H9V5.95H3.157L3.476 8H8v1H3.632l.312 2ZM6 3h4V1H6v2Z"
-                            />
-                          </svg>
-                        </button>
-                        <span
-                          class="euiScreenReaderOnly"
-                          id="random_html_id"
-                        >
-                          Cancel
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr
-                  class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
-                >
-                  <td
-                    class="euiTableRowCellCheckbox"
-                  >
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <div
-                        class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                      >
-                        <input
-                          aria-label="Select this row"
-                          class="euiCheckbox__input"
-                          data-test-subj="checkboxSelectRow-node-P0Q9R8S7:3603-1640995203000"
-                          id="_selection_column_node-P0Q9R8S7:3603-1640995203000-checkbox"
-                          title="Select this row"
-                          type="checkbox"
-                        />
-                        <div
-                          class="euiCheckbox__square"
-                        />
-                      </div>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Timestamp
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      Sep 24, 2021 @ 12:00:00 AM
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Task ID
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <button
-                        class="euiLink euiLink--primary"
-                        type="button"
-                      >
-                        node-P0Q9R8S7:3603
-                      </button>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Index
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        top_queries-2025.06.06-11009
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Coordinator node
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        node-P0Q9R8S7
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Time elapsed
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      9.53 s
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      CPU usage
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      84.33 µs
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Memory usage
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      3.72 KB
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Search type
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        QUERY THEN FETCH
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Status
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <span
-                        class="euiBadge euiBadge--iconLeft"
-                        style="background-color: rgb(121, 170, 217); color: rgb(0, 0, 0);"
-                        title="Running"
-                      >
-                        <span
-                          class="euiBadge__content"
-                        >
-                          <span
-                            class="euiBadge__text"
-                          >
-                            Running
-                          </span>
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      WLM Group
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <button
-                        class="euiLink euiLink--primary"
-                        type="button"
-                      >
-                        DEFAULT_QUERY_GROUP
-                         
-                        <svg
-                          aria-hidden="true"
-                          class="euiIcon euiIcon--small euiIcon-isLoaded"
-                          focusable="false"
-                          height="16"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell euiTableRowCell--hasActions"
-                  >
-                    <div
-                      class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
-                    >
-                      <span
-                        class="euiToolTipAnchor"
-                      >
-                        <button
-                          aria-labelledby="random_html_id"
-                          class="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
-                          type="button"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonIcon__icon"
-                            focusable="false"
-                            height="16"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 3h5v1H0V3h5V1a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2Zm-7.056 8H7v1H4.1l.392 2.519c.042.269.254.458.493.458h6.03c.239 0 .451-.189.493-.458l1.498-9.576H14l-1.504 9.73c-.116.747-.74 1.304-1.481 1.304h-6.03c-.741 0-1.365-.557-1.481-1.304l-1.511-9.73H9V5.95H3.157L3.476 8H8v1H3.632l.312 2ZM6 3h4V1H6v2Z"
-                            />
-                          </svg>
-                        </button>
-                        <span
-                          class="euiScreenReaderOnly"
-                          id="random_html_id"
-                        >
-                          Cancel
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr
-                  class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
-                >
-                  <td
-                    class="euiTableRowCellCheckbox"
-                  >
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <div
-                        class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                      >
-                        <input
-                          aria-label="Select this row"
-                          class="euiCheckbox__input"
-                          data-test-subj="checkboxSelectRow-4W2VTHIgQY-oB7dSrYz4:3604-1640995204000"
-                          id="_selection_column_4W2VTHIgQY-oB7dSrYz4:3604-1640995204000-checkbox"
-                          title="Select this row"
-                          type="checkbox"
-                        />
-                        <div
-                          class="euiCheckbox__square"
-                        />
-                      </div>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Timestamp
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      Sep 24, 2021 @ 12:00:00 AM
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Task ID
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <button
-                        class="euiLink euiLink--primary"
-                        type="button"
-                      >
-                        4W2VTHIgQY-oB7dSrYz4:3604
-                      </button>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Index
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        top_queries-2025.06.06-11009
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Coordinator node
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        4W2VTHIgQY-oB7dSrYz4
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Time elapsed
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      6.08 s
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      CPU usage
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      99.93 µs
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Memory usage
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      4.26 KB
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Search type
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        QUERY THEN FETCH
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Status
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <span
-                        class="euiBadge euiBadge--iconLeft"
-                        style="background-color: rgb(121, 170, 217); color: rgb(0, 0, 0);"
-                        title="Running"
-                      >
-                        <span
-                          class="euiBadge__content"
-                        >
-                          <span
-                            class="euiBadge__text"
-                          >
-                            Running
-                          </span>
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      WLM Group
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <button
-                        class="euiLink euiLink--primary"
-                        type="button"
-                      >
-                        DEFAULT_QUERY_GROUP
-                         
-                        <svg
-                          aria-hidden="true"
-                          class="euiIcon euiIcon--small euiIcon-isLoaded"
-                          focusable="false"
-                          height="16"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell euiTableRowCell--hasActions"
-                  >
-                    <div
-                      class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
-                    >
-                      <span
-                        class="euiToolTipAnchor"
-                      >
-                        <button
-                          aria-labelledby="random_html_id"
-                          class="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
-                          type="button"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonIcon__icon"
-                            focusable="false"
-                            height="16"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 3h5v1H0V3h5V1a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2Zm-7.056 8H7v1H4.1l.392 2.519c.042.269.254.458.493.458h6.03c.239 0 .451-.189.493-.458l1.498-9.576H14l-1.504 9.73c-.116.747-.74 1.304-1.481 1.304h-6.03c-.741 0-1.365-.557-1.481-1.304l-1.511-9.73H9V5.95H3.157L3.476 8H8v1H3.632l.312 2ZM6 3h4V1H6v2Z"
-                            />
-                          </svg>
-                        </button>
-                        <span
-                          class="euiScreenReaderOnly"
-                          id="random_html_id"
-                        >
-                          Cancel
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr
-                  class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
-                >
-                  <td
-                    class="euiTableRowCellCheckbox"
-                  >
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <div
-                        class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                      >
-                        <input
-                          aria-label="Select this row"
-                          class="euiCheckbox__input"
-                          data-test-subj="checkboxSelectRow-node-M2O3P4Q5:3605-1640995205000"
-                          disabled=""
-                          id="_selection_column_node-M2O3P4Q5:3605-1640995205000-checkbox"
-                          title="Select this row"
-                          type="checkbox"
-                        />
-                        <div
-                          class="euiCheckbox__square"
-                        />
-                      </div>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Timestamp
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      Sep 24, 2021 @ 12:00:00 AM
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Task ID
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <button
-                        class="euiLink euiLink--primary"
-                        type="button"
-                      >
-                        node-M2O3P4Q5:3605
-                      </button>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Index
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        top_queries-2025.06.06-11009
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Coordinator node
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        node-M2O3P4Q5
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Time elapsed
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      5.97 s
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      CPU usage
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      102.07 µs
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Memory usage
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      3.86 KB
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Search type
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        QUERY THEN FETCH
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Status
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <span
-                        class="euiBadge euiBadge--iconLeft"
-                        style="background-color: rgb(255, 126, 98); color: rgb(0, 0, 0);"
-                        title="Cancelled"
-                      >
-                        <span
-                          class="euiBadge__content"
-                        >
-                          <span
-                            class="euiBadge__text"
-                          >
-                            Cancelled
-                          </span>
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      WLM Group
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <button
-                        class="euiLink euiLink--primary"
-                        type="button"
-                      >
-                        SEARCH_WORKLOAD_GROUP
-                         
-                        <svg
-                          aria-hidden="true"
-                          class="euiIcon euiIcon--small euiIcon-isLoaded"
-                          focusable="false"
-                          height="16"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell euiTableRowCell--hasActions"
-                  >
-                    <div
-                      class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
-                    />
-                  </td>
-                </tr>
-                <tr
-                  class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
-                >
-                  <td
-                    class="euiTableRowCellCheckbox"
-                  >
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <div
-                        class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                      >
-                        <input
-                          aria-label="Select this row"
-                          class="euiCheckbox__input"
-                          data-test-subj="checkboxSelectRow-node-B2C3D4E5:3606-1640995206000"
-                          disabled=""
-                          id="_selection_column_node-B2C3D4E5:3606-1640995206000-checkbox"
-                          title="Select this row"
-                          type="checkbox"
-                        />
-                        <div
-                          class="euiCheckbox__square"
-                        />
-                      </div>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Timestamp
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      Sep 24, 2021 @ 12:00:00 AM
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Task ID
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <button
-                        class="euiLink euiLink--primary"
-                        type="button"
-                      >
-                        node-B2C3D4E5:3606
-                      </button>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Index
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        top_queries-2025.06.06-11009
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Coordinator node
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        node-B2C3D4E5
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Time elapsed
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      6.45 s
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      CPU usage
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      86.46 µs
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Memory usage
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      3.82 KB
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Search type
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        QUERY THEN FETCH
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Status
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <span
-                        class="euiBadge euiBadge--iconLeft"
-                        style="background-color: rgb(255, 126, 98); color: rgb(0, 0, 0);"
-                        title="Cancelled"
-                      >
-                        <span
-                          class="euiBadge__content"
-                        >
-                          <span
-                            class="euiBadge__text"
-                          >
-                            Cancelled
-                          </span>
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      WLM Group
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <button
-                        class="euiLink euiLink--primary"
-                        type="button"
-                      >
-                        DEFAULT_QUERY_GROUP
-                         
-                        <svg
-                          aria-hidden="true"
-                          class="euiIcon euiIcon--small euiIcon-isLoaded"
-                          focusable="false"
-                          height="16"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell euiTableRowCell--hasActions"
-                  >
-                    <div
-                      class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
-                    />
-                  </td>
-                </tr>
-                <tr
-                  class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
-                >
-                  <td
-                    class="euiTableRowCellCheckbox"
-                  >
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <div
-                        class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                      >
-                        <input
-                          aria-label="Select this row"
-                          class="euiCheckbox__input"
-                          data-test-subj="checkboxSelectRow-node-N2O3P4Q5:3607-1640995207000"
-                          id="_selection_column_node-N2O3P4Q5:3607-1640995207000-checkbox"
-                          title="Select this row"
-                          type="checkbox"
-                        />
-                        <div
-                          class="euiCheckbox__square"
-                        />
-                      </div>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Timestamp
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      Sep 24, 2021 @ 12:00:00 AM
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Task ID
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <button
-                        class="euiLink euiLink--primary"
-                        type="button"
-                      >
-                        node-N2O3P4Q5:3607
-                      </button>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Index
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        top_queries-2025.06.06-11009
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Coordinator node
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        node-N2O3P4Q5
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Time elapsed
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      8.45 s
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      CPU usage
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      70.64 µs
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Memory usage
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      2.07 KB
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Search type
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        QUERY THEN FETCH
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Status
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <span
-                        class="euiBadge euiBadge--iconLeft"
-                        style="background-color: rgb(121, 170, 217); color: rgb(0, 0, 0);"
-                        title="Running"
-                      >
-                        <span
-                          class="euiBadge__content"
-                        >
-                          <span
-                            class="euiBadge__text"
-                          >
-                            Running
-                          </span>
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      WLM Group
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <button
-                        class="euiLink euiLink--primary"
-                        type="button"
-                      >
-                        DEFAULT_QUERY_GROUP
-                         
-                        <svg
-                          aria-hidden="true"
-                          class="euiIcon euiIcon--small euiIcon-isLoaded"
-                          focusable="false"
-                          height="16"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell euiTableRowCell--hasActions"
-                  >
-                    <div
-                      class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
-                    >
-                      <span
-                        class="euiToolTipAnchor"
-                      >
-                        <button
-                          aria-labelledby="random_html_id"
-                          class="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
-                          type="button"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonIcon__icon"
-                            focusable="false"
-                            height="16"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11 3h5v1H0V3h5V1a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2Zm-7.056 8H7v1H4.1l.392 2.519c.042.269.254.458.493.458h6.03c.239 0 .451-.189.493-.458l1.498-9.576H14l-1.504 9.73c-.116.747-.74 1.304-1.481 1.304h-6.03c-.741 0-1.365-.557-1.481-1.304l-1.511-9.73H9V5.95H3.157L3.476 8H8v1H3.632l.312 2ZM6 3h4V1H6v2Z"
-                            />
-                          </svg>
-                        </button>
-                        <span
-                          class="euiScreenReaderOnly"
-                          id="random_html_id"
-                        >
-                          Cancel
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr
-                  class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
-                >
-                  <td
-                    class="euiTableRowCellCheckbox"
-                  >
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <div
-                        class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                      >
-                        <input
-                          aria-label="Select this row"
-                          class="euiCheckbox__input"
-                          data-test-subj="checkboxSelectRow-2VTHIgQY-oB7dSrYz4BQ:3608-1640995208000"
-                          disabled=""
-                          id="_selection_column_2VTHIgQY-oB7dSrYz4BQ:3608-1640995208000-checkbox"
-                          title="Select this row"
-                          type="checkbox"
-                        />
-                        <div
-                          class="euiCheckbox__square"
-                        />
-                      </div>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Timestamp
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      Sep 24, 2021 @ 12:00:00 AM
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Task ID
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <button
-                        class="euiLink euiLink--primary"
-                        type="button"
-                      >
-                        2VTHIgQY-oB7dSrYz4BQ:3608
-                      </button>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Index
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        top_queries-2025.06.06-11009
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Coordinator node
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        2VTHIgQY-oB7dSrYz4BQ
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Time elapsed
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      7.31 s
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      CPU usage
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      68.28 µs
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Memory usage
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      4.25 KB
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Search type
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        QUERY THEN FETCH
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Status
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <span
-                        class="euiBadge euiBadge--iconLeft"
-                        style="background-color: rgb(255, 126, 98); color: rgb(0, 0, 0);"
-                        title="Cancelled"
-                      >
-                        <span
-                          class="euiBadge__content"
-                        >
-                          <span
-                            class="euiBadge__text"
-                          >
-                            Cancelled
-                          </span>
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      WLM Group
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <button
-                        class="euiLink euiLink--primary"
-                        type="button"
-                      >
-                        DEFAULT_QUERY_GROUP
-                         
-                        <svg
-                          aria-hidden="true"
-                          class="euiIcon euiIcon--small euiIcon-isLoaded"
-                          focusable="false"
-                          height="16"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell euiTableRowCell--hasActions"
-                  >
-                    <div
-                      class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
-                    />
-                  </td>
-                </tr>
-                <tr
-                  class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
-                >
-                  <td
-                    class="euiTableRowCellCheckbox"
-                  >
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <div
-                        class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
-                      >
-                        <input
-                          aria-label="Select this row"
-                          class="euiCheckbox__input"
-                          data-test-subj="checkboxSelectRow-node-X9Y8Z7W6V5:3609-1640995209000"
-                          disabled=""
-                          id="_selection_column_node-X9Y8Z7W6V5:3609-1640995209000-checkbox"
-                          title="Select this row"
-                          type="checkbox"
-                        />
-                        <div
-                          class="euiCheckbox__square"
-                        />
-                      </div>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Timestamp
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      Sep 24, 2021 @ 12:00:00 AM
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Task ID
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <button
-                        class="euiLink euiLink--primary"
-                        type="button"
-                      >
-                        node-X9Y8Z7W6V5:3609
-                      </button>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Index
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        top_queries-2025.06.06-11009
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Coordinator node
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        node-X9Y8Z7W6V5
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Time elapsed
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      5.17 s
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      CPU usage
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      113.61 µs
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Memory usage
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      2.71 KB
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Search type
-                    </div>
-                    <div
-                      class="euiTableCellContent"
-                    >
-                      <span
-                        class="euiTableCellContent__text"
-                      >
-                        QUERY THEN FETCH
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      Status
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <span
-                        class="euiBadge euiBadge--iconLeft"
-                        style="background-color: rgb(255, 126, 98); color: rgb(0, 0, 0);"
-                        title="Cancelled"
-                      >
-                        <span
-                          class="euiBadge__content"
-                        >
-                          <span
-                            class="euiBadge__text"
-                          >
-                            Cancelled
-                          </span>
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell"
-                  >
-                    <div
-                      class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-                    >
-                      WLM Group
-                    </div>
-                    <div
-                      class="euiTableCellContent euiTableCellContent--overflowingContent"
-                    >
-                      <button
-                        class="euiLink euiLink--primary"
-                        type="button"
-                      >
-                        DEFAULT_QUERY_GROUP
-                         
-                        <svg
-                          aria-hidden="true"
-                          class="euiIcon euiIcon--small euiIcon-isLoaded"
-                          focusable="false"
-                          height="16"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </td>
-                  <td
-                    class="euiTableRowCell euiTableRowCell--hasActions"
-                  >
-                    <div
-                      class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
-                    />
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-          <div>
-            <div
-              class="euiSpacer euiSpacer--m"
-            />
-            <div
-              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
             >
               <div
                 class="euiFlexItem euiFlexItem--flexGrowZero"
               >
                 <div
-                  class="euiPopover euiPopover--anchorUpRight"
+                  class="euiCheckbox"
+                >
+                  <input
+                    aria-label="Select all rows"
+                    class="euiCheckbox__input"
+                    id="_selection_column-checkbox_random_html_id"
+                    type="checkbox"
+                  />
+                  <div
+                    class="euiCheckbox__square"
+                  />
+                  <label
+                    class="euiCheckbox__label"
+                    for="_selection_column-checkbox_random_html_id"
+                  >
+                    Select all rows
+                  </label>
+                </div>
+              </div>
+              <div
+                class="euiFlexItem euiFlexItem--flexGrowZero"
+              />
+            </div>
+          </div>
+          <table
+            class="euiTable euiTable--responsive"
+            id="random_html_id"
+            tabindex="-1"
+          >
+            <caption
+              class="euiScreenReaderOnly euiTableCaption"
+            />
+            <thead>
+              <tr>
+                <th
+                  class="euiTableHeaderCellCheckbox"
+                  scope="col"
                 >
                   <div
-                    class="euiPopover__anchor"
+                    class="euiTableCellContent"
+                  >
+                    <div
+                      class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                    >
+                      <input
+                        aria-label="Select all rows"
+                        class="euiCheckbox__input"
+                        data-test-subj="checkboxSelectAll"
+                        id="_selection_column-checkbox_random_html_id"
+                        type="checkbox"
+                      />
+                      <div
+                        class="euiCheckbox__square"
+                      />
+                    </div>
+                  </div>
+                </th>
+                <th
+                  class="euiTableHeaderCell"
+                  data-test-subj="tableHeaderCell_Timestamp_0"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <span
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                      title="Timestamp"
+                    >
+                      Timestamp
+                    </span>
+                  </span>
+                </th>
+                <th
+                  class="euiTableHeaderCell"
+                  data-test-subj="tableHeaderCell_id_1"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <span
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                      title="Task ID"
+                    >
+                      Task ID
+                    </span>
+                  </span>
+                </th>
+                <th
+                  class="euiTableHeaderCell"
+                  data-test-subj="tableHeaderCell_index_2"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <span
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                      title="Index"
+                    >
+                      Index
+                    </span>
+                  </span>
+                </th>
+                <th
+                  class="euiTableHeaderCell"
+                  data-test-subj="tableHeaderCell_coordinator_node_3"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <span
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                      title="Coordinator node"
+                    >
+                      Coordinator node
+                    </span>
+                  </span>
+                </th>
+                <th
+                  class="euiTableHeaderCell"
+                  data-test-subj="tableHeaderCell_Time elapsed_4"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <span
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                      title="Time elapsed"
+                    >
+                      Time elapsed
+                    </span>
+                  </span>
+                </th>
+                <th
+                  class="euiTableHeaderCell"
+                  data-test-subj="tableHeaderCell_CPU usage_5"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <span
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                      title="CPU usage"
+                    >
+                      CPU usage
+                    </span>
+                  </span>
+                </th>
+                <th
+                  class="euiTableHeaderCell"
+                  data-test-subj="tableHeaderCell_Memory usage_6"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <span
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                      title="Memory usage"
+                    >
+                      Memory usage
+                    </span>
+                  </span>
+                </th>
+                <th
+                  class="euiTableHeaderCell"
+                  data-test-subj="tableHeaderCell_search_type_7"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <span
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                      title="Search type"
+                    >
+                      Search type
+                    </span>
+                  </span>
+                </th>
+                <th
+                  class="euiTableHeaderCell"
+                  data-test-subj="tableHeaderCell_Status_8"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <span
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                      title="Status"
+                    >
+                      Status
+                    </span>
+                  </span>
+                </th>
+                <th
+                  class="euiTableHeaderCell"
+                  data-test-subj="tableHeaderCell_WLM Group_9"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <span
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                      title="WLM Group"
+                    >
+                      WLM Group
+                    </span>
+                  </span>
+                </th>
+                <th
+                  class="euiTableHeaderCell"
+                  role="columnheader"
+                  scope="col"
+                >
+                  <span
+                    class="euiTableCellContent euiTableCellContent--alignRight"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                      title="Actions"
+                    >
+                      Actions
+                    </span>
+                  </span>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+              >
+                <td
+                  class="euiTableRowCellCheckbox"
+                >
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <div
+                      class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                    >
+                      <input
+                        aria-label="Select this row"
+                        class="euiCheckbox__input"
+                        data-test-subj="checkboxSelectRow-node-A1B2C3D4E5:3600-1640995200000"
+                        disabled=""
+                        id="_selection_column_node-A1B2C3D4E5:3600-1640995200000-checkbox"
+                        title="Select this row"
+                        type="checkbox"
+                      />
+                      <div
+                        class="euiCheckbox__square"
+                      />
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Timestamp
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    Sep 24, 2021 @ 12:00:00 AM
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Task ID
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
                   >
                     <button
-                      class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
-                      data-test-subj="tablePaginationPopoverButton"
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      node-A1B2C3D4E5:3600
+                    </button>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Index
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      top_queries-2025.06.06-11009
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Coordinator node
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      node-A1B2C3D4E5
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Time elapsed
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    7.99 s
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    CPU usage
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    89.95 µs
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Memory usage
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    3.73 KB
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Search type
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      QUERY THEN FETCH
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Status
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <span
+                      class="euiBadge euiBadge--iconLeft"
+                      style="background-color: rgb(255, 126, 98); color: rgb(0, 0, 0);"
+                      title="Cancelled"
+                    >
+                      <span
+                        class="euiBadge__content"
+                      >
+                        <span
+                          class="euiBadge__text"
+                        >
+                          Cancelled
+                        </span>
+                      </span>
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    WLM Group
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      ANALYTICS_WORKLOAD_GROUP
+                       
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--small euiIcon-isLoaded"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell euiTableRowCell--hasActions"
+                >
+                  <div
+                    class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+                  />
+                </td>
+              </tr>
+              <tr
+                class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+              >
+                <td
+                  class="euiTableRowCellCheckbox"
+                >
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <div
+                      class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                    >
+                      <input
+                        aria-label="Select this row"
+                        class="euiCheckbox__input"
+                        data-test-subj="checkboxSelectRow-4W2VTHIgQY-oB7dSrYz4B:3601-1640995201000"
+                        disabled=""
+                        id="_selection_column_4W2VTHIgQY-oB7dSrYz4B:3601-1640995201000-checkbox"
+                        title="Select this row"
+                        type="checkbox"
+                      />
+                      <div
+                        class="euiCheckbox__square"
+                      />
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Timestamp
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    Sep 24, 2021 @ 12:00:00 AM
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Task ID
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      4W2VTHIgQY-oB7dSrYz4B:3601
+                    </button>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Index
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      top_queries-2025.06.06-11009
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Coordinator node
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      4W2VTHIgQY-oB7dSrYz4B
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Time elapsed
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    6.41 s
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    CPU usage
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    113.70 µs
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Memory usage
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    2.59 KB
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Search type
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      QUERY THEN FETCH
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Status
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <span
+                      class="euiBadge euiBadge--iconLeft"
+                      style="background-color: rgb(255, 126, 98); color: rgb(0, 0, 0);"
+                      title="Cancelled"
+                    >
+                      <span
+                        class="euiBadge__content"
+                      >
+                        <span
+                          class="euiBadge__text"
+                        >
+                          Cancelled
+                        </span>
+                      </span>
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    WLM Group
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      DEFAULT_QUERY_GROUP
+                       
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--small euiIcon-isLoaded"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell euiTableRowCell--hasActions"
+                >
+                  <div
+                    class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+                  />
+                </td>
+              </tr>
+              <tr
+                class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+              >
+                <td
+                  class="euiTableRowCellCheckbox"
+                >
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <div
+                      class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                    >
+                      <input
+                        aria-label="Select this row"
+                        class="euiCheckbox__input"
+                        data-test-subj="checkboxSelectRow-node-X9Y8Z7W6:3602-1640995202000"
+                        id="_selection_column_node-X9Y8Z7W6:3602-1640995202000-checkbox"
+                        title="Select this row"
+                        type="checkbox"
+                      />
+                      <div
+                        class="euiCheckbox__square"
+                      />
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Timestamp
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    Sep 24, 2021 @ 12:00:00 AM
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Task ID
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      node-X9Y8Z7W6:3602
+                    </button>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Index
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      top_queries-2025.06.06-11009
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Coordinator node
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      node-X9Y8Z7W6
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Time elapsed
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    9.63 s
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    CPU usage
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    65.78 µs
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Memory usage
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    3.9 KB
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Search type
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      QUERY THEN FETCH
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Status
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <span
+                      class="euiBadge euiBadge--iconLeft"
+                      style="background-color: rgb(121, 170, 217); color: rgb(0, 0, 0);"
+                      title="Running"
+                    >
+                      <span
+                        class="euiBadge__content"
+                      >
+                        <span
+                          class="euiBadge__text"
+                        >
+                          Running
+                        </span>
+                      </span>
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    WLM Group
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      ANALYTICS_WORKLOAD_GROUP
+                       
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--small euiIcon-isLoaded"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell euiTableRowCell--hasActions"
+                >
+                  <div
+                    class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+                  >
+                    <span
+                      class="euiToolTipAnchor"
+                    >
+                      <button
+                        aria-labelledby="random_html_id"
+                        class="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonIcon__icon"
+                          focusable="false"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 3h5v1H0V3h5V1a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2Zm-7.056 8H7v1H4.1l.392 2.519c.042.269.254.458.493.458h6.03c.239 0 .451-.189.493-.458l1.498-9.576H14l-1.504 9.73c-.116.747-.74 1.304-1.481 1.304h-6.03c-.741 0-1.365-.557-1.481-1.304l-1.511-9.73H9V5.95H3.157L3.476 8H8v1H3.632l.312 2ZM6 3h4V1H6v2Z"
+                          />
+                        </svg>
+                      </button>
+                      <span
+                        class="euiScreenReaderOnly"
+                        id="random_html_id"
+                      >
+                        Cancel
+                      </span>
+                    </span>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+              >
+                <td
+                  class="euiTableRowCellCheckbox"
+                >
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <div
+                      class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                    >
+                      <input
+                        aria-label="Select this row"
+                        class="euiCheckbox__input"
+                        data-test-subj="checkboxSelectRow-node-P0Q9R8S7:3603-1640995203000"
+                        id="_selection_column_node-P0Q9R8S7:3603-1640995203000-checkbox"
+                        title="Select this row"
+                        type="checkbox"
+                      />
+                      <div
+                        class="euiCheckbox__square"
+                      />
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Timestamp
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    Sep 24, 2021 @ 12:00:00 AM
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Task ID
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      node-P0Q9R8S7:3603
+                    </button>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Index
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      top_queries-2025.06.06-11009
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Coordinator node
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      node-P0Q9R8S7
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Time elapsed
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    9.53 s
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    CPU usage
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    84.33 µs
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Memory usage
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    3.72 KB
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Search type
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      QUERY THEN FETCH
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Status
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <span
+                      class="euiBadge euiBadge--iconLeft"
+                      style="background-color: rgb(121, 170, 217); color: rgb(0, 0, 0);"
+                      title="Running"
+                    >
+                      <span
+                        class="euiBadge__content"
+                      >
+                        <span
+                          class="euiBadge__text"
+                        >
+                          Running
+                        </span>
+                      </span>
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    WLM Group
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      DEFAULT_QUERY_GROUP
+                       
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--small euiIcon-isLoaded"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell euiTableRowCell--hasActions"
+                >
+                  <div
+                    class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+                  >
+                    <span
+                      class="euiToolTipAnchor"
+                    >
+                      <button
+                        aria-labelledby="random_html_id"
+                        class="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonIcon__icon"
+                          focusable="false"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 3h5v1H0V3h5V1a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2Zm-7.056 8H7v1H4.1l.392 2.519c.042.269.254.458.493.458h6.03c.239 0 .451-.189.493-.458l1.498-9.576H14l-1.504 9.73c-.116.747-.74 1.304-1.481 1.304h-6.03c-.741 0-1.365-.557-1.481-1.304l-1.511-9.73H9V5.95H3.157L3.476 8H8v1H3.632l.312 2ZM6 3h4V1H6v2Z"
+                          />
+                        </svg>
+                      </button>
+                      <span
+                        class="euiScreenReaderOnly"
+                        id="random_html_id"
+                      >
+                        Cancel
+                      </span>
+                    </span>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+              >
+                <td
+                  class="euiTableRowCellCheckbox"
+                >
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <div
+                      class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                    >
+                      <input
+                        aria-label="Select this row"
+                        class="euiCheckbox__input"
+                        data-test-subj="checkboxSelectRow-4W2VTHIgQY-oB7dSrYz4:3604-1640995204000"
+                        id="_selection_column_4W2VTHIgQY-oB7dSrYz4:3604-1640995204000-checkbox"
+                        title="Select this row"
+                        type="checkbox"
+                      />
+                      <div
+                        class="euiCheckbox__square"
+                      />
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Timestamp
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    Sep 24, 2021 @ 12:00:00 AM
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Task ID
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      4W2VTHIgQY-oB7dSrYz4:3604
+                    </button>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Index
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      top_queries-2025.06.06-11009
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Coordinator node
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      4W2VTHIgQY-oB7dSrYz4
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Time elapsed
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    6.08 s
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    CPU usage
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    99.93 µs
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Memory usage
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    4.26 KB
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Search type
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      QUERY THEN FETCH
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Status
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <span
+                      class="euiBadge euiBadge--iconLeft"
+                      style="background-color: rgb(121, 170, 217); color: rgb(0, 0, 0);"
+                      title="Running"
+                    >
+                      <span
+                        class="euiBadge__content"
+                      >
+                        <span
+                          class="euiBadge__text"
+                        >
+                          Running
+                        </span>
+                      </span>
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    WLM Group
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      DEFAULT_QUERY_GROUP
+                       
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--small euiIcon-isLoaded"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell euiTableRowCell--hasActions"
+                >
+                  <div
+                    class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+                  >
+                    <span
+                      class="euiToolTipAnchor"
+                    >
+                      <button
+                        aria-labelledby="random_html_id"
+                        class="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonIcon__icon"
+                          focusable="false"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 3h5v1H0V3h5V1a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2Zm-7.056 8H7v1H4.1l.392 2.519c.042.269.254.458.493.458h6.03c.239 0 .451-.189.493-.458l1.498-9.576H14l-1.504 9.73c-.116.747-.74 1.304-1.481 1.304h-6.03c-.741 0-1.365-.557-1.481-1.304l-1.511-9.73H9V5.95H3.157L3.476 8H8v1H3.632l.312 2ZM6 3h4V1H6v2Z"
+                          />
+                        </svg>
+                      </button>
+                      <span
+                        class="euiScreenReaderOnly"
+                        id="random_html_id"
+                      >
+                        Cancel
+                      </span>
+                    </span>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+              >
+                <td
+                  class="euiTableRowCellCheckbox"
+                >
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <div
+                      class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                    >
+                      <input
+                        aria-label="Select this row"
+                        class="euiCheckbox__input"
+                        data-test-subj="checkboxSelectRow-node-M2O3P4Q5:3605-1640995205000"
+                        disabled=""
+                        id="_selection_column_node-M2O3P4Q5:3605-1640995205000-checkbox"
+                        title="Select this row"
+                        type="checkbox"
+                      />
+                      <div
+                        class="euiCheckbox__square"
+                      />
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Timestamp
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    Sep 24, 2021 @ 12:00:00 AM
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Task ID
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      node-M2O3P4Q5:3605
+                    </button>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Index
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      top_queries-2025.06.06-11009
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Coordinator node
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      node-M2O3P4Q5
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Time elapsed
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    5.97 s
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    CPU usage
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    102.07 µs
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Memory usage
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    3.86 KB
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Search type
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      QUERY THEN FETCH
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Status
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <span
+                      class="euiBadge euiBadge--iconLeft"
+                      style="background-color: rgb(255, 126, 98); color: rgb(0, 0, 0);"
+                      title="Cancelled"
+                    >
+                      <span
+                        class="euiBadge__content"
+                      >
+                        <span
+                          class="euiBadge__text"
+                        >
+                          Cancelled
+                        </span>
+                      </span>
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    WLM Group
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      SEARCH_WORKLOAD_GROUP
+                       
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--small euiIcon-isLoaded"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell euiTableRowCell--hasActions"
+                >
+                  <div
+                    class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+                  />
+                </td>
+              </tr>
+              <tr
+                class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+              >
+                <td
+                  class="euiTableRowCellCheckbox"
+                >
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <div
+                      class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                    >
+                      <input
+                        aria-label="Select this row"
+                        class="euiCheckbox__input"
+                        data-test-subj="checkboxSelectRow-node-B2C3D4E5:3606-1640995206000"
+                        disabled=""
+                        id="_selection_column_node-B2C3D4E5:3606-1640995206000-checkbox"
+                        title="Select this row"
+                        type="checkbox"
+                      />
+                      <div
+                        class="euiCheckbox__square"
+                      />
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Timestamp
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    Sep 24, 2021 @ 12:00:00 AM
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Task ID
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      node-B2C3D4E5:3606
+                    </button>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Index
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      top_queries-2025.06.06-11009
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Coordinator node
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      node-B2C3D4E5
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Time elapsed
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    6.45 s
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    CPU usage
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    86.46 µs
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Memory usage
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    3.82 KB
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Search type
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      QUERY THEN FETCH
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Status
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <span
+                      class="euiBadge euiBadge--iconLeft"
+                      style="background-color: rgb(255, 126, 98); color: rgb(0, 0, 0);"
+                      title="Cancelled"
+                    >
+                      <span
+                        class="euiBadge__content"
+                      >
+                        <span
+                          class="euiBadge__text"
+                        >
+                          Cancelled
+                        </span>
+                      </span>
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    WLM Group
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      DEFAULT_QUERY_GROUP
+                       
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--small euiIcon-isLoaded"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell euiTableRowCell--hasActions"
+                >
+                  <div
+                    class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+                  />
+                </td>
+              </tr>
+              <tr
+                class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+              >
+                <td
+                  class="euiTableRowCellCheckbox"
+                >
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <div
+                      class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                    >
+                      <input
+                        aria-label="Select this row"
+                        class="euiCheckbox__input"
+                        data-test-subj="checkboxSelectRow-node-N2O3P4Q5:3607-1640995207000"
+                        id="_selection_column_node-N2O3P4Q5:3607-1640995207000-checkbox"
+                        title="Select this row"
+                        type="checkbox"
+                      />
+                      <div
+                        class="euiCheckbox__square"
+                      />
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Timestamp
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    Sep 24, 2021 @ 12:00:00 AM
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Task ID
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      node-N2O3P4Q5:3607
+                    </button>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Index
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      top_queries-2025.06.06-11009
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Coordinator node
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      node-N2O3P4Q5
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Time elapsed
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    8.45 s
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    CPU usage
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    70.64 µs
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Memory usage
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    2.07 KB
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Search type
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      QUERY THEN FETCH
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Status
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <span
+                      class="euiBadge euiBadge--iconLeft"
+                      style="background-color: rgb(121, 170, 217); color: rgb(0, 0, 0);"
+                      title="Running"
+                    >
+                      <span
+                        class="euiBadge__content"
+                      >
+                        <span
+                          class="euiBadge__text"
+                        >
+                          Running
+                        </span>
+                      </span>
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    WLM Group
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      DEFAULT_QUERY_GROUP
+                       
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--small euiIcon-isLoaded"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell euiTableRowCell--hasActions"
+                >
+                  <div
+                    class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+                  >
+                    <span
+                      class="euiToolTipAnchor"
+                    >
+                      <button
+                        aria-labelledby="random_html_id"
+                        class="euiButtonIcon euiButtonIcon--danger euiButtonIcon--empty euiButtonIcon--xSmall euiTableCellContent__hoverItem"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonIcon__icon"
+                          focusable="false"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 3h5v1H0V3h5V1a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2Zm-7.056 8H7v1H4.1l.392 2.519c.042.269.254.458.493.458h6.03c.239 0 .451-.189.493-.458l1.498-9.576H14l-1.504 9.73c-.116.747-.74 1.304-1.481 1.304h-6.03c-.741 0-1.365-.557-1.481-1.304l-1.511-9.73H9V5.95H3.157L3.476 8H8v1H3.632l.312 2ZM6 3h4V1H6v2Z"
+                          />
+                        </svg>
+                      </button>
+                      <span
+                        class="euiScreenReaderOnly"
+                        id="random_html_id"
+                      >
+                        Cancel
+                      </span>
+                    </span>
+                  </div>
+                </td>
+              </tr>
+              <tr
+                class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+              >
+                <td
+                  class="euiTableRowCellCheckbox"
+                >
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <div
+                      class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                    >
+                      <input
+                        aria-label="Select this row"
+                        class="euiCheckbox__input"
+                        data-test-subj="checkboxSelectRow-2VTHIgQY-oB7dSrYz4BQ:3608-1640995208000"
+                        disabled=""
+                        id="_selection_column_2VTHIgQY-oB7dSrYz4BQ:3608-1640995208000-checkbox"
+                        title="Select this row"
+                        type="checkbox"
+                      />
+                      <div
+                        class="euiCheckbox__square"
+                      />
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Timestamp
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    Sep 24, 2021 @ 12:00:00 AM
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Task ID
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      2VTHIgQY-oB7dSrYz4BQ:3608
+                    </button>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Index
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      top_queries-2025.06.06-11009
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Coordinator node
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      2VTHIgQY-oB7dSrYz4BQ
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Time elapsed
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    7.31 s
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    CPU usage
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    68.28 µs
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Memory usage
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    4.25 KB
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Search type
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      QUERY THEN FETCH
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Status
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <span
+                      class="euiBadge euiBadge--iconLeft"
+                      style="background-color: rgb(255, 126, 98); color: rgb(0, 0, 0);"
+                      title="Cancelled"
+                    >
+                      <span
+                        class="euiBadge__content"
+                      >
+                        <span
+                          class="euiBadge__text"
+                        >
+                          Cancelled
+                        </span>
+                      </span>
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    WLM Group
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      DEFAULT_QUERY_GROUP
+                       
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--small euiIcon-isLoaded"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell euiTableRowCell--hasActions"
+                >
+                  <div
+                    class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+                  />
+                </td>
+              </tr>
+              <tr
+                class="euiTableRow euiTableRow-isSelectable euiTableRow-hasActions"
+              >
+                <td
+                  class="euiTableRowCellCheckbox"
+                >
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <div
+                      class="euiCheckbox euiCheckbox--inList euiCheckbox--noLabel"
+                    >
+                      <input
+                        aria-label="Select this row"
+                        class="euiCheckbox__input"
+                        data-test-subj="checkboxSelectRow-node-X9Y8Z7W6V5:3609-1640995209000"
+                        disabled=""
+                        id="_selection_column_node-X9Y8Z7W6V5:3609-1640995209000-checkbox"
+                        title="Select this row"
+                        type="checkbox"
+                      />
+                      <div
+                        class="euiCheckbox__square"
+                      />
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Timestamp
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    Sep 24, 2021 @ 12:00:00 AM
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Task ID
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      node-X9Y8Z7W6V5:3609
+                    </button>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Index
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      top_queries-2025.06.06-11009
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Coordinator node
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      node-X9Y8Z7W6V5
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Time elapsed
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    5.17 s
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    CPU usage
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    113.61 µs
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Memory usage
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    2.71 KB
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Search type
+                  </div>
+                  <div
+                    class="euiTableCellContent"
+                  >
+                    <span
+                      class="euiTableCellContent__text"
+                    >
+                      QUERY THEN FETCH
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    Status
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <span
+                      class="euiBadge euiBadge--iconLeft"
+                      style="background-color: rgb(255, 126, 98); color: rgb(0, 0, 0);"
+                      title="Cancelled"
+                    >
+                      <span
+                        class="euiBadge__content"
+                      >
+                        <span
+                          class="euiBadge__text"
+                        >
+                          Cancelled
+                        </span>
+                      </span>
+                    </span>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell"
+                >
+                  <div
+                    class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
+                  >
+                    WLM Group
+                  </div>
+                  <div
+                    class="euiTableCellContent euiTableCellContent--overflowingContent"
+                  >
+                    <button
+                      class="euiLink euiLink--primary"
+                      type="button"
+                    >
+                      DEFAULT_QUERY_GROUP
+                       
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--small euiIcon-isLoaded"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </td>
+                <td
+                  class="euiTableRowCell euiTableRowCell--hasActions"
+                >
+                  <div
+                    class="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--showOnHover euiTableCellContent--overflowingContent"
+                  />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div>
+          <div
+            class="euiSpacer euiSpacer--m"
+          />
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow"
+          >
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <div
+                class="euiPopover euiPopover--anchorUpRight"
+              >
+                <div
+                  class="euiPopover__anchor"
+                >
+                  <button
+                    class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--xSmall"
+                    data-test-subj="tablePaginationPopoverButton"
+                    type="button"
+                  >
+                    <span
+                      class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                          fill-rule="non-zero"
+                        />
+                      </svg>
+                      <span
+                        class="euiButtonEmpty__text"
+                      >
+                        Rows per page
+                        : 
+                        10
+                      </span>
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <nav
+                class="euiPagination"
+              >
+                <button
+                  aria-label="Previous page"
+                  class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                  data-test-subj="pagination-button-previous"
+                  disabled=""
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonIcon__icon"
+                    focusable="false"
+                    height="16"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M10.843 13.069 6.232 8.384a.546.546 0 0 1 0-.768l4.61-4.685a.552.552 0 0 0 0-.771.53.53 0 0 0-.759 0l-4.61 4.684a1.65 1.65 0 0 0 0 2.312l4.61 4.684a.53.53 0 0 0 .76 0 .552.552 0 0 0 0-.771Z"
+                      fill-rule="nonzero"
+                    />
+                  </svg>
+                </button>
+                <ul
+                  class="euiPagination__list"
+                >
+                  <li
+                    class="euiPagination__item"
+                  >
+                    <button
+                      aria-controls="random_html_id"
+                      aria-current="true"
+                      aria-label="Page 1 of 2"
+                      class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
+                      data-test-subj="pagination-button-0"
+                      disabled=""
                       type="button"
                     >
                       <span
-                        class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                        class="euiButtonContent euiButtonEmpty__content"
                       >
-                        <svg
-                          aria-hidden="true"
-                          class="euiIcon euiIcon--small euiIcon--inherit euiButtonContent__icon"
-                          focusable="false"
-                          height="16"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                            fill-rule="non-zero"
-                          />
-                        </svg>
                         <span
                           class="euiButtonEmpty__text"
                         >
-                          Rows per page
-                          : 
-                          10
+                          1
                         </span>
                       </span>
                     </button>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <nav
-                  class="euiPagination"
+                  </li>
+                  <li
+                    class="euiPagination__item"
+                  >
+                    <a
+                      aria-controls="random_html_id"
+                      aria-label="Page 2 of 2"
+                      class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiPaginationButton euiPaginationButton--hideOnMobile"
+                      data-test-subj="pagination-button-1"
+                      href="#random_html_id"
+                      rel="noreferrer"
+                    >
+                      <span
+                        class="euiButtonContent euiButtonEmpty__content"
+                      >
+                        <span
+                          class="euiButtonEmpty__text"
+                        >
+                          2
+                        </span>
+                      </span>
+                    </a>
+                  </li>
+                </ul>
+                <a
+                  aria-controls="random_html_id"
+                  aria-label="Next page, 2"
+                  class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
+                  data-test-subj="pagination-button-next"
+                  href="#random_html_id"
+                  rel="noreferrer"
                 >
-                  <button
-                    aria-label="Previous page"
-                    class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                    data-test-subj="pagination-button-previous"
-                    disabled=""
-                    type="button"
+                  <svg
+                    aria-hidden="true"
+                    class="euiIcon euiIcon--medium euiIcon--inherit euiButtonIcon__icon"
+                    focusable="false"
+                    height="16"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    <svg
-                      aria-hidden="true"
-                      class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonIcon__icon"
-                      focusable="false"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M10.843 13.069 6.232 8.384a.546.546 0 0 1 0-.768l4.61-4.685a.552.552 0 0 0 0-.771.53.53 0 0 0-.759 0l-4.61 4.684a1.65 1.65 0 0 0 0 2.312l4.61 4.684a.53.53 0 0 0 .76 0 .552.552 0 0 0 0-.771Z"
-                        fill-rule="nonzero"
-                      />
-                    </svg>
-                  </button>
-                  <ul
-                    class="euiPagination__list"
-                  >
-                    <li
-                      class="euiPagination__item"
-                    >
-                      <button
-                        aria-controls="random_html_id"
-                        aria-current="true"
-                        aria-label="Page 1 of 2"
-                        class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiButtonEmpty-isDisabled euiPaginationButton euiPaginationButton-isActive euiPaginationButton--hideOnMobile"
-                        data-test-subj="pagination-button-0"
-                        disabled=""
-                        type="button"
-                      >
-                        <span
-                          class="euiButtonContent euiButtonEmpty__content"
-                        >
-                          <span
-                            class="euiButtonEmpty__text"
-                          >
-                            1
-                          </span>
-                        </span>
-                      </button>
-                    </li>
-                    <li
-                      class="euiPagination__item"
-                    >
-                      <a
-                        aria-controls="random_html_id"
-                        aria-label="Page 2 of 2"
-                        class="euiButtonEmpty euiButtonEmpty--text euiButtonEmpty--small euiPaginationButton euiPaginationButton--hideOnMobile"
-                        data-test-subj="pagination-button-1"
-                        href="#random_html_id"
-                        rel="noreferrer"
-                      >
-                        <span
-                          class="euiButtonContent euiButtonEmpty__content"
-                        >
-                          <span
-                            class="euiButtonEmpty__text"
-                          >
-                            2
-                          </span>
-                        </span>
-                      </a>
-                    </li>
-                  </ul>
-                  <a
-                    aria-controls="random_html_id"
-                    aria-label="Next page, 2"
-                    class="euiButtonIcon euiButtonIcon--text euiButtonIcon--empty euiButtonIcon--xSmall"
-                    data-test-subj="pagination-button-next"
-                    href="#random_html_id"
-                    rel="noreferrer"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonIcon__icon"
-                      focusable="false"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
-                        fill-rule="nonzero"
-                      />
-                    </svg>
-                  </a>
-                </nav>
-              </div>
+                    <path
+                      d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
+                      fill-rule="nonzero"
+                    />
+                  </svg>
+                </a>
+              </nav>
             </div>
           </div>
         </div>

--- a/public/pages/QueryInsights/QueryInsights.test.tsx
+++ b/public/pages/QueryInsights/QueryInsights.test.tsx
@@ -130,28 +130,28 @@ describe('QueryInsights Component', () => {
     it('should initialize search query with wlmGroupId from URL', () => {
       renderQueryInsights(['/?wlmGroupId=analytics-workload']);
 
-      const searchBox = screen.getByPlaceholderText('Search queries');
+      const searchBox = screen.getByPlaceholderText('e.g. latency >= 100 AND type = query');
       expect(searchBox).toHaveValue('wlm_group_id:(analytics-workload)');
     });
 
     it('should initialize empty search query when no wlmGroupId in URL', () => {
       renderQueryInsights(['/']);
 
-      const searchBox = screen.getByPlaceholderText('Search queries');
+      const searchBox = screen.getByPlaceholderText('e.g. latency >= 100 AND type = query');
       expect(searchBox).toHaveValue('');
     });
 
     it('should extract only wlmGroupId when multiple URL parameters exist', () => {
       renderQueryInsights(['/?wlmGroupId=search-heavy&dashboard=main&tab=queries']);
 
-      const searchBox = screen.getByPlaceholderText('Search queries');
+      const searchBox = screen.getByPlaceholderText('e.g. latency >= 100 AND type = query');
       expect(searchBox).toHaveValue('wlm_group_id:(search-heavy)');
     });
 
     it('should decode URL-encoded wlmGroupId values', () => {
       renderQueryInsights(['/?wlmGroupId=ml-training']);
 
-      const searchBox = screen.getByPlaceholderText('Search queries');
+      const searchBox = screen.getByPlaceholderText('e.g. latency >= 100 AND type = query');
       expect(searchBox).toHaveValue('wlm_group_id:(ml-training)');
     });
   });
@@ -640,20 +640,23 @@ describe('QueryInsights Component', () => {
         renderQueryInsights();
       });
 
-      expect(screen.getByPlaceholderText('Search queries')).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText('e.g. latency >= 100 AND type = query')
+      ).toBeInTheDocument();
     });
 
-    it('opens Type filter popover on click', async () => {
+    it('shows suggestions when typing in search bar', async () => {
       mockHttp.get.mockResolvedValue({ workload_groups: [] });
       await act(async () => {
         renderQueryInsights();
       });
 
-      const typeButton = findTypeFilterButton();
-      fireEvent.click(typeButton);
+      const searchInput = screen.getByPlaceholderText('e.g. latency >= 100 AND type = query');
+      fireEvent.change(searchInput, { target: { value: 'lat' } });
 
+      // Should show field suggestions
       await waitFor(() => {
-        expect(screen.getByRole('dialog')).toBeInTheDocument();
+        expect(searchInput).toHaveValue('lat');
       });
     });
 
@@ -663,7 +666,7 @@ describe('QueryInsights Component', () => {
         renderQueryInsights();
       });
 
-      const searchInput = screen.getByPlaceholderText('Search queries');
+      const searchInput = screen.getByPlaceholderText('e.g. latency >= 100 AND type = query');
       fireEvent.change(searchInput, { target: { value: 'a2e1c822' } });
 
       // Search should filter the table
@@ -678,7 +681,7 @@ describe('QueryInsights Component', () => {
         renderQueryInsights();
       });
 
-      const searchInput = screen.getByPlaceholderText('Search queries');
+      const searchInput = screen.getByPlaceholderText('e.g. latency >= 100 AND type = query');
       fireEvent.change(searchInput, { target: { value: 'my-index' } });
 
       await waitFor(() => {
@@ -693,7 +696,7 @@ describe('QueryInsights Component', () => {
         renderQueryInsights();
       });
 
-      const searchInput = screen.getByPlaceholderText('Search queries');
+      const searchInput = screen.getByPlaceholderText('e.g. latency >= 100 AND type = query');
       fireEvent.change(searchInput, { target: { value: 'KINGun8' } });
 
       await waitFor(() => {
@@ -708,7 +711,7 @@ describe('QueryInsights Component', () => {
         renderQueryInsights();
       });
 
-      const searchInput = screen.getByPlaceholderText('Search queries');
+      const searchInput = screen.getByPlaceholderText('e.g. latency >= 100 AND type = query');
       fireEvent.change(searchInput, { target: { value: 'SEARCH_GROUP' } });
 
       await waitFor(() => {
@@ -723,7 +726,7 @@ describe('QueryInsights Component', () => {
         renderQueryInsights();
       });
 
-      const searchInput = screen.getByPlaceholderText('Search queries');
+      const searchInput = screen.getByPlaceholderText('e.g. latency >= 100 AND type = query');
       // Search for X-Opaque-Id value from fixture
       fireEvent.change(searchInput, { target: { value: '90eb5c3b-8448' } });
 
@@ -739,7 +742,7 @@ describe('QueryInsights Component', () => {
         renderQueryInsights();
       });
 
-      const searchInput = screen.getByPlaceholderText('Search queries');
+      const searchInput = screen.getByPlaceholderText('e.g. latency >= 100 AND type = query');
       // Search for total_shards value
       fireEvent.change(searchInput, { target: { value: 'query_then_fetch' } });
 

--- a/public/pages/QueryInsights/QueryInsights.test.tsx
+++ b/public/pages/QueryInsights/QueryInsights.test.tsx
@@ -131,7 +131,7 @@ describe('QueryInsights Component', () => {
       renderQueryInsights(['/?wlmGroupId=analytics-workload']);
 
       const searchBox = screen.getByPlaceholderText('e.g. latency >= 100 AND type = query');
-      expect(searchBox).toHaveValue('wlm_group_id:(analytics-workload)');
+      expect(searchBox).toHaveValue('wlm_group_id = analytics-workload');
     });
 
     it('should initialize empty search query when no wlmGroupId in URL', () => {
@@ -145,14 +145,14 @@ describe('QueryInsights Component', () => {
       renderQueryInsights(['/?wlmGroupId=search-heavy&dashboard=main&tab=queries']);
 
       const searchBox = screen.getByPlaceholderText('e.g. latency >= 100 AND type = query');
-      expect(searchBox).toHaveValue('wlm_group_id:(search-heavy)');
+      expect(searchBox).toHaveValue('wlm_group_id = search-heavy');
     });
 
     it('should decode URL-encoded wlmGroupId values', () => {
       renderQueryInsights(['/?wlmGroupId=ml-training']);
 
       const searchBox = screen.getByPlaceholderText('e.g. latency >= 100 AND type = query');
-      expect(searchBox).toHaveValue('wlm_group_id:(ml-training)');
+      expect(searchBox).toHaveValue('wlm_group_id = ml-training');
     });
   });
 

--- a/public/pages/QueryInsights/QueryInsights.tsx
+++ b/public/pages/QueryInsights/QueryInsights.tsx
@@ -19,11 +19,6 @@ import {
   EuiText,
   EuiTextAlign,
   EuiIconTip,
-  EuiFieldSearch,
-  EuiFilterGroup,
-  EuiFilterButton,
-  EuiPopover,
-  EuiSelectable,
   EuiButtonGroup,
   EuiAccordion,
   EuiToolTip,
@@ -67,6 +62,12 @@ import {
   isVersion33OrHigher,
   isVersion36OrHigher,
 } from '../../utils/version-utils';
+import {
+  DynamicSearchBar,
+  FieldDef,
+  parseExpression,
+  evaluateExpression,
+} from '../../components/DynamicSearchBar';
 import { DEFAULT_WORKLOAD_GROUP } from '../../../common/constants';
 
 // --- constants for field names and defaults ---
@@ -80,7 +81,7 @@ const NODE_ID_FIELD = 'node_id';
 const TOTAL_SHARDS_FIELD = 'total_shards';
 const WLM_GROUP_FIELD = 'wlm_group_id';
 const METRIC_DEFAULT_MSG = 'Not enabled';
-const GROUP_BY_FIELD = 'group_by';
+const _GROUP_BY_FIELD = 'group_by';
 
 /**
  * QueryInsights component
@@ -118,17 +119,6 @@ const QueryInsights = ({
 
   // --- state for pagination and filters ---
   const [pagination, setPagination] = useState({ pageIndex: 0 });
-  const [searchText, setSearchText] = useState('');
-  const [isTypeFilterOpen, setIsTypeFilterOpen] = useState(false);
-  const [isIndicesFilterOpen, setIsIndicesFilterOpen] = useState(false);
-  const [isSearchTypeFilterOpen, setIsSearchTypeFilterOpen] = useState(false);
-  const [isNodeIdFilterOpen, setIsNodeIdFilterOpen] = useState(false);
-  const [isWlmGroupFilterOpen, setIsWlmGroupFilterOpen] = useState(false);
-  const [selectedGroupBy, setSelectedGroupBy] = useState<string[]>([]);
-  const [selectedIndices, setSelectedIndices] = useState<string[]>([]);
-  const [selectedSearchTypes, setSelectedSearchTypes] = useState<string[]>([]);
-  const [selectedNodeIds, setSelectedNodeIds] = useState<string[]>([]);
-  const [selectedWlmGroups, setSelectedWlmGroups] = useState<string[]>([]);
   const [wlmIdToNameMap, setWlmIdToNameMap] = useState<Record<string, string>>({});
   const [wlmAvailable, setWlmAvailable] = useState<boolean>(false);
   const [statusSupported, setStatusSupported] = useState<boolean>(false);
@@ -172,44 +162,13 @@ const QueryInsights = ({
     return wlmId ? `table-${wlmId}` : 'table-default';
   }, [location.search]);
 
-  // Build search query string from filter states
-  const buildSearchQuery = useCallback(
-    (
-      groupBy: string[],
-      indices: string[],
-      searchTypes: string[],
-      nodeIds: string[],
-      wlmGroups: string[],
-      freeText: string
-    ) => {
-      const parts: string[] = [];
-      if (groupBy.length) parts.push(`${GROUP_BY_FIELD}:(${groupBy.join(' or ')})`);
-      if (indices.length) parts.push(`${INDICES_FIELD}:(${indices.join(' or ')})`);
-      if (searchTypes.length) parts.push(`${SEARCH_TYPE_FIELD}:(${searchTypes.join(' or ')})`);
-      if (nodeIds.length) parts.push(`${NODE_ID_FIELD}:(${nodeIds.join(' or ')})`);
-      if (wlmGroups.length) parts.push(`${WLM_GROUP_FIELD}:(${wlmGroups.join(' or ')})`);
-      if (freeText) parts.push(freeText);
-      return parts.join(' ');
-    },
-    []
-  );
-
-  // Get wlmGroupId from URL parameters once and clean URL
+  // Clean URL after extracting wlmGroupId
   useEffect(() => {
     const urlSearchParams = new URLSearchParams(location.search);
-    const wlmGroupIdFromSearch = urlSearchParams.get('wlmGroupId');
-    if (wlmGroupIdFromSearch) {
-      console.log('[QueryInsights] Navigation from WLM detected:', {
-        wlmGroupId: wlmGroupIdFromSearch,
-        timestamp: new Date().toISOString(),
-        currentPath: location.pathname,
-        fullUrl: location.pathname + location.search,
-      });
-      setSelectedWlmGroups([wlmGroupIdFromSearch]);
-      setSearchQuery(buildSearchQuery([], [], [], [], [wlmGroupIdFromSearch], ''));
+    if (urlSearchParams.get('wlmGroupId')) {
       history.replace(location.pathname);
     }
-  }, [location.search, history, location.pathname, buildSearchQuery]);
+  }, [location.search, history, location.pathname]);
 
   const from = parseDateString(currStart);
   const to = parseDateString(currEnd);
@@ -314,69 +273,105 @@ const QueryInsights = ({
    *   (`group_by !== 'NONE'`) to avoid double counting and missing per-index/search-type/node metadata.
    */
 
-  const items = useMemo(() => {
-    const nonGroupActive =
-      selectedIndices.length > 0 ||
-      selectedSearchTypes.length > 0 ||
-      selectedNodeIds.length > 0 ||
-      selectedWlmGroups.length > 0 ||
-      !!searchText;
+  // --- Expression-based filtering ---
+  const searchFields = useMemo<FieldDef[]>(() => {
+    const fields: FieldDef[] = [
+      { label: 'Id', key: 'id', accessor: (q) => q.id, type: 'string' },
+      {
+        label: 'Type',
+        key: 'type',
+        accessor: (q) => (q.group_by === 'SIMILARITY' ? 'group' : 'query'),
+        type: 'string',
+      },
+      {
+        label: 'Latency',
+        key: 'latency',
+        accessor: (q) => q.measurements?.latency?.number,
+        type: 'number',
+        unit: 'ms',
+      },
+      {
+        label: 'CPU Time',
+        key: 'cpu',
+        accessor: (q) =>
+          q.measurements?.cpu?.number ? q.measurements.cpu.number / 1000000 : undefined,
+        type: 'number',
+        unit: 'ms',
+      },
+      {
+        label: 'Memory',
+        key: 'memory',
+        accessor: (q) => q.measurements?.memory?.number,
+        type: 'number',
+        unit: 'B',
+      },
+      {
+        label: 'Query Count',
+        key: 'query_count',
+        accessor: (q) =>
+          q.measurements?.latency?.count ||
+          q.measurements?.cpu?.count ||
+          q.measurements?.memory?.count ||
+          1,
+        type: 'number',
+      },
+      { label: 'Timestamp', key: 'timestamp', accessor: (q) => q.timestamp, type: 'number' },
+      { label: 'Indices', key: 'indices', accessor: (q) => q.indices, type: 'array' },
+      { label: 'Search Type', key: 'search_type', accessor: (q) => q.search_type, type: 'string' },
+      { label: 'Node ID', key: 'node_id', accessor: (q) => q.node_id, type: 'string' },
+      {
+        label: 'Total Shards',
+        key: 'total_shards',
+        accessor: (q) => q.total_shards,
+        type: 'number',
+      },
+      {
+        label: 'Status',
+        key: 'status',
+        accessor: (q) => (q.failed ? 'failed' : 'completed'),
+        type: 'string',
+      },
+    ];
+    if (queryInsightWlmNavigationSupported) {
+      fields.push({
+        label: 'WLM Group',
+        key: 'wlm_group_id',
+        accessor: (q) => q.wlm_group_id,
+        type: 'string',
+      });
+    }
+    return fields;
+  }, [queryInsightWlmNavigationSupported]);
 
-    return queries.filter((q: SearchQueryRecord) => {
-      // If the user applied non-group filters (indices, search_type, node_id, wlm_group, or free-text),
-      // but has NOT explicitly chosen "group" (selectedGroupBy is empty or includes both),
-      // then hide grouped rows (group_by = SIMILARITY).
-      if (nonGroupActive && (selectedGroupBy.length === 0 || selectedGroupBy.length === 2)) {
-        if (q.group_by !== 'NONE') return false;
-      }
-
-      if (selectedIndices.length) {
-        const rowIdx = Array.isArray(q.indices) ? q.indices : [];
-        const overlap = rowIdx.some((i) => selectedIndices.includes(i));
-        if (!overlap) return false;
-      }
-
-      if (selectedSearchTypes.length && !selectedSearchTypes.includes(q.search_type)) return false;
-
-      if (selectedNodeIds.length && !selectedNodeIds.includes(q.node_id)) return false;
-
-      if (selectedWlmGroups.length && !selectedWlmGroups.includes(q.wlm_group_id)) return false;
-
-      if (searchText) {
-        const text = searchText.toLowerCase();
-        const searchableText = Object.values(q)
-          .map((v) => {
-            try {
-              if (v == null) return '';
-              if (typeof v === 'string') return v;
-              if (typeof v === 'number') return String(v);
-              if (Array.isArray(v)) return v.join(' ');
-              if (typeof v === 'object') return JSON.stringify(v);
-              return '';
-            } catch {
-              return '';
-            }
-          })
-          .join(' ')
-          .toLowerCase();
-        if (!searchableText.includes(text)) return false;
-      }
-
-      if (selectedGroupBy.length === 1) {
-        if (!selectedGroupBy.includes(q.group_by)) return false;
-      }
-
-      return true;
+  const fieldMap = useMemo(() => {
+    const map = new Map<string, FieldDef>();
+    searchFields.forEach((f) => {
+      map.set(f.key.toLowerCase(), f);
+      map.set(f.label.toLowerCase(), f);
     });
-  }, [
-    queries,
-    selectedIndices,
-    selectedSearchTypes,
-    selectedNodeIds,
-    selectedWlmGroups,
-    searchText,
-    selectedGroupBy,
-  ]);
+    return map;
+  }, [searchFields]);
+
+  const parsedExpression = useMemo(() => parseExpression(searchQuery), [searchQuery]);
+
+  // Derive selectedGroupBy from expression for effectiveView/column logic
+  const selectedGroupBy = useMemo(() => {
+    const typeConds = parsedExpression.conditions.filter(
+      (c) => c.field.toLowerCase() === 'type' || c.field.toLowerCase() === 'group_by'
+    );
+    if (typeConds.length === 0) return [] as string[];
+    return typeConds.map((c) => {
+      const val = c.value.toLowerCase();
+      if (val === 'group' || val === 'similarity') return 'SIMILARITY';
+      return 'NONE';
+    });
+  }, [parsedExpression]);
+
+  const items = useMemo(() => {
+    return queries.filter((q: SearchQueryRecord) =>
+      evaluateExpression(q, parsedExpression, fieldMap)
+    );
+  }, [queries, parsedExpression, fieldMap]);
 
   // For metrics/visualizations, always filter out grouped queries
   const itemsForMetrics = useMemo(() => {
@@ -707,26 +702,17 @@ const QueryInsights = ({
    * based on selected filters and presence of query/group rows
    */
   const columnsToShow = useMemo(() => {
-    // true if the user applied filters that only apply to queries
-    // (indices, searchType, nodeId, or free text).
-    // Groups don't have those fields.
-    const nonGroupActive =
-      selectedIndices.length > 0 ||
-      selectedSearchTypes.length > 0 ||
-      selectedNodeIds.length > 0 ||
-      selectedWlmGroups.length > 0 ||
-      !!searchText;
+    // Check if any non-type filter conditions exist in the expression
+    const hasNonTypeFilter = parsedExpression.conditions.some(
+      (c) => c.field.toLowerCase() !== 'type' && c.field.toLowerCase() !== 'group_by'
+    );
+    const hasFreeText = !!parsedExpression.freeText;
+    const nonGroupActive = hasNonTypeFilter || hasFreeText;
 
-    // If the user explicitly picked only "group", show group columns.
-    // If they explicitly picked only "query", show query columns.
     if (selectedGroupBy.length === 1) {
       return selectedGroupBy[0] === 'SIMILARITY' ? groupTypeColumns : queryTypeColumns;
     }
 
-    // Non-group filters applied but group-by not explicitly chosen
-    // If filters like indices/searchType/nodeId/wlmGroup are active,
-    // and group-by is either empty (no choice) or includes both,
-    // force the view into query mode (groups would look wrong here).
     if (nonGroupActive && (selectedGroupBy.length === 0 || selectedGroupBy.length === 2)) {
       return queryTypeColumns;
     }
@@ -735,128 +721,26 @@ const QueryInsights = ({
     const hasAnyGroup = items.some((q: SearchQueryRecord) => q.group_by === 'SIMILARITY');
 
     if (items.length === 0) return defaultColumns;
-
     if (hasAnyQuery && hasAnyGroup) return defaultColumns;
-
     if (hasAnyGroup) return groupTypeColumns;
-
     return queryTypeColumns;
   }, [
     items,
     selectedGroupBy,
-    selectedIndices,
-    selectedSearchTypes,
-    selectedNodeIds,
-    selectedWlmGroups,
-    searchText,
+    parsedExpression,
     defaultColumns,
     groupTypeColumns,
     queryTypeColumns,
   ]);
 
-  const arraysEqualAsSets = (a: string[], b: string[]) => {
-    if (a.length !== b.length) return false;
-    const setB = new Set(b);
-    for (const x of a) if (!setB.has(x)) return false;
-    return true;
-  };
-
-  const parseList = (s: string) =>
-    s
-      .split(/\s*(?:\bor\b|,)\s*/i)
-      .map((x) => x.trim())
-      .filter(Boolean);
-
-  const extractField = (text: string, field: string): string[] => {
-    const rx = new RegExp(`${field}:\\(([^)]+)\\)`, 'i');
-    const m = rx.exec(text || '');
-    return m ? parseList(m[1]) : [];
-  };
-
   const onSearchChange = (text: string) => {
     setSearchQuery(text);
-
-    // Find every structured filter chunk like "field:(...)" in the search text and return the full matches.
-    // Regex: \b        → word boundary (start of a field name)
-    //        [\w.]+    → field name (letters/digits/_ or dots, e.g. "indices", "measurements.latency")
-    //        :         → literal colon
-    //        \( [^)]+ \) → parentheses containing any chars except ')' (the filter values)
-    // The 'g' flag finds all occurrences. matchAll() yields matches; map(m => m[0]) returns each full matched substring.
-    const fieldChunks = [...text.matchAll(/\b[\w.]+:\([^)]+\)/g)].map((m) => m[0]);
-
-    let free = text;
-    fieldChunks.forEach((chunk) => (free = free.replace(chunk, '')));
-    const nextText = free.trim().toLowerCase();
-    if (nextText !== searchText) setSearchText(nextText);
-
-    const gb = extractField(text, GROUP_BY_FIELD);
-    if (!arraysEqualAsSets(gb, selectedGroupBy)) setSelectedGroupBy(gb);
-
-    const idx = extractField(text, INDICES_FIELD);
-    if (!arraysEqualAsSets(idx, selectedIndices)) setSelectedIndices(idx);
-
-    const st = extractField(text, SEARCH_TYPE_FIELD);
-    if (!arraysEqualAsSets(st, selectedSearchTypes)) setSelectedSearchTypes(st);
-
-    const nid = extractField(text, NODE_ID_FIELD);
-    if (!arraysEqualAsSets(nid, selectedNodeIds)) setSelectedNodeIds(nid);
-
-    const wlm = extractField(text, WLM_GROUP_FIELD);
-    if (!arraysEqualAsSets(wlm, selectedWlmGroups)) {
-      setSelectedWlmGroups(wlm);
-    }
   };
 
   const onRefresh = async ({ start, end }: { start: string; end: string }) => {
     onTimeChange({ start, end });
     retrieveQueries(start, end);
   };
-
-  const indexOptions = useMemo(() => {
-    const set = new Set<string>();
-    for (const q of queries) {
-      const arr = (q as any)[INDICES_FIELD];
-      if (Array.isArray(arr)) arr.forEach((s) => s && set.add(String(s)));
-    }
-    return Array.from(set).map((idx) => ({ value: idx, name: idx, view: idx }));
-  }, [queries]);
-
-  const searchTypeOptions = useMemo(() => {
-    const set = new Set<string>();
-    for (const q of queries) {
-      const v = (q as any)[SEARCH_TYPE_FIELD];
-      if (v) set.add(String(v));
-    }
-    return Array.from(set).map((v) => ({ value: v, name: v, view: v }));
-  }, [queries]);
-
-  const nodeIdOptions = useMemo(() => {
-    const set = new Set<string>();
-    for (const q of queries) {
-      const v = (q as any)[NODE_ID_FIELD];
-      if (v) set.add(String(v));
-    }
-    return Array.from(set).map((v) => ({ value: v, name: v, view: v.replaceAll('_', ' ') }));
-  }, [queries]);
-
-  // Generate filter options for WLM groups with ID-to-name mapping
-  const wlmGroupOptions = useMemo(() => {
-    const set = new Set<string>();
-
-    for (const q of queries) {
-      const v = (q as any)[WLM_GROUP_FIELD];
-      if (v) set.add(String(v));
-    }
-
-    return Array.from(set).map((v) => {
-      const label = wlmIdToNameMap[v] || v;
-      return {
-        value: v,
-        name: label,
-        view: label,
-      };
-    });
-  }, [queries, wlmIdToNameMap]);
 
   const percentileMetrics = useMemo(() => {
     const latencies: number[] = [];
@@ -1133,253 +1017,14 @@ const QueryInsights = ({
       {!loading && (
         <>
           <EuiSpacer size="m" />
-          <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
-            <EuiFlexItem grow style={{ minWidth: 0 }}>
-              <EuiFieldSearch
-                placeholder="Search queries"
+          <EuiFlexGroup alignItems="center" gutterSize="m">
+            <EuiFlexItem grow>
+              <DynamicSearchBar
+                fields={searchFields}
+                queries={queries}
                 value={searchQuery}
-                onChange={(e) => onSearchChange(e.target.value)}
-                compressed
-                fullWidth
+                onChange={onSearchChange}
               />
-            </EuiFlexItem>
-            <EuiFlexItem grow={false} style={{ minWidth: 0, overflow: 'auto' }}>
-              <EuiFilterGroup>
-                <EuiPopover
-                  button={
-                    <EuiFilterButton
-                      iconType="arrowDown"
-                      onClick={() => setIsTypeFilterOpen(!isTypeFilterOpen)}
-                      hasActiveFilters={selectedGroupBy.length > 0}
-                      numActiveFilters={
-                        selectedGroupBy.length > 0 ? selectedGroupBy.length : undefined
-                      }
-                    >
-                      {TYPE}
-                    </EuiFilterButton>
-                  }
-                  isOpen={isTypeFilterOpen}
-                  closePopover={() => setIsTypeFilterOpen(false)}
-                  panelPaddingSize="none"
-                >
-                  <EuiSelectable
-                    options={[
-                      {
-                        label: 'query',
-                        checked: selectedGroupBy.includes('NONE') ? 'on' : undefined,
-                      },
-                      {
-                        label: 'group',
-                        checked: selectedGroupBy.includes('SIMILARITY') ? 'on' : undefined,
-                      },
-                    ]}
-                    onChange={(options) => {
-                      const selected = options
-                        .filter((opt) => opt.checked === 'on')
-                        .map((opt) => (opt.label === 'query' ? 'NONE' : 'SIMILARITY'));
-                      setSelectedGroupBy(selected);
-                      setSearchQuery(
-                        buildSearchQuery(
-                          selected,
-                          selectedIndices,
-                          selectedSearchTypes,
-                          selectedNodeIds,
-                          selectedWlmGroups,
-                          searchText
-                        )
-                      );
-                    }}
-                    listProps={{ onFocusBadge: false }}
-                  >
-                    {(list) => <div style={{ width: 200 }}>{list}</div>}
-                  </EuiSelectable>
-                </EuiPopover>
-                <EuiPopover
-                  button={
-                    <EuiFilterButton
-                      iconType="arrowDown"
-                      onClick={() => setIsIndicesFilterOpen(!isIndicesFilterOpen)}
-                      hasActiveFilters={selectedIndices.length > 0}
-                      numActiveFilters={
-                        selectedIndices.length > 0 ? selectedIndices.length : undefined
-                      }
-                    >
-                      {INDICES}
-                    </EuiFilterButton>
-                  }
-                  isOpen={isIndicesFilterOpen}
-                  closePopover={() => setIsIndicesFilterOpen(false)}
-                  panelPaddingSize="none"
-                >
-                  <EuiSelectable
-                    options={indexOptions.map((opt) => ({
-                      label: opt.value,
-                      checked: selectedIndices.includes(opt.value) ? 'on' : undefined,
-                    }))}
-                    onChange={(options) => {
-                      const selected = options
-                        .filter((opt) => opt.checked === 'on')
-                        .map((opt) => opt.label);
-                      setSelectedIndices(selected);
-                      setSearchQuery(
-                        buildSearchQuery(
-                          selectedGroupBy,
-                          selected,
-                          selectedSearchTypes,
-                          selectedNodeIds,
-                          selectedWlmGroups,
-                          searchText
-                        )
-                      );
-                    }}
-                    listProps={{ onFocusBadge: false }}
-                  >
-                    {(list) => (
-                      <div style={{ width: 200, maxHeight: 300, overflow: 'auto' }}>{list}</div>
-                    )}
-                  </EuiSelectable>
-                </EuiPopover>
-                <EuiPopover
-                  button={
-                    <EuiFilterButton
-                      iconType="arrowDown"
-                      onClick={() => setIsSearchTypeFilterOpen(!isSearchTypeFilterOpen)}
-                      hasActiveFilters={selectedSearchTypes.length > 0}
-                      numActiveFilters={
-                        selectedSearchTypes.length > 0 ? selectedSearchTypes.length : undefined
-                      }
-                    >
-                      {SEARCH_TYPE}
-                    </EuiFilterButton>
-                  }
-                  isOpen={isSearchTypeFilterOpen}
-                  closePopover={() => setIsSearchTypeFilterOpen(false)}
-                  panelPaddingSize="none"
-                >
-                  <EuiSelectable
-                    options={searchTypeOptions.map((opt) => ({
-                      label: opt.value,
-                      checked: selectedSearchTypes.includes(opt.value) ? 'on' : undefined,
-                    }))}
-                    onChange={(options) => {
-                      const selected = options
-                        .filter((opt) => opt.checked === 'on')
-                        .map((opt) => opt.label);
-                      setSelectedSearchTypes(selected);
-                      setSearchQuery(
-                        buildSearchQuery(
-                          selectedGroupBy,
-                          selectedIndices,
-                          selected,
-                          selectedNodeIds,
-                          selectedWlmGroups,
-                          searchText
-                        )
-                      );
-                    }}
-                    listProps={{ onFocusBadge: false }}
-                  >
-                    {(list) => (
-                      <div style={{ width: 200, maxHeight: 300, overflow: 'auto' }}>{list}</div>
-                    )}
-                  </EuiSelectable>
-                </EuiPopover>
-                <EuiPopover
-                  button={
-                    <EuiFilterButton
-                      iconType="arrowDown"
-                      onClick={() => setIsNodeIdFilterOpen(!isNodeIdFilterOpen)}
-                      hasActiveFilters={selectedNodeIds.length > 0}
-                      numActiveFilters={
-                        selectedNodeIds.length > 0 ? selectedNodeIds.length : undefined
-                      }
-                    >
-                      {NODE_ID}
-                    </EuiFilterButton>
-                  }
-                  isOpen={isNodeIdFilterOpen}
-                  closePopover={() => setIsNodeIdFilterOpen(false)}
-                  panelPaddingSize="none"
-                >
-                  <EuiSelectable
-                    options={nodeIdOptions.map((opt) => ({
-                      label: opt.value,
-                      checked: selectedNodeIds.includes(opt.value) ? 'on' : undefined,
-                    }))}
-                    onChange={(options) => {
-                      const selected = options
-                        .filter((opt) => opt.checked === 'on')
-                        .map((opt) => opt.label);
-                      setSelectedNodeIds(selected);
-                      setSearchQuery(
-                        buildSearchQuery(
-                          selectedGroupBy,
-                          selectedIndices,
-                          selectedSearchTypes,
-                          selected,
-                          selectedWlmGroups,
-                          searchText
-                        )
-                      );
-                    }}
-                    listProps={{ onFocusBadge: false }}
-                  >
-                    {(list) => (
-                      <div style={{ width: 200, maxHeight: 300, overflow: 'auto' }}>{list}</div>
-                    )}
-                  </EuiSelectable>
-                </EuiPopover>
-                {queryInsightWlmNavigationSupported && (
-                  <EuiPopover
-                    button={
-                      <EuiFilterButton
-                        iconType="arrowDown"
-                        onClick={() => setIsWlmGroupFilterOpen(!isWlmGroupFilterOpen)}
-                        hasActiveFilters={selectedWlmGroups.length > 0}
-                        numActiveFilters={
-                          selectedWlmGroups.length > 0 ? selectedWlmGroups.length : undefined
-                        }
-                      >
-                        {WLM_GROUP}
-                      </EuiFilterButton>
-                    }
-                    isOpen={isWlmGroupFilterOpen}
-                    closePopover={() => setIsWlmGroupFilterOpen(false)}
-                    panelPaddingSize="none"
-                  >
-                    <EuiSelectable
-                      options={wlmGroupOptions.map((opt) => ({
-                        label: opt.name,
-                        checked: selectedWlmGroups.includes(opt.value) ? 'on' : undefined,
-                      }))}
-                      onChange={(options) => {
-                        const selected = options
-                          .filter((opt) => opt.checked === 'on')
-                          .map((opt) => {
-                            const option = wlmGroupOptions.find((o) => o.name === opt.label);
-                            return option ? option.value : opt.label;
-                          });
-                        setSelectedWlmGroups(selected);
-                        setSearchQuery(
-                          buildSearchQuery(
-                            selectedGroupBy,
-                            selectedIndices,
-                            selectedSearchTypes,
-                            selectedNodeIds,
-                            selected,
-                            searchText
-                          )
-                        );
-                      }}
-                      listProps={{ onFocusBadge: false }}
-                    >
-                      {(list) => (
-                        <div style={{ width: 200, maxHeight: 300, overflow: 'auto' }}>{list}</div>
-                      )}
-                    </EuiSelectable>
-                  </EuiPopover>
-                )}
-              </EuiFilterGroup>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiSuperDatePicker

--- a/public/pages/QueryInsights/QueryInsights.tsx
+++ b/public/pages/QueryInsights/QueryInsights.tsx
@@ -81,7 +81,6 @@ const NODE_ID_FIELD = 'node_id';
 const TOTAL_SHARDS_FIELD = 'total_shards';
 const WLM_GROUP_FIELD = 'wlm_group_id';
 const METRIC_DEFAULT_MSG = 'Not enabled';
-const _GROUP_BY_FIELD = 'group_by';
 
 /**
  * QueryInsights component
@@ -129,7 +128,7 @@ const QueryInsights = ({
   const urlParams = new URLSearchParams(location.search);
   const wlmGroupIdFromUrl = urlParams.get('wlmGroupId');
   const [searchQuery, setSearchQuery] = useState<string>(
-    wlmGroupIdFromUrl ? `${WLM_GROUP_FIELD}:(${wlmGroupIdFromUrl})` : ''
+    wlmGroupIdFromUrl ? `wlm_group_id = ${wlmGroupIdFromUrl}` : ''
   );
   const [chartGroupBy, setChartGroupBy] = useState<'node' | 'index' | 'username' | 'wlm'>('node');
   const [performanceMetric, setPerformanceMetric] = useState<
@@ -1017,7 +1016,7 @@ const QueryInsights = ({
       {!loading && (
         <>
           <EuiSpacer size="m" />
-          <EuiFlexGroup alignItems="center" gutterSize="m">
+          <EuiFlexGroup alignItems="flexStart" gutterSize="m">
             <EuiFlexItem grow>
               <DynamicSearchBar
                 fields={searchFields}

--- a/public/pages/QueryInsights/__snapshots__/QueryInsights.test.tsx.snap
+++ b/public/pages/QueryInsights/__snapshots__/QueryInsights.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
     class="euiSpacer euiSpacer--m"
   />
   <div
-    class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+    class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsFlexStart euiFlexGroup--directionRow euiFlexGroup--responsive"
   >
     <div
       class="euiFlexItem"
@@ -15,14 +15,14 @@ exports[`QueryInsights Component renders the table with the correct columns and 
         style="position: relative; min-width: 400px;"
       >
         <div
-          class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+          class="euiFormControlLayout euiFormControlLayout--fullWidth"
         >
           <div
             class="euiFormControlLayout__childrenWrapper"
           >
             <input
               aria-label="Dynamic search bar"
-              class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
+              class="euiFieldSearch euiFieldSearch--fullWidth"
               placeholder="e.g. latency >= 100 AND type = query"
               type="search"
               value=""
@@ -35,7 +35,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
               >
                 <svg
                   aria-hidden="true"
-                  class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                  class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
                   focusable="false"
                   height="16"
                   role="img"

--- a/public/pages/QueryInsights/__snapshots__/QueryInsights.test.tsx.snap
+++ b/public/pages/QueryInsights/__snapshots__/QueryInsights.test.tsx.snap
@@ -6,72 +6,36 @@ exports[`QueryInsights Component renders the table with the correct columns and 
     class="euiSpacer euiSpacer--m"
   />
   <div
-    class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+    class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
   >
     <div
       class="euiFlexItem"
-      style="min-width: 0;"
     >
       <div
-        class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
+        style="position: relative; min-width: 400px;"
       >
         <div
-          class="euiFormControlLayout__childrenWrapper"
-        >
-          <input
-            class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
-            placeholder="Search queries"
-            type="search"
-            value=""
-          />
-          <div
-            class="euiFormControlLayoutIcons"
-          >
-            <span
-              class="euiFormControlLayoutCustomIcon"
-            >
-              <svg
-                aria-hidden="true"
-                class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
-                focusable="false"
-                height="16"
-                role="img"
-                viewBox="0 0 16 16"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
-                />
-              </svg>
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="euiFlexItem euiFlexItem--flexGrowZero"
-      style="min-width: 0; overflow: auto;"
-    >
-      <div
-        class="euiFilterGroup"
-      >
-        <div
-          class="euiPopover euiPopover--anchorDownCenter"
+          class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
         >
           <div
-            class="euiPopover__anchor"
+            class="euiFormControlLayout__childrenWrapper"
           >
-            <button
-              class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
-              type="button"
+            <input
+              aria-label="Dynamic search bar"
+              class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
+              placeholder="e.g. latency >= 100 AND type = query"
+              type="search"
+              value=""
+            />
+            <div
+              class="euiFormControlLayoutIcons"
             >
               <span
-                class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
+                class="euiFormControlLayoutCustomIcon"
               >
                 <svg
                   aria-hidden="true"
-                  class="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                  class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                   focusable="false"
                   height="16"
                   role="img"
@@ -80,152 +44,11 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
-                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                    fill-rule="non-zero"
+                    d="m11.271 11.978 3.872 3.873a.502.502 0 0 0 .708 0 .502.502 0 0 0 0-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 0 0 4.949 2.05.5.5 0 0 0 0-1 5.96 5.96 0 0 1-4.242-1.757 6.01 6.01 0 0 1 0-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 0 1 0 8.486.5.5 0 0 0 .034.738Z"
                   />
                 </svg>
-                <span
-                  class="euiButtonEmpty__text"
-                >
-                  <span
-                    class="euiFilterButton__textShift"
-                    data-text="Type"
-                    title="Type"
-                  >
-                    Type
-                  </span>
-                </span>
               </span>
-            </button>
-          </div>
-        </div>
-        <div
-          class="euiPopover euiPopover--anchorDownCenter"
-        >
-          <div
-            class="euiPopover__anchor"
-          >
-            <button
-              class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
-              type="button"
-            >
-              <span
-                class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                  focusable="false"
-                  height="16"
-                  role="img"
-                  viewBox="0 0 16 16"
-                  width="16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                    fill-rule="non-zero"
-                  />
-                </svg>
-                <span
-                  class="euiButtonEmpty__text"
-                >
-                  <span
-                    class="euiFilterButton__textShift"
-                    data-text="Indices"
-                    title="Indices"
-                  >
-                    Indices
-                  </span>
-                </span>
-              </span>
-            </button>
-          </div>
-        </div>
-        <div
-          class="euiPopover euiPopover--anchorDownCenter"
-        >
-          <div
-            class="euiPopover__anchor"
-          >
-            <button
-              class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
-              type="button"
-            >
-              <span
-                class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                  focusable="false"
-                  height="16"
-                  role="img"
-                  viewBox="0 0 16 16"
-                  width="16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                    fill-rule="non-zero"
-                  />
-                </svg>
-                <span
-                  class="euiButtonEmpty__text"
-                >
-                  <span
-                    class="euiFilterButton__textShift"
-                    data-text="Search Type"
-                    title="Search Type"
-                  >
-                    Search Type
-                  </span>
-                </span>
-              </span>
-            </button>
-          </div>
-        </div>
-        <div
-          class="euiPopover euiPopover--anchorDownCenter"
-        >
-          <div
-            class="euiPopover__anchor"
-          >
-            <button
-              class="euiButtonEmpty euiButtonEmpty--text euiFilterButton euiFilterButton--hasIcon"
-              type="button"
-            >
-              <span
-                class="euiButtonContent euiButtonContent--iconRight euiButtonEmpty__content"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
-                  focusable="false"
-                  height="16"
-                  role="img"
-                  viewBox="0 0 16 16"
-                  width="16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                    fill-rule="non-zero"
-                  />
-                </svg>
-                <span
-                  class="euiButtonEmpty__text"
-                >
-                  <span
-                    class="euiFilterButton__textShift"
-                    data-text="Coordinator Node ID"
-                    title="Coordinator Node ID"
-                  >
-                    Coordinator Node ID
-                  </span>
-                </span>
-              </span>
-            </button>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Description

Replace the existing filter bar (Type, Indices, Search Type, Node ID, WLM Group popovers) with a new DynamicSearchBar component that provides a unified, expression-based search experience on the Top N Queries page.

#### Changes
New Component: DynamicSearchBar

- Typed expression search: field operator value syntax (e.g., latency >= 100 AND type = query)
- Context-aware suggestions as you type:
- Field names when starting a new condition
- Operators after selecting a field (=, !=, >, <, >=, <=, between, starts_with, ends_with, contains)
- Values from actual data after selecting an operator
- Conjunctions (AND, OR) after completing a condition
- Filter badges below the search bar showing active conditions with X to remove
- Auto-formatting for between expressions: typing latency between 100 500 auto-formats to latency between (100, 500)
- Free-text search across all fields when no structured expression is detected
- Integration
- Replaces EuiFieldSearch + EuiFilterGroup with EuiPopover/EuiSelectable filter buttons
- Maintains WLM group URL parameter initialization (?wlmGroupId=...)
- Table filtering uses evaluateExpression() for structured queries and free-text fallback

Tests

- Updated unit tests in QueryInsights.test.tsx for new search bar placeholder and behavior
- Added DynamicSearchBar Cypress tests in 1_top_queries.cy.js covering suggestions, filtering, badges, between formatting
- Updated 10_topN_queries_wlm.cy.js to use search bar for WLM filtering
- Removed obsolete "Filters and Search" Cypress tests that referenced old filter popovers

Supported Operators

1. Number	=, !=, >, <, >=, <=, between
2. String	=, !=, starts_with, ends_with, contains
3. Array	= (contains), != (does not contain)
4. Boolean	=, !=

Example Queries
```
latency >= 100
type = query AND search_type = query_then_fetch
latency between (50, 200) AND node_id = nodeA
indices contains kibana
```

Testing

-  Unit tests pass (yarn test:jest)
-  Lint passes (npx eslint --fix)
-  Cypress tests for DynamicSearchBar pass
-  Manual testing with live cluster

Screenshots

<img width="1724" height="772" alt="Screenshot 2026-05-06 at 1 21 06 AM" src="https://github.com/user-attachments/assets/e4c23b1a-5348-4bbe-b246-c3cfaca5c3bb" />

<img width="1724" height="1045" alt="Screenshot 2026-05-19 at 12 41 52 PM" src="https://github.com/user-attachments/assets/02be1517-fcef-415d-ac10-588a34284760" />



### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
