### PR TITLE
Added remote repository exporter to configuration page

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - "*"
 env:
-  GRADLE_VERSION: '7.6.1'
+  GRADLE_VERSION: '9.4.1'
   CYPRESS_VIDEO: true
   CYPRESS_SCREENSHOT_ON_RUN_FAILURE: true
 

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -61,6 +61,9 @@ export const EXPORTER_TYPES_LIST = [
   { value: EXPORTER_TYPE.localIndex, text: 'Local Index' },
   { value: EXPORTER_TYPE.none, text: 'None' },
 ];
+export const DEFAULT_REMOTE_EXPORTER_ENABLED = false;
+export const DEFAULT_REMOTE_EXPORTER_REPOSITORY = '';
+export const DEFAULT_REMOTE_EXPORTER_PATH = 'query-insights';
 export const DEFAULT_METRIC_ENABLED = true;
 export const DEFAULT_TOP_N_SIZE = '10';
 export const DEFAULT_WINDOW_SIZE = '5';

--- a/cypress/e2e/qi/3_configurations.cy.js
+++ b/cypress/e2e/qi/3_configurations.cy.js
@@ -37,8 +37,8 @@ describe('Query Insights Configurations Page', () => {
     cy.contains('button', 'Live queries').should('be.visible');
     cy.contains('button', 'Configuration').should('have.class', 'euiTab-isSelected');
     // Validate the panels
-    // 6 panels: Settings, Status, Group Settings, Group Status, Delete After Settings, Delete After Status
-    cy.get('.euiPanel').should('have.length', 6);
+    // 8 panels: Settings, Status, Group Settings, Group Status, Export Settings, Export Status, Remote Exporter Settings, Remote Exporter Status
+    cy.get('.euiPanel').should('have.length', 8);
   });
 
   /**

--- a/public/pages/Configuration/Components/RegisterRepositoryFlyout.test.tsx
+++ b/public/pages/Configuration/Components/RegisterRepositoryFlyout.test.tsx
@@ -1,0 +1,484 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import RegisterRepositoryFlyout from './RegisterRepositoryFlyout';
+
+const mockOnClose = jest.fn();
+const mockOnSuccess = jest.fn();
+const mockAddSuccess = jest.fn();
+const mockAddDanger = jest.fn();
+
+const createMockCore = (overrides: Record<string, jest.Mock> = {}) => ({
+  http: {
+    get: overrides.get || jest.fn().mockResolvedValue({ ok: true, response: {} }),
+    put: overrides.put || jest.fn().mockResolvedValue({ ok: true }),
+    delete: overrides.delete || jest.fn().mockResolvedValue({ ok: true }),
+  },
+  notifications: {
+    toasts: {
+      addSuccess: mockAddSuccess,
+      addDanger: mockAddDanger,
+    },
+  },
+});
+
+const renderFlyout = (coreOverrides: Record<string, jest.Mock> = {}) => {
+  const core = createMockCore(coreOverrides);
+  render(
+    <RegisterRepositoryFlyout
+      core={core as any}
+      dataSourceId="test-ds"
+      onClose={mockOnClose}
+      onSuccess={mockOnSuccess}
+    />
+  );
+  return core;
+};
+
+const fillForm = (repoName: string, bucket: string, basePath = '') => {
+  fireEvent.change(screen.getByPlaceholderText('my-s3-repository'), {
+    target: { value: repoName },
+  });
+  fireEvent.change(screen.getByPlaceholderText('my-opensearch-snapshots'), {
+    target: { value: bucket },
+  });
+  if (basePath) {
+    fireEvent.change(screen.getByPlaceholderText('snapshots'), {
+      target: { value: basePath },
+    });
+  }
+};
+
+describe('RegisterRepositoryFlyout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('should render the flyout with all form fields', () => {
+      renderFlyout();
+      expect(screen.getByText('Register S3 repository')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('my-s3-repository')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('my-opensearch-snapshots')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('snapshots')).toBeInTheDocument();
+      expect(screen.getByText('Register repository')).toBeInTheDocument();
+      expect(screen.getByText('Cancel')).toBeInTheDocument();
+    });
+
+    it('should call onClose when Cancel is clicked', () => {
+      renderFlyout();
+      fireEvent.click(screen.getByText('Cancel'));
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('Validation', () => {
+    it('should show error when repository name is empty', async () => {
+      renderFlyout();
+      fillForm('', 'my-bucket');
+      fireEvent.click(screen.getByText('Register repository'));
+      await waitFor(() => {
+        expect(screen.getByText('Repository name is required.')).toBeInTheDocument();
+      });
+    });
+
+    it('should show error when bucket is empty', async () => {
+      renderFlyout();
+      fillForm('my-repo', '');
+      fireEvent.click(screen.getByText('Register repository'));
+      await waitFor(() => {
+        expect(screen.getByText('Bucket name is required.')).toBeInTheDocument();
+      });
+    });
+
+    it('should show errors for both empty fields', async () => {
+      renderFlyout();
+      fireEvent.click(screen.getByText('Register repository'));
+      await waitFor(() => {
+        expect(screen.getByText('Repository name is required.')).toBeInTheDocument();
+        expect(screen.getByText('Bucket name is required.')).toBeInTheDocument();
+      });
+    });
+
+    it('should block registration when repo name already exists', async () => {
+      const core = renderFlyout({
+        get: jest.fn().mockResolvedValue({
+          ok: true,
+          response: { 'existing-repo': { type: 's3', settings: { bucket: 'b' } } },
+        }),
+      });
+      fillForm('existing-repo', 'my-bucket');
+      fireEvent.click(screen.getByText('Register repository'));
+      await waitFor(() => {
+        expect(
+          screen.getByText('A repository named "existing-repo" already exists.')
+        ).toBeInTheDocument();
+      });
+      expect(core.http.put).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Successful Registration', () => {
+    it('should call onSuccess and onClose on successful registration', async () => {
+      renderFlyout({
+        get: jest.fn().mockResolvedValue({ ok: true, response: {} }),
+        put: jest.fn().mockResolvedValue({ ok: true }),
+      });
+      fillForm('new-repo', 'my-bucket', 'data/path');
+      fireEvent.click(screen.getByText('Register repository'));
+      await waitFor(() => {
+        expect(mockAddSuccess).toHaveBeenCalledWith('Repository "new-repo" registered.');
+        expect(mockOnSuccess).toHaveBeenCalledWith('new-repo');
+        expect(mockOnClose).toHaveBeenCalled();
+      });
+    });
+
+    it('should send base_path in settings when provided', async () => {
+      const mockPut = jest.fn().mockResolvedValue({ ok: true });
+      renderFlyout({
+        get: jest.fn().mockResolvedValue({ ok: true, response: {} }),
+        put: mockPut,
+      });
+      fillForm('new-repo', 'my-bucket', 'my/path');
+      fireEvent.click(screen.getByText('Register repository'));
+      await waitFor(() => {
+        expect(mockPut).toHaveBeenCalledWith(
+          '/api/snapshot/repository',
+          expect.objectContaining({
+            body: JSON.stringify({
+              repository: 'new-repo',
+              type: 's3',
+              settings: { bucket: 'my-bucket', base_path: 'my/path' },
+            }),
+          })
+        );
+      });
+    });
+
+    it('should not send base_path when empty', async () => {
+      const mockPut = jest.fn().mockResolvedValue({ ok: true });
+      renderFlyout({
+        get: jest.fn().mockResolvedValue({ ok: true, response: {} }),
+        put: mockPut,
+      });
+      fillForm('new-repo', 'my-bucket');
+      fireEvent.click(screen.getByText('Register repository'));
+      await waitFor(() => {
+        expect(mockPut).toHaveBeenCalledWith(
+          '/api/snapshot/repository',
+          expect.objectContaining({
+            body: JSON.stringify({
+              repository: 'new-repo',
+              type: 's3',
+              settings: { bucket: 'my-bucket' },
+            }),
+          })
+        );
+      });
+    });
+  });
+
+  describe('Failed Registration', () => {
+    it('should show user-friendly error for missing credentials', async () => {
+      renderFlyout({
+        get: jest.fn().mockResolvedValue({ ok: true, response: {} }),
+        put: jest.fn().mockResolvedValue({
+          ok: false,
+          response: JSON.stringify({
+            error: {
+              reason: '[repo] path not accessible',
+              caused_by: { reason: 'Failed to load credentials from IMDS.' },
+            },
+          }),
+        }),
+        delete: jest.fn().mockResolvedValue({ ok: true }),
+      });
+      fillForm('new-repo', 'my-bucket');
+      fireEvent.click(screen.getByText('Register repository'));
+      await waitFor(() => {
+        expect(mockAddDanger).toHaveBeenCalledWith(
+          expect.stringContaining('AWS credentials are not configured')
+        );
+      });
+    });
+
+    it('should show user-friendly error for missing region', async () => {
+      renderFlyout({
+        get: jest.fn().mockResolvedValue({ ok: true, response: {} }),
+        put: jest.fn().mockResolvedValue({
+          ok: false,
+          response: JSON.stringify({
+            error: {
+              reason: '[repo] path not accessible',
+              caused_by: {
+                reason: 'Unable to load region from any of the providers in the chain',
+              },
+            },
+          }),
+        }),
+        delete: jest.fn().mockResolvedValue({ ok: true }),
+      });
+      fillForm('new-repo', 'my-bucket');
+      fireEvent.click(screen.getByText('Register repository'));
+      await waitFor(() => {
+        expect(mockAddDanger).toHaveBeenCalledWith(
+          expect.stringContaining('AWS region is not configured')
+        );
+      });
+    });
+
+    it('should show user-friendly error for non-existent bucket', async () => {
+      renderFlyout({
+        get: jest.fn().mockResolvedValue({ ok: true, response: {} }),
+        put: jest.fn().mockResolvedValue({
+          ok: false,
+          response: JSON.stringify({
+            error: {
+              reason: '[repo] path not accessible',
+              caused_by: { reason: 'The specified bucket does not exist' },
+            },
+          }),
+        }),
+        delete: jest.fn().mockResolvedValue({ ok: true }),
+      });
+      fillForm('new-repo', 'bad-bucket');
+      fireEvent.click(screen.getByText('Register repository'));
+      await waitFor(() => {
+        expect(mockAddDanger).toHaveBeenCalledWith(
+          expect.stringContaining('S3 bucket does not exist')
+        );
+      });
+    });
+
+    it('should show user-friendly error for access denied', async () => {
+      renderFlyout({
+        get: jest.fn().mockResolvedValue({ ok: true, response: {} }),
+        put: jest.fn().mockResolvedValue({
+          ok: false,
+          response: JSON.stringify({
+            error: {
+              reason: '[repo] path not accessible',
+              caused_by: { reason: 'Access Denied (Service: S3, Status Code: 403)' },
+            },
+          }),
+        }),
+        delete: jest.fn().mockResolvedValue({ ok: true }),
+      });
+      fillForm('new-repo', 'my-bucket');
+      fireEvent.click(screen.getByText('Register repository'));
+      await waitFor(() => {
+        expect(mockAddDanger).toHaveBeenCalledWith(expect.stringContaining('Access denied'));
+      });
+    });
+
+    it('should clean up broken repo entry on failed registration', async () => {
+      const mockDelete = jest.fn().mockResolvedValue({ ok: true });
+      renderFlyout({
+        get: jest.fn().mockResolvedValue({ ok: true, response: {} }),
+        put: jest.fn().mockResolvedValue({
+          ok: false,
+          response: JSON.stringify({
+            error: { reason: 'verification failed' },
+          }),
+        }),
+        delete: mockDelete,
+      });
+      fillForm('new-repo', 'my-bucket');
+      fireEvent.click(screen.getByText('Register repository'));
+      await waitFor(() => {
+        expect(mockDelete).toHaveBeenCalledWith(
+          '/api/snapshot/repository/new-repo',
+          expect.objectContaining({ query: { dataSourceId: 'test-ds' } })
+        );
+      });
+    });
+
+    it('should handle network errors gracefully', async () => {
+      renderFlyout({
+        get: jest.fn().mockResolvedValue({ ok: true, response: {} }),
+        put: jest.fn().mockRejectedValue(new Error('Network error')),
+      });
+      fillForm('new-repo', 'my-bucket');
+      fireEvent.click(screen.getByText('Register repository'));
+      await waitFor(() => {
+        expect(mockAddDanger).toHaveBeenCalledWith('Failed to register repository: Network error');
+      });
+    });
+
+    it('should handle errors without message property', async () => {
+      renderFlyout({
+        get: jest.fn().mockResolvedValue({ ok: true, response: {} }),
+        put: jest.fn().mockRejectedValue({ body: { message: 'Server unavailable' } }),
+      });
+      fillForm('new-repo', 'my-bucket');
+      fireEvent.click(screen.getByText('Register repository'));
+      await waitFor(() => {
+        expect(mockAddDanger).toHaveBeenCalledWith(
+          'Failed to register repository: Server unavailable'
+        );
+      });
+    });
+
+    it('should show fallback error with caused_by for unknown errors', async () => {
+      renderFlyout({
+        get: jest.fn().mockResolvedValue({ ok: true, response: {} }),
+        put: jest.fn().mockResolvedValue({
+          ok: false,
+          response: JSON.stringify({
+            error: {
+              reason: '[repo] path not accessible',
+              caused_by: { reason: 'Some unexpected error from OpenSearch' },
+            },
+          }),
+        }),
+        delete: jest.fn().mockResolvedValue({ ok: true }),
+      });
+      fillForm('new-repo', 'my-bucket');
+      fireEvent.click(screen.getByText('Register repository'));
+      await waitFor(() => {
+        expect(mockAddDanger).toHaveBeenCalledWith(
+          'Failed to register repository: [repo] path not accessible. Caused by: Some unexpected error from OpenSearch'
+        );
+      });
+    });
+
+    it('should proceed with registration when duplicate check API fails', async () => {
+      const mockPut = jest.fn().mockResolvedValue({ ok: true });
+      renderFlyout({
+        get: jest.fn().mockRejectedValue(new Error('Network error')),
+        put: mockPut,
+      });
+      fillForm('new-repo', 'my-bucket');
+      fireEvent.click(screen.getByText('Register repository'));
+      await waitFor(() => {
+        expect(mockPut).toHaveBeenCalled();
+        expect(mockAddSuccess).toHaveBeenCalledWith('Repository "new-repo" registered.');
+      });
+    });
+
+    it('should still show error toast when cleanup delete fails', async () => {
+      renderFlyout({
+        get: jest.fn().mockResolvedValue({ ok: true, response: {} }),
+        put: jest.fn().mockResolvedValue({
+          ok: false,
+          response: JSON.stringify({
+            error: { reason: 'verification failed' },
+          }),
+        }),
+        delete: jest.fn().mockRejectedValue(new Error('Delete failed')),
+      });
+      fillForm('new-repo', 'my-bucket');
+      fireEvent.click(screen.getByText('Register repository'));
+      await waitFor(() => {
+        expect(mockAddDanger).toHaveBeenCalledWith(
+          expect.stringContaining('Failed to register repository')
+        );
+      });
+    });
+
+    it('should trim whitespace from inputs before submitting', async () => {
+      const mockPut = jest.fn().mockResolvedValue({ ok: true });
+      renderFlyout({
+        get: jest.fn().mockResolvedValue({ ok: true, response: {} }),
+        put: mockPut,
+      });
+      fillForm('  new-repo  ', '  my-bucket  ', '  my/path  ');
+      fireEvent.click(screen.getByText('Register repository'));
+      await waitFor(() => {
+        expect(mockPut).toHaveBeenCalledWith(
+          '/api/snapshot/repository',
+          expect.objectContaining({
+            body: JSON.stringify({
+              repository: 'new-repo',
+              type: 's3',
+              settings: { bucket: 'my-bucket', base_path: 'my/path' },
+            }),
+          })
+        );
+      });
+    });
+
+    it('should clear repository name error when user starts typing', async () => {
+      renderFlyout();
+      fillForm('', 'my-bucket');
+      fireEvent.click(screen.getByText('Register repository'));
+      await waitFor(() => {
+        expect(screen.getByText('Repository name is required.')).toBeInTheDocument();
+      });
+      fireEvent.change(screen.getByPlaceholderText('my-s3-repository'), {
+        target: { value: 'n' },
+      });
+      await waitFor(() => {
+        expect(screen.queryByText('Repository name is required.')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should clear bucket error when user starts typing', async () => {
+      renderFlyout();
+      fillForm('my-repo', '');
+      fireEvent.click(screen.getByText('Register repository'));
+      await waitFor(() => {
+        expect(screen.getByText('Bucket name is required.')).toBeInTheDocument();
+      });
+      fireEvent.change(screen.getByPlaceholderText('my-opensearch-snapshots'), {
+        target: { value: 'b' },
+      });
+      await waitFor(() => {
+        expect(screen.queryByText('Bucket name is required.')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should show loading state while submitting', async () => {
+      let resolveRegistration: any;
+      const mockPut = jest.fn().mockReturnValue(
+        new Promise((resolve) => {
+          resolveRegistration = resolve;
+        })
+      );
+      renderFlyout({
+        get: jest.fn().mockResolvedValue({ ok: true, response: {} }),
+        put: mockPut,
+      });
+      fillForm('new-repo', 'my-bucket');
+      fireEvent.click(screen.getByText('Register repository'));
+      // Button should be in loading state
+      await waitFor(() => {
+        const submitButton = screen.getByRole('button', { name: /Register repository/i });
+        expect(submitButton).toBeDisabled();
+      });
+      resolveRegistration({ ok: true });
+      await waitFor(() => {
+        expect(mockOnClose).toHaveBeenCalled();
+      });
+    });
+
+    it('should prevent multiple simultaneous submissions', async () => {
+      let resolveRegistration: any;
+      const mockPut = jest.fn().mockReturnValue(
+        new Promise((resolve) => {
+          resolveRegistration = resolve;
+        })
+      );
+      renderFlyout({
+        get: jest.fn().mockResolvedValue({ ok: true, response: {} }),
+        put: mockPut,
+      });
+      fillForm('new-repo', 'my-bucket');
+      // Click submit multiple times rapidly
+      const button = screen.getByText('Register repository');
+      fireEvent.click(button);
+      fireEvent.click(button);
+      fireEvent.click(button);
+      // Should only call PUT once
+      await waitFor(() => {
+        expect(mockPut).toHaveBeenCalledTimes(1);
+      });
+      resolveRegistration({ ok: true });
+    });
+  });
+});

--- a/public/pages/Configuration/Components/RegisterRepositoryFlyout.tsx
+++ b/public/pages/Configuration/Components/RegisterRepositoryFlyout.tsx
@@ -1,0 +1,249 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from 'react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFieldText,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutFooter,
+  EuiFlyoutHeader,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiTitle,
+} from '@elastic/eui';
+import { CoreStart } from 'opensearch-dashboards/public';
+
+interface RegisterRepositoryFlyoutProps {
+  core: CoreStart;
+  dataSourceId?: string;
+  onClose: () => void;
+  onSuccess: (repoName: string) => void;
+}
+
+const RegisterRepositoryFlyout = ({
+  core,
+  dataSourceId,
+  onClose,
+  onSuccess,
+}: RegisterRepositoryFlyoutProps) => {
+  const [repoName, setRepoName] = useState('');
+  const [bucket, setBucket] = useState('');
+  const [basePath, setBasePath] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [repoNameError, setRepoNameError] = useState('');
+  const [bucketError, setBucketError] = useState('');
+
+  const parseErrorReason = (rawResponse: string): string => {
+    try {
+      const parsed = typeof rawResponse === 'string' ? JSON.parse(rawResponse) : rawResponse;
+      const topReason = parsed?.error?.reason;
+      if (!topReason) return rawResponse;
+
+      // Collect all reasons from the caused_by chain
+      const allReasons: string[] = [topReason];
+      let err = parsed?.error?.caused_by;
+      while (err) {
+        if (err.reason) allReasons.push(err.reason);
+        err = err.caused_by;
+      }
+      const fullChain = allReasons.join(' ');
+
+      // Detect specific error patterns and return user-friendly messages
+      if (/credentials|IMDS|access_key|secret_key/i.test(fullChain)) {
+        return (
+          'AWS credentials are not configured. Add credentials to the OpenSearch keystore ' +
+          'using: bin/opensearch-keystore add s3.client.default.access_key and ' +
+          'bin/opensearch-keystore add s3.client.default.secret_key, then restart the cluster.'
+        );
+      }
+      if (/load region|region.*provider/i.test(fullChain)) {
+        return (
+          'AWS region is not configured. Set s3.client.default.region in opensearch.yml ' +
+          'and restart the cluster, or set the AWS_REGION environment variable.'
+        );
+      }
+      if (/Access Denied|AccessDenied|403/i.test(fullChain)) {
+        return (
+          'Access denied. Verify that the IAM credentials have the required S3 permissions ' +
+          'for the specified bucket.'
+        );
+      }
+      if (/NoSuchBucket|bucket does not exist/i.test(fullChain)) {
+        return 'The specified S3 bucket does not exist. Verify the bucket name and region.';
+      }
+
+      // Fallback: show top reason + deepest non-generic cause
+      const genericPatterns = /^(Connect timed out|Read timed out|Connection refused|java\.)/i;
+      const actionableReason = [...allReasons]
+        .slice(1)
+        .reverse()
+        .find((r) => !genericPatterns.test(r));
+
+      if (actionableReason) {
+        return `${topReason}. Caused by: ${actionableReason}`;
+      }
+      return topReason;
+    } catch {
+      return rawResponse;
+    }
+  };
+
+  /**
+   * Registers an S3 snapshot repository in OpenSearch.
+   *
+   * Note: OpenSearch creates the repository metadata before running verification.
+   * If verification fails (e.g., bad credentials, missing bucket), we clean up
+   * the broken entry to avoid leaving orphaned repositories in the cluster state.
+   */
+  const onSubmit = async () => {
+    let hasError = false;
+    if (!repoName.trim()) {
+      setRepoNameError('Repository name is required.');
+      hasError = true;
+    } else {
+      setRepoNameError('');
+    }
+    if (!bucket.trim()) {
+      setBucketError('Bucket name is required.');
+      hasError = true;
+    } else {
+      setBucketError('');
+    }
+    if (hasError) return;
+
+    setIsSubmitting(true);
+    try {
+      const trimmedName = repoName.trim();
+      const settings: Record<string, string> = { bucket: bucket.trim() };
+      if (basePath.trim()) settings.base_path = basePath.trim();
+
+      // Check if a repo with this name already exists
+      try {
+        const existingRepos = await core.http.get('/api/snapshot/repositories', {
+          query: { dataSourceId: dataSourceId || '' },
+        });
+        if (existingRepos.ok && existingRepos.response && trimmedName in existingRepos.response) {
+          setRepoNameError(`A repository named "${trimmedName}" already exists.`);
+          setIsSubmitting(false);
+          return;
+        }
+      } catch (e) {
+        // If we can't check, proceed with registration — OpenSearch will reject duplicates
+        console.warn('Unable to check existing repositories:', e);
+      }
+
+      const resp = await core.http.put('/api/snapshot/repository', {
+        query: { dataSourceId: dataSourceId || '' },
+        body: JSON.stringify({
+          repository: trimmedName,
+          type: 's3',
+          settings,
+        }),
+      });
+
+      if (resp.ok) {
+        core.notifications.toasts.addSuccess(`Repository "${trimmedName}" registered.`);
+        onSuccess(trimmedName);
+        onClose();
+      } else {
+        // OpenSearch creates the repo metadata entry before verification runs.
+        // If verification fails, the broken entry remains — clean it up.
+        try {
+          await core.http.delete(`/api/snapshot/repository/${encodeURIComponent(trimmedName)}`, {
+            query: { dataSourceId: dataSourceId || '' },
+          });
+        } catch (e) {
+          console.warn('Failed to clean up broken repository entry:', e);
+        }
+        core.notifications.toasts.addDanger(
+          `Failed to register repository: ${parseErrorReason(resp.response || 'Unknown error')}`
+        );
+      }
+    } catch (error: any) {
+      core.notifications.toasts.addDanger(
+        `Failed to register repository: ${
+          error.message || error.body?.message || 'Network error occurred'
+        }`
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <EuiFlyout ownFocus onClose={onClose} size="s">
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m">
+          <h2>Register S3 repository</h2>
+        </EuiTitle>
+      </EuiFlyoutHeader>
+
+      <EuiFlyoutBody>
+        <EuiFormRow label="Repository name" isInvalid={!!repoNameError} error={repoNameError}>
+          <EuiFieldText
+            placeholder="my-s3-repository"
+            value={repoName}
+            onChange={(e) => {
+              setRepoName(e.target.value);
+              if (repoNameError) setRepoNameError('');
+            }}
+            isInvalid={!!repoNameError}
+            data-test-subj="register-repo-name"
+          />
+        </EuiFormRow>
+
+        <EuiFormRow label="S3 bucket" isInvalid={!!bucketError} error={bucketError}>
+          <EuiFieldText
+            placeholder="my-opensearch-snapshots"
+            value={bucket}
+            onChange={(e) => {
+              setBucket(e.target.value);
+              if (bucketError) setBucketError('');
+            }}
+            isInvalid={!!bucketError}
+            data-test-subj="register-repo-bucket"
+          />
+        </EuiFormRow>
+
+        <EuiFormRow
+          label="Base path"
+          helpText="Optional. The path within the bucket for repository data."
+        >
+          <EuiFieldText
+            placeholder="snapshots"
+            value={basePath}
+            onChange={(e) => setBasePath(e.target.value)}
+            data-test-subj="register-repo-base-path"
+          />
+        </EuiFormRow>
+      </EuiFlyoutBody>
+
+      <EuiFlyoutFooter>
+        <EuiFlexGroup justifyContent="spaceBetween">
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty onClick={onClose}>Cancel</EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              fill
+              onClick={onSubmit}
+              isLoading={isSubmitting}
+              data-test-subj="register-repo-submit"
+            >
+              Register repository
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutFooter>
+    </EuiFlyout>
+  );
+};
+
+// eslint-disable-next-line import/no-default-export
+export default RegisterRepositoryFlyout;

--- a/public/pages/Configuration/Configuration.test.tsx
+++ b/public/pages/Configuration/Configuration.test.tsx
@@ -22,6 +22,9 @@ const mockCoreStart = {
   chrome: {
     setBreadcrumbs: jest.fn(),
   },
+  http: {
+    get: jest.fn().mockResolvedValue({ ok: true, response: {} }),
+  },
 };
 
 const defaultLatencySettings = {
@@ -52,6 +55,12 @@ const dataRetentionSettings = {
   deleteAfterDays: '179',
 };
 
+const remoteExporterSettings = {
+  enabled: false,
+  repository: '',
+  path: 'query-insights',
+};
+
 const dataSourceMenuMock = jest.fn(() => <div>Mock DataSourceMenu</div>);
 
 const dataSourceManagementMock = {
@@ -75,6 +84,7 @@ const renderConfiguration = (overrides = {}) =>
           groupBySettings={groupBySettings}
           configInfo={mockConfigInfo}
           dataRetentionSettings={dataRetentionSettings}
+          remoteExporterSettings={remoteExporterSettings}
           core={mockCoreStart}
           depsStart={{ navigation: {} }}
           params={{} as any}
@@ -86,7 +96,10 @@ const renderConfiguration = (overrides = {}) =>
 
 const getWindowSizeConfigurations = () => screen.getAllByRole('combobox');
 const getTopNSizeConfiguration = () => screen.getAllByRole('spinbutton');
-const getEnableToggle = () => screen.getByRole('switch');
+const getEnableToggle = () => {
+  const toggles = screen.getAllByRole('switch');
+  return toggles[0]; // First switch is the top-n-metric toggle
+};
 
 describe('Configuration Component', () => {
   beforeEach(() => {
@@ -141,7 +154,10 @@ describe('Configuration Component', () => {
         'MINUTES',
         'local_index',
         'SIMILARITY',
-        '179'
+        '179',
+        false,
+        '',
+        'query-insights'
       );
     });
   });
@@ -329,6 +345,262 @@ describe('Configuration Component', () => {
           false
         );
       });
+
+      it('should return false when remote is enabled but repository is empty', () => {
+        expect(
+          validateConfiguration('50', '5', 'MINUTES', '30', EXPORTER_TYPE.localIndex, true, '')
+        ).toBe(false);
+      });
+
+      it('should return true when remote is enabled with a repository', () => {
+        expect(
+          validateConfiguration(
+            '50',
+            '5',
+            'MINUTES',
+            '30',
+            EXPORTER_TYPE.localIndex,
+            true,
+            'my-repo'
+          )
+        ).toBe(true);
+      });
+
+      it('should return true when remote is disabled regardless of repository', () => {
+        expect(
+          validateConfiguration('50', '5', 'MINUTES', '30', EXPORTER_TYPE.localIndex, false, '')
+        ).toBe(true);
+      });
+    });
+  });
+
+  describe('Remote Repository Exporter', () => {
+    const getRemoteToggle = () => {
+      const toggles = screen.getAllByRole('switch');
+      return toggles[toggles.length - 1]; // Last switch is the remote exporter toggle
+    };
+
+    it('should show remote exporter toggle in disabled state by default', () => {
+      renderConfiguration();
+      const remoteToggle = getRemoteToggle();
+      expect(remoteToggle).not.toBeChecked();
+    });
+
+    it('should not show repository fields when remote exporter is disabled', () => {
+      renderConfiguration();
+      expect(screen.queryByText('exporter.remote.repository')).not.toBeInTheDocument();
+      expect(screen.queryByText('exporter.remote.path')).not.toBeInTheDocument();
+    });
+
+    it('should check plugin when remote toggle is enabled', async () => {
+      mockCoreStart.http.get.mockResolvedValue({ ok: true, response: {} });
+      renderConfiguration();
+      fireEvent.click(getRemoteToggle());
+      await waitFor(() => {
+        expect(mockCoreStart.http.get).toHaveBeenCalledWith(
+          '/api/cat/plugins',
+          expect.objectContaining({ query: { dataSourceId: 'test' } })
+        );
+      });
+    });
+
+    it('should show plugin not installed error when plugin is missing', async () => {
+      mockCoreStart.http.get.mockImplementation((url: string) => {
+        if (url === '/api/cat/plugins') {
+          return Promise.resolve({ ok: true, response: [{ component: 'other-plugin' }] });
+        }
+        return Promise.resolve({ ok: true, response: {} });
+      });
+      renderConfiguration();
+      fireEvent.click(getRemoteToggle());
+      await waitFor(() => {
+        expect(screen.getByText('The repository-s3 plugin is not installed')).toBeInTheDocument();
+      });
+    });
+
+    it('should show repository fields when plugin check fails (optimistic fallback)', async () => {
+      mockCoreStart.http.get.mockImplementation((url: string) => {
+        if (url === '/api/cat/plugins') {
+          return Promise.reject(new Error('Network error'));
+        }
+        return Promise.resolve({ ok: true, response: {} });
+      });
+      renderConfiguration();
+      fireEvent.click(getRemoteToggle());
+      await waitFor(() => {
+        expect(screen.getByText('Register new')).toBeInTheDocument();
+      });
+    });
+
+    it('should show repository fields when plugin is installed', async () => {
+      mockCoreStart.http.get.mockImplementation((url: string) => {
+        if (url === '/api/cat/plugins') {
+          return Promise.resolve({ ok: true, response: [{ component: 'repository-s3' }] });
+        }
+        if (url === '/api/snapshot/repositories') {
+          return Promise.resolve({ ok: true, response: { 'my-repo': { type: 's3' } } });
+        }
+        return Promise.resolve({ ok: true, response: {} });
+      });
+      renderConfiguration();
+      fireEvent.click(getRemoteToggle());
+      await waitFor(() => {
+        expect(screen.getByText('Register new')).toBeInTheDocument();
+      });
+    });
+
+    it('should show repository fields on load when remote exporter is already enabled', async () => {
+      mockCoreStart.http.get.mockImplementation((url: string) => {
+        if (url === '/api/cat/plugins') {
+          return Promise.resolve({ ok: true, response: [{ component: 'repository-s3' }] });
+        }
+        if (url === '/api/snapshot/repositories') {
+          return Promise.resolve({ ok: true, response: { 'my-repo': { type: 's3' } } });
+        }
+        return Promise.resolve({ ok: true, response: {} });
+      });
+      render(
+        <MemoryRouter>
+          <DataSourceContext.Provider value={mockDataSourceContext}>
+            <Configuration
+              latencySettings={defaultLatencySettings}
+              cpuSettings={defaultCpuSettings}
+              memorySettings={defaultMemorySettings}
+              groupBySettings={groupBySettings}
+              configInfo={mockConfigInfo}
+              dataRetentionSettings={dataRetentionSettings}
+              remoteExporterSettings={{ enabled: true, repository: 'my-repo', path: 'insights' }}
+              core={mockCoreStart}
+              depsStart={{ navigation: {} }}
+              params={{} as any}
+              dataSourceManagement={dataSourceManagementMock}
+            />
+          </DataSourceContext.Provider>
+        </MemoryRouter>
+      );
+      await waitFor(() => {
+        expect(screen.getByText('Register new')).toBeInTheDocument();
+      });
+    });
+
+    it('should show remote exporter status as Disabled in status panel', () => {
+      renderConfiguration();
+      expect(screen.getByText('Remote Exporter')).toBeInTheDocument();
+    });
+
+    it('should not show Save when remote is enabled but no repository selected', async () => {
+      mockCoreStart.http.get.mockImplementation((url: string) => {
+        if (url === '/api/cat/plugins') {
+          return Promise.resolve({ ok: true, response: [{ component: 'repository-s3' }] });
+        }
+        return Promise.resolve({ ok: true, response: {} });
+      });
+      renderConfiguration();
+      fireEvent.click(getRemoteToggle());
+      await waitFor(() => {
+        expect(screen.getByText('Register new')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('Save')).not.toBeInTheDocument();
+    });
+
+    it('should open register repository flyout when Register new is clicked', async () => {
+      mockCoreStart.http.get.mockImplementation((url: string) => {
+        if (url === '/api/cat/plugins') {
+          return Promise.resolve({ ok: true, response: [{ component: 'repository-s3' }] });
+        }
+        return Promise.resolve({ ok: true, response: {} });
+      });
+      renderConfiguration();
+      fireEvent.click(getRemoteToggle());
+      await waitFor(() => {
+        expect(screen.getByText('Register new')).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText('Register new'));
+      await waitFor(() => {
+        expect(screen.getByText('Register S3 repository')).toBeInTheDocument();
+      });
+    });
+
+    it('should hide fields when toggle is turned off after being on', async () => {
+      mockCoreStart.http.get.mockImplementation((url: string) => {
+        if (url === '/api/cat/plugins') {
+          return Promise.resolve({ ok: true, response: [{ component: 'repository-s3' }] });
+        }
+        return Promise.resolve({ ok: true, response: {} });
+      });
+      renderConfiguration();
+      fireEvent.click(getRemoteToggle());
+      await waitFor(() => {
+        expect(screen.getByText('Register new')).toBeInTheDocument();
+      });
+      fireEvent.click(getRemoteToggle());
+      expect(screen.queryByText('Register new')).not.toBeInTheDocument();
+    });
+
+    it('should only show S3 type repositories in dropdown', async () => {
+      mockCoreStart.http.get.mockImplementation((url: string) => {
+        if (url === '/api/cat/plugins') {
+          return Promise.resolve({ ok: true, response: [{ component: 'repository-s3' }] });
+        }
+        if (url === '/api/snapshot/repositories') {
+          return Promise.resolve({
+            ok: true,
+            response: {
+              's3-repo': { type: 's3' },
+              'fs-repo': { type: 'fs' },
+              'another-s3': { type: 's3' },
+            },
+          });
+        }
+        return Promise.resolve({ ok: true, response: {} });
+      });
+      renderConfiguration();
+      fireEvent.click(getRemoteToggle());
+      await waitFor(() => {
+        expect(screen.getByText('Register new')).toBeInTheDocument();
+      });
+      // EuiComboBox renders options as data attributes or in dropdown
+      // The repoOptions state should only contain s3 repos
+      expect(screen.queryByText('fs-repo')).not.toBeInTheDocument();
+    });
+
+    it('should reset remote fields on Cancel', async () => {
+      mockCoreStart.http.get.mockImplementation((url: string) => {
+        if (url === '/api/cat/plugins') {
+          return Promise.resolve({ ok: true, response: [{ component: 'repository-s3' }] });
+        }
+        return Promise.resolve({ ok: true, response: {} });
+      });
+      render(
+        <MemoryRouter>
+          <DataSourceContext.Provider value={mockDataSourceContext}>
+            <Configuration
+              latencySettings={defaultLatencySettings}
+              cpuSettings={defaultCpuSettings}
+              memorySettings={defaultMemorySettings}
+              groupBySettings={groupBySettings}
+              configInfo={mockConfigInfo}
+              dataRetentionSettings={dataRetentionSettings}
+              remoteExporterSettings={{ enabled: true, repository: 'my-repo', path: 'insights' }}
+              core={mockCoreStart}
+              depsStart={{ navigation: {} }}
+              params={{} as any}
+              dataSourceManagement={dataSourceManagementMock}
+            />
+          </DataSourceContext.Provider>
+        </MemoryRouter>
+      );
+      await waitFor(() => {
+        expect(screen.getByText('Register new')).toBeInTheDocument();
+      });
+      // Change the path
+      const pathInput = screen.getByDisplayValue('insights');
+      fireEvent.change(pathInput, { target: { value: 'new-path' } });
+      expect(screen.getByDisplayValue('new-path')).toBeInTheDocument();
+      // Click Cancel
+      fireEvent.click(screen.getByText('Cancel'));
+      // Should reset to original value
+      expect(screen.getByDisplayValue('insights')).toBeInTheDocument();
     });
   });
 });

--- a/public/pages/Configuration/Configuration.tsx
+++ b/public/pages/Configuration/Configuration.tsx
@@ -8,13 +8,17 @@ import {
   EuiBottomBar,
   EuiButton,
   EuiButtonEmpty,
+  EuiCallOut,
+  EuiComboBox,
   EuiFieldNumber,
+  EuiFieldText,
   EuiFlexGrid,
   EuiFlexGroup,
   EuiFlexItem,
   EuiForm,
   EuiFormRow,
   EuiHealth,
+  EuiLink,
   EuiPanel,
   EuiSelect,
   EuiSpacer,
@@ -22,6 +26,7 @@ import {
   EuiText,
   EuiTitle,
   EuiDescriptionList,
+  EuiLoadingSpinner,
 } from '@elastic/eui';
 import { useHistory, useLocation } from 'react-router-dom';
 import { AppMountParameters, CoreStart } from 'opensearch-dashboards/public';
@@ -32,6 +37,7 @@ import {
   GroupBySettings,
   DataSourceContext,
   DataRetentionSettings,
+  RemoteExporterSettings,
 } from '../TopNQueries/TopNQueries';
 import {
   METRIC_TYPES_TEXT,
@@ -44,6 +50,7 @@ import {
 import { QueryInsightsDataSourceMenu } from '../../components/DataSourcePicker';
 import { QueryInsightsDashboardsPluginStartDependencies } from '../../types';
 import { validateConfiguration } from './configurationValidation';
+import RegisterRepositoryFlyout from './Components/RegisterRepositoryFlyout';
 
 const Configuration = ({
   latencySettings,
@@ -51,6 +58,7 @@ const Configuration = ({
   memorySettings,
   groupBySettings,
   dataRetentionSettings,
+  remoteExporterSettings,
   configInfo,
   core,
   depsStart,
@@ -62,6 +70,7 @@ const Configuration = ({
   memorySettings: MetricSettings;
   groupBySettings: GroupBySettings;
   dataRetentionSettings: DataRetentionSettings;
+  remoteExporterSettings: RemoteExporterSettings;
   configInfo: any;
   core: CoreStart;
   params: AppMountParameters;
@@ -81,6 +90,58 @@ const Configuration = ({
   const [deleteAfterDays, setDeleteAfterDays] = useState(dataRetentionSettings.deleteAfterDays);
   const [exporterType, setExporterTypeType] = useState(dataRetentionSettings.exporterType);
 
+  const [remoteEnabled, setRemoteEnabled] = useState(remoteExporterSettings.enabled);
+  const [remoteRepository, setRemoteRepository] = useState(remoteExporterSettings.repository);
+  const [remotePath, setRemotePath] = useState(remoteExporterSettings.path);
+  const [isRepoFlyoutOpen, setIsRepoFlyoutOpen] = useState(false);
+  const [repoOptions, setRepoOptions] = useState<Array<{ label: string }>>([]);
+  const [isS3PluginInstalled, setIsS3PluginInstalled] = useState<boolean | null>(null);
+  const [isCheckingPlugin, setIsCheckingPlugin] = useState(false);
+
+  const checkS3Plugin = useCallback(async () => {
+    setIsCheckingPlugin(true);
+    try {
+      const resp = await core.http.get('/api/cat/plugins', {
+        query: { dataSourceId: dataSource?.id || '' },
+      });
+      if (resp.ok && Array.isArray(resp.response)) {
+        const found = resp.response.some(
+          (p: { component: string }) => p.component === 'repository-s3'
+        );
+        setIsS3PluginInstalled(found);
+      }
+    } catch (error) {
+      console.error('Failed to check for repository-s3 plugin:', error);
+      // On failure, assume plugin is installed so the user isn't stuck
+      setIsS3PluginInstalled(true);
+    } finally {
+      setIsCheckingPlugin(false);
+    }
+  }, [core.http, dataSource]);
+
+  const fetchRepositories = useCallback(async () => {
+    try {
+      const resp = await core.http.get('/api/snapshot/repositories', {
+        query: { dataSourceId: dataSource?.id || '' },
+      });
+      if (resp.ok && resp.response) {
+        const names = Object.keys(resp.response)
+          .filter((name) => resp.response[name].type === 's3')
+          .map((name) => ({ label: name }));
+        setRepoOptions(names);
+      }
+    } catch (error) {
+      console.error('Failed to fetch snapshot repositories:', error);
+    }
+  }, [core.http, dataSource]);
+
+  useEffect(() => {
+    fetchRepositories();
+    if (remoteExporterSettings.enabled) {
+      checkS3Plugin();
+    }
+  }, [fetchRepositories, checkS3Plugin, remoteExporterSettings.enabled]);
+
   const [metricSettingsMap, setMetricSettingsMap] = useState({
     latency: latencySettings,
     cpu: cpuSettings,
@@ -93,6 +154,10 @@ const Configuration = ({
 
   const [dataRetentionSettingMap, setDataRetentionSettingMap] = useState({
     dataRetention: dataRetentionSettings,
+  });
+
+  const [remoteExporterSettingMap, setRemoteExporterSettingMap] = useState({
+    remoteExporter: remoteExporterSettings,
   });
 
   useEffect(() => {
@@ -110,7 +175,10 @@ const Configuration = ({
     setTime(currMetric.currTimeUnit);
     setIsEnabled(currMetric.isEnabled);
     // setExporterTypeType(currMetric.exporterType);
-  }, [metric, metricSettingsMap]);
+    setRemoteEnabled(remoteExporterSettingMap.remoteExporter.enabled);
+    setRemoteRepository(remoteExporterSettingMap.remoteExporter.repository);
+    setRemotePath(remoteExporterSettingMap.remoteExporter.path);
+  }, [metric, metricSettingsMap, remoteExporterSettingMap]);
 
   useEffect(() => {
     newOrReset();
@@ -130,6 +198,15 @@ const Configuration = ({
     setDeleteAfterDays(dataRetentionSettings.deleteAfterDays);
     setExporterTypeType(dataRetentionSettings.exporterType);
   }, [dataRetentionSettings]);
+
+  useEffect(() => {
+    setRemoteExporterSettingMap({
+      remoteExporter: remoteExporterSettings,
+    });
+    setRemoteEnabled(remoteExporterSettings.enabled);
+    setRemoteRepository(remoteExporterSettings.repository);
+    setRemotePath(remoteExporterSettings.path);
+  }, [remoteExporterSettings]);
 
   useEffect(() => {
     core.chrome.setBreadcrumbs([
@@ -178,6 +255,18 @@ const Configuration = ({
     setDeleteAfterDays(e.target.value);
   };
 
+  const onRemoteEnabledChange = (e: any) => {
+    const enabling = e.target.checked;
+    setRemoteEnabled(enabling);
+    if (enabling && isS3PluginInstalled === null) {
+      checkS3Plugin();
+    }
+  };
+
+  const onRemotePathChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setRemotePath(e.target.value);
+  };
+
   const MinutesBox = () => (
     <EuiSelect
       id="minutes"
@@ -210,9 +299,22 @@ const Configuration = ({
     time !== metricSettingsMap[metric].currTimeUnit ||
     groupBy !== groupBySettingMap.groupBy.groupBy ||
     exporterType !== dataRetentionSettingMap.dataRetention.exporterType ||
-    deleteAfterDays !== dataRetentionSettingMap.dataRetention.deleteAfterDays;
+    deleteAfterDays !== dataRetentionSettingMap.dataRetention.deleteAfterDays ||
+    remoteEnabled !== remoteExporterSettingMap.remoteExporter.enabled ||
+    remoteRepository !== remoteExporterSettingMap.remoteExporter.repository ||
+    remotePath !== remoteExporterSettingMap.remoteExporter.path;
 
-  const isValid = validateConfiguration(topNSize, windowSize, time, deleteAfterDays, exporterType);
+  const isValid =
+    validateConfiguration(
+      topNSize,
+      windowSize,
+      time,
+      deleteAfterDays,
+      exporterType,
+      remoteEnabled,
+      remoteRepository
+    ) &&
+    (!remoteEnabled || isS3PluginInstalled !== false);
 
   const formRowPadding = { padding: '0px 0px 20px' };
   const enabledSymb = <EuiHealth color="primary">Enabled</EuiHealth>;
@@ -464,7 +566,7 @@ const Configuration = ({
             <EuiForm>
               <EuiFlexItem>
                 <EuiTitle size="s">
-                  <h2>Query Insights export and data retention settings</h2>
+                  <h2>Export and data retention settings</h2>
                 </EuiTitle>
               </EuiFlexItem>
               <EuiFlexItem>
@@ -534,7 +636,7 @@ const Configuration = ({
           <EuiPanel paddingSize="m" grow={false}>
             <EuiFlexItem>
               <EuiTitle size="s">
-                <h2>Statuses for data retention</h2>
+                <h2>Statuses for export and retention</h2>
               </EuiTitle>
             </EuiFlexItem>
             <EuiFlexItem>
@@ -545,6 +647,192 @@ const Configuration = ({
                 <EuiFlexItem>
                   <EuiSpacer size="xs" />
                   {exporterType === EXPORTER_TYPE.localIndex ? enabledSymb : disabledSymb}
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiFlexItem>
+          </EuiPanel>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiFlexGroup>
+        <EuiFlexItem grow={6}>
+          <EuiPanel paddingSize="m">
+            <EuiForm>
+              <EuiFlexItem>
+                <EuiTitle size="s">
+                  <h2>Remote repository exporter settings</h2>
+                </EuiTitle>
+                <EuiSpacer size="xs" />
+                <EuiText size="xs" color="subdued">
+                  Export top N query insights data to a remote S3 repository for cheaper, long-term
+                  storage. Unlike the local index exporter, Query Insights does not read from remote
+                  repository data. Data retention is managed by the bucket configuration, not
+                  OpenSearch.
+                </EuiText>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiFlexGrid columns={2} gutterSize="s" style={{ padding: '15px 0px' }}>
+                  <EuiFlexItem>
+                    <EuiDescriptionList
+                      compressed={true}
+                      listItems={[
+                        {
+                          title: <h3>Enabled</h3>,
+                          description: 'Enable or disable the remote repository exporter.',
+                        },
+                      ]}
+                    />
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                    <EuiFormRow style={formRowPadding}>
+                      <EuiFlexItem>
+                        <EuiSpacer size="s" />
+                        <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+                          <EuiFlexItem grow={false}>
+                            <EuiSwitch
+                              label=""
+                              checked={remoteEnabled}
+                              onChange={onRemoteEnabledChange}
+                              data-test-subj="remote-exporter-toggle"
+                            />
+                          </EuiFlexItem>
+                          {isCheckingPlugin && (
+                            <EuiFlexItem grow={false}>
+                              <EuiLoadingSpinner size="m" />
+                            </EuiFlexItem>
+                          )}
+                        </EuiFlexGroup>
+                      </EuiFlexItem>
+                    </EuiFormRow>
+                  </EuiFlexItem>
+                </EuiFlexGrid>
+              </EuiFlexItem>
+              {remoteEnabled && isS3PluginInstalled === false && (
+                <EuiFlexItem>
+                  <EuiCallOut
+                    title="The repository-s3 plugin is not installed"
+                    color="danger"
+                    iconType="alert"
+                    size="s"
+                  >
+                    <EuiText size="xs">
+                      <p>
+                        The remote exporter requires the{' '}
+                        <EuiLink
+                          href="https://opensearch.org/docs/latest/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore/#amazon-s3"
+                          target="_blank"
+                          external
+                        >
+                          repository-s3 plugin
+                        </EuiLink>
+                        . Follow the setup guide to install the plugin, configure AWS credentials,
+                        and restart the cluster.
+                      </p>
+                    </EuiText>
+                  </EuiCallOut>
+                </EuiFlexItem>
+              )}
+              {remoteEnabled && isS3PluginInstalled === true && (
+                <EuiFlexItem>
+                  <EuiFlexGrid columns={2} gutterSize="s" style={{ padding: '0px 0px 15px' }}>
+                    <EuiFlexItem>
+                      <EuiDescriptionList
+                        compressed={true}
+                        listItems={[
+                          {
+                            title: <h3>Repository</h3>,
+                            description:
+                              'The name of the registered snapshot repository to use for exporting data.',
+                          },
+                        ]}
+                      />
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                      <EuiFormRow
+                        label="exporter.remote.repository"
+                        helpText="Select an existing repository or register a new one."
+                        style={formRowPadding}
+                        isInvalid={remoteEnabled && remoteRepository.trim() === ''}
+                        error={
+                          remoteEnabled && remoteRepository.trim() === ''
+                            ? 'Repository name is required when remote export is enabled.'
+                            : undefined
+                        }
+                      >
+                        <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+                          <EuiFlexItem>
+                            <EuiComboBox
+                              placeholder={
+                                repoOptions.length === 0
+                                  ? 'No S3 repositories registered'
+                                  : 'Select a registered S3 repository'
+                              }
+                              singleSelection={{ asPlainText: true }}
+                              options={repoOptions}
+                              isLoading={isCheckingPlugin}
+                              selectedOptions={
+                                remoteRepository ? [{ label: remoteRepository }] : []
+                              }
+                              onChange={(selected) => {
+                                setRemoteRepository(selected.length > 0 ? selected[0].label : '');
+                              }}
+                              data-test-subj="remote-exporter-repository"
+                            />
+                          </EuiFlexItem>
+                          <EuiFlexItem grow={false}>
+                            <EuiButton
+                              size="s"
+                              onClick={() => setIsRepoFlyoutOpen(true)}
+                              data-test-subj="register-repo-button"
+                            >
+                              Register new
+                            </EuiButton>
+                          </EuiFlexItem>
+                        </EuiFlexGroup>
+                      </EuiFormRow>
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                      <EuiDescriptionList
+                        compressed={true}
+                        listItems={[
+                          {
+                            title: <h3>Path</h3>,
+                            description:
+                              'The base path within the repository for organizing exported files.',
+                          },
+                        ]}
+                      />
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                      <EuiFormRow label="exporter.remote.path" style={formRowPadding}>
+                        <EuiFieldText
+                          placeholder="query-insights"
+                          value={remotePath}
+                          onChange={onRemotePathChange}
+                          data-test-subj="remote-exporter-path"
+                        />
+                      </EuiFormRow>
+                    </EuiFlexItem>
+                  </EuiFlexGrid>
+                </EuiFlexItem>
+              )}
+            </EuiForm>
+          </EuiPanel>
+        </EuiFlexItem>
+        <EuiFlexItem grow={2}>
+          <EuiPanel paddingSize="m" grow={false}>
+            <EuiFlexItem>
+              <EuiTitle size="s">
+                <h2>Statuses for remote exporter</h2>
+              </EuiTitle>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFlexGroup>
+                <EuiFlexItem>
+                  <EuiText size="s">Remote Exporter</EuiText>
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <EuiSpacer size="xs" />
+                  {remoteExporterSettings.enabled ? enabledSymb : disabledSymb}
                 </EuiFlexItem>
               </EuiFlexGroup>
             </EuiFlexItem>
@@ -576,7 +864,10 @@ const Configuration = ({
                     time,
                     exporterType,
                     groupBy,
-                    deleteAfterDays
+                    deleteAfterDays,
+                    remoteEnabled,
+                    remoteRepository,
+                    remotePath
                   );
                   return history.push(QUERY_INSIGHTS);
                 }}
@@ -587,6 +878,17 @@ const Configuration = ({
           </EuiFlexGroup>
         </EuiBottomBar>
       ) : null}
+      {isRepoFlyoutOpen && (
+        <RegisterRepositoryFlyout
+          core={core}
+          dataSourceId={dataSource?.id}
+          onClose={() => setIsRepoFlyoutOpen(false)}
+          onSuccess={(repoName) => {
+            setRemoteRepository(repoName);
+            fetchRepositories();
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/public/pages/Configuration/__snapshots__/Configuration.test.tsx.snap
+++ b/public/pages/Configuration/__snapshots__/Configuration.test.tsx.snap
@@ -834,7 +834,7 @@ exports[`Configuration Component renders with default settings: should match def
               <h2
                 class="euiTitle euiTitle--small"
               >
-                Query Insights export and data retention settings
+                Export and data retention settings
               </h2>
             </div>
             <div
@@ -998,7 +998,7 @@ exports[`Configuration Component renders with default settings: should match def
             <h2
               class="euiTitle euiTitle--small"
             >
-              Statuses for data retention
+              Statuses for export and retention
             </h2>
           </div>
           <div
@@ -1050,6 +1050,231 @@ exports[`Configuration Component renders with default settings: should match def
                       class="euiFlexItem euiFlexItem--flexGrowZero"
                     >
                       Enabled
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+    >
+      <div
+        class="euiFlexItem euiFlexItem--flexGrow6"
+      >
+        <div
+          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+        >
+          <div
+            class="euiForm"
+          >
+            <div
+              class="euiFlexItem"
+            >
+              <h2
+                class="euiTitle euiTitle--small"
+              >
+                Remote repository exporter settings
+              </h2>
+              <div
+                class="euiSpacer euiSpacer--xs"
+              />
+              <div
+                class="euiText euiText--extraSmall"
+              >
+                <div
+                  class="euiTextColor euiTextColor--subdued"
+                >
+                  Export top N query insights data to a remote S3 repository for cheaper, long-term storage. Unlike the local index exporter, Query Insights does not read from remote repository data. Data retention is managed by the bucket configuration, not OpenSearch.
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFlexGrid euiFlexGrid--gutterSmall euiFlexGrid--halves euiFlexGrid--responsive"
+                style="padding: 15px 0px;"
+              >
+                <div
+                  class="euiFlexItem"
+                >
+                  <dl
+                    class="euiDescriptionList euiDescriptionList--row euiDescriptionList--compressed"
+                  >
+                    <dt
+                      class="euiDescriptionList__title"
+                    >
+                      <h3>
+                        Enabled
+                      </h3>
+                    </dt>
+                    <dd
+                      class="euiDescriptionList__description"
+                    >
+                      Enable or disable the remote repository exporter.
+                    </dd>
+                  </dl>
+                </div>
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiFormRow"
+                    id="random_html_id-row"
+                    style="padding: 0px 0px 20px;"
+                  >
+                    <div
+                      class="euiFormRow__fieldWrapper"
+                    >
+                      <div
+                        class="euiFlexItem"
+                        id="random_html_id"
+                      >
+                        <div
+                          class="euiSpacer euiSpacer--s"
+                        />
+                        <div
+                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                        >
+                          <div
+                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              class="euiSwitch euiSwitch--primary"
+                            >
+                              <button
+                                aria-checked="false"
+                                aria-labelledby="random_html_id"
+                                class="euiSwitch__button"
+                                data-test-subj="remote-exporter-toggle"
+                                id="random_html_id"
+                                role="switch"
+                                type="button"
+                              >
+                                <span
+                                  class="euiSwitch__body"
+                                >
+                                  <span
+                                    class="euiSwitch__thumb"
+                                  />
+                                  <span
+                                    class="euiSwitch__track"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="euiIcon euiIcon--medium euiIcon-isLoading euiSwitch__icon"
+                                      focusable="false"
+                                      height="16"
+                                      role="img"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                      />
+                                    </svg>
+                                    <svg
+                                      aria-hidden="true"
+                                      class="euiIcon euiIcon--medium euiIcon-isLoading euiSwitch__icon euiSwitch__icon--checked"
+                                      focusable="false"
+                                      height="16"
+                                      role="img"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </button>
+                              <span
+                                class="euiSwitch__label"
+                                id="random_html_id"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiFlexItem euiFlexItem--flexGrow2"
+      >
+        <div
+          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPanel--flexGrowZero"
+        >
+          <div
+            class="euiFlexItem"
+          >
+            <h2
+              class="euiTitle euiTitle--small"
+            >
+              Statuses for remote exporter
+            </h2>
+          </div>
+          <div
+            class="euiFlexItem"
+          >
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+            >
+              <div
+                class="euiFlexItem"
+              >
+                <div
+                  class="euiText euiText--small"
+                >
+                  Remote Exporter
+                </div>
+              </div>
+              <div
+                class="euiFlexItem"
+              >
+                <div
+                  class="euiSpacer euiSpacer--xs"
+                />
+                <div
+                  class="euiHealth euiHealth--textSizeS"
+                >
+                  <div
+                    class="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                  >
+                    <div
+                      class="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--medium euiIcon-isLoading"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                        />
+                      </svg>
+                    </div>
+                    <div
+                      class="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      Disabled
                     </div>
                   </div>
                 </div>
@@ -1869,7 +2094,7 @@ exports[`Configuration Component updates state when toggling metrics and enables
               <h2
                 class="euiTitle euiTitle--small"
               >
-                Query Insights export and data retention settings
+                Export and data retention settings
               </h2>
             </div>
             <div
@@ -2034,7 +2259,7 @@ exports[`Configuration Component updates state when toggling metrics and enables
             <h2
               class="euiTitle euiTitle--small"
             >
-              Statuses for data retention
+              Statuses for export and retention
             </h2>
           </div>
           <div
@@ -2088,6 +2313,234 @@ exports[`Configuration Component updates state when toggling metrics and enables
                       class="euiFlexItem euiFlexItem--flexGrowZero"
                     >
                       Enabled
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+    >
+      <div
+        class="euiFlexItem euiFlexItem--flexGrow6"
+      >
+        <div
+          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+        >
+          <div
+            class="euiForm"
+          >
+            <div
+              class="euiFlexItem"
+            >
+              <h2
+                class="euiTitle euiTitle--small"
+              >
+                Remote repository exporter settings
+              </h2>
+              <div
+                class="euiSpacer euiSpacer--xs"
+              />
+              <div
+                class="euiText euiText--extraSmall"
+              >
+                <div
+                  class="euiTextColor euiTextColor--subdued"
+                >
+                  Export top N query insights data to a remote S3 repository for cheaper, long-term storage. Unlike the local index exporter, Query Insights does not read from remote repository data. Data retention is managed by the bucket configuration, not OpenSearch.
+                </div>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiFlexGrid euiFlexGrid--gutterSmall euiFlexGrid--halves euiFlexGrid--responsive"
+                style="padding: 15px 0px;"
+              >
+                <div
+                  class="euiFlexItem"
+                >
+                  <dl
+                    class="euiDescriptionList euiDescriptionList--row euiDescriptionList--compressed"
+                  >
+                    <dt
+                      class="euiDescriptionList__title"
+                    >
+                      <h3>
+                        Enabled
+                      </h3>
+                    </dt>
+                    <dd
+                      class="euiDescriptionList__description"
+                    >
+                      Enable or disable the remote repository exporter.
+                    </dd>
+                  </dl>
+                </div>
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiFormRow"
+                    id="random_html_id-row"
+                    style="padding: 0px 0px 20px;"
+                  >
+                    <div
+                      class="euiFormRow__fieldWrapper"
+                    >
+                      <div
+                        class="euiFlexItem"
+                        id="random_html_id"
+                      >
+                        <div
+                          class="euiSpacer euiSpacer--s"
+                        />
+                        <div
+                          class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                        >
+                          <div
+                            class="euiFlexItem euiFlexItem--flexGrowZero"
+                          >
+                            <div
+                              class="euiSwitch euiSwitch--primary"
+                            >
+                              <button
+                                aria-checked="false"
+                                aria-labelledby="random_html_id"
+                                class="euiSwitch__button"
+                                data-test-subj="remote-exporter-toggle"
+                                id="random_html_id"
+                                role="switch"
+                                type="button"
+                              >
+                                <span
+                                  class="euiSwitch__body"
+                                >
+                                  <span
+                                    class="euiSwitch__thumb"
+                                  />
+                                  <span
+                                    class="euiSwitch__track"
+                                  >
+                                    <svg
+                                      aria-hidden="true"
+                                      class="euiIcon euiIcon--medium euiSwitch__icon"
+                                      focusable="false"
+                                      height="16"
+                                      role="img"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M7.293 8 3.146 3.854a.5.5 0 1 1 .708-.708L8 7.293l4.146-4.147a.5.5 0 0 1 .708.708L8.707 8l4.147 4.146a.5.5 0 0 1-.708.708L8 8.707l-4.146 4.147a.5.5 0 0 1-.708-.708L7.293 8Z"
+                                      />
+                                    </svg>
+                                    <svg
+                                      aria-hidden="true"
+                                      class="euiIcon euiIcon--medium euiSwitch__icon euiSwitch__icon--checked"
+                                      focusable="false"
+                                      height="16"
+                                      role="img"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M6.5 12a.502.502 0 0 1-.354-.146l-4-4a.502.502 0 0 1 .708-.708L6.5 10.793l6.646-6.647a.502.502 0 0 1 .708.708l-7 7A.502.502 0 0 1 6.5 12"
+                                        fill-rule="evenodd"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </button>
+                              <span
+                                class="euiSwitch__label"
+                                id="random_html_id"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="euiFlexItem euiFlexItem--flexGrow2"
+      >
+        <div
+          class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPanel--flexGrowZero"
+        >
+          <div
+            class="euiFlexItem"
+          >
+            <h2
+              class="euiTitle euiTitle--small"
+            >
+              Statuses for remote exporter
+            </h2>
+          </div>
+          <div
+            class="euiFlexItem"
+          >
+            <div
+              class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+            >
+              <div
+                class="euiFlexItem"
+              >
+                <div
+                  class="euiText euiText--small"
+                >
+                  Remote Exporter
+                </div>
+              </div>
+              <div
+                class="euiFlexItem"
+              >
+                <div
+                  class="euiSpacer euiSpacer--xs"
+                />
+                <div
+                  class="euiHealth euiHealth--textSizeS"
+                >
+                  <div
+                    class="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                  >
+                    <div
+                      class="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--medium"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <circle
+                          cx="8"
+                          cy="8"
+                          r="4"
+                        />
+                      </svg>
+                    </div>
+                    <div
+                      class="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      Disabled
                     </div>
                   </div>
                 </div>

--- a/public/pages/Configuration/configurationValidation.ts
+++ b/public/pages/Configuration/configurationValidation.ts
@@ -45,11 +45,16 @@ export const validateConfiguration = (
   windowSize: string,
   timeUnit: string,
   deleteAfterDays: string,
-  exporterType: string
+  exporterType: string,
+  remoteEnabled?: boolean,
+  remoteRepository?: string
 ): boolean => {
+  const isRemoteValid =
+    !remoteEnabled || (remoteRepository !== undefined && remoteRepository.trim() !== '');
   return (
     validateTopNSize(topNSize) &&
     validateWindowSize(windowSize, timeUnit) &&
-    validateDeleteAfterDays(deleteAfterDays, exporterType)
+    validateDeleteAfterDays(deleteAfterDays, exporterType) &&
+    isRemoteValid
   );
 };

--- a/public/pages/TopNQueries/TopNQueries.tsx
+++ b/public/pages/TopNQueries/TopNQueries.tsx
@@ -29,6 +29,9 @@ import {
   DEFAULT_EXPORTER_TYPE,
   DEFAULT_GROUP_BY,
   DEFAULT_METRIC_ENABLED,
+  DEFAULT_REMOTE_EXPORTER_ENABLED,
+  DEFAULT_REMOTE_EXPORTER_PATH,
+  DEFAULT_REMOTE_EXPORTER_REPOSITORY,
   DEFAULT_SHOW_LIVE_QUERIES_ON_ERROR,
   DEFAULT_TIME_UNIT,
   DEFAULT_TOP_N_SIZE,
@@ -64,6 +67,12 @@ export interface GroupBySettings {
 export interface DataRetentionSettings {
   exporterType: string;
   deleteAfterDays: string;
+}
+
+export interface RemoteExporterSettings {
+  enabled: boolean;
+  repository: string;
+  path: string;
 }
 
 export interface DataSourceContextType {
@@ -146,6 +155,12 @@ const TopNQueries = ({
   const [dataRetentionSettings, setDataRetentionSettings] = useState<DataRetentionSettings>({
     deleteAfterDays: '',
     exporterType: EXPORTER_TYPE.none,
+  });
+
+  const [remoteExporterSettings, setRemoteExporterSettings] = useState<RemoteExporterSettings>({
+    enabled: DEFAULT_REMOTE_EXPORTER_ENABLED,
+    repository: DEFAULT_REMOTE_EXPORTER_REPOSITORY,
+    path: DEFAULT_REMOTE_EXPORTER_PATH,
   });
 
   const setMetricSettings = (metricType: string, updates: Partial<MetricSettings>) => {
@@ -300,7 +315,10 @@ const TopNQueries = ({
       newTimeUnit: string = '',
       newExporterType: string = '',
       newGroupBy: string = '',
-      newDeleteAfterDays: string = ''
+      newDeleteAfterDays: string = '',
+      newRemoteEnabled: boolean = false,
+      newRemoteRepository: string = '',
+      newRemotePath: string = ''
     ) => {
       if (get) {
         try {
@@ -369,6 +387,25 @@ const TopNQueries = ({
             DEFAULT_EXPORTER_TYPE
           );
           setDataRetentionSettings({ deleteAfterDays, exporterType });
+
+          const remoteEnabled =
+            persistentSettings?.exporter?.remote?.enabled === 'true' ||
+            transientSettings?.exporter?.remote?.enabled === 'true';
+          const remoteRepository = getMergedStringSettings(
+            persistentSettings?.exporter?.remote?.repository,
+            transientSettings?.exporter?.remote?.repository,
+            DEFAULT_REMOTE_EXPORTER_REPOSITORY
+          );
+          const remotePath = getMergedStringSettings(
+            persistentSettings?.exporter?.remote?.path,
+            transientSettings?.exporter?.remote?.path,
+            DEFAULT_REMOTE_EXPORTER_PATH
+          );
+          setRemoteExporterSettings({
+            enabled: remoteEnabled,
+            repository: remoteRepository,
+            path: remotePath,
+          });
         } catch (error) {
           console.error('Failed to retrieve settings:', error);
         }
@@ -385,6 +422,11 @@ const TopNQueries = ({
             deleteAfterDays: newDeleteAfterDays,
             exporterType: newExporterType,
           });
+          setRemoteExporterSettings({
+            enabled: newRemoteEnabled,
+            repository: newRemoteRepository,
+            path: newRemotePath,
+          });
           const queryParams: Record<string, any> = {
             metric,
             enabled,
@@ -392,6 +434,9 @@ const TopNQueries = ({
             exporterType: newExporterType,
             group_by: newGroupBy,
             delete_after_days: newDeleteAfterDays,
+            remote_enabled: newRemoteEnabled,
+            remote_repository: newRemoteRepository,
+            remote_path: newRemotePath,
             dataSourceId: getDataSourceFromUrl().id,
           };
           if (newTimeUnit === 'MINUTES') {
@@ -536,6 +581,7 @@ const TopNQueries = ({
               memorySettings={memorySettings}
               groupBySettings={groupBySettings}
               dataRetentionSettings={dataRetentionSettings}
+              remoteExporterSettings={remoteExporterSettings}
               configInfo={retrieveConfigInfo}
               core={core}
               depsStart={depsStart}

--- a/server/clusters/queryInsightsPlugin.ts
+++ b/server/clusters/queryInsightsPlugin.ts
@@ -202,4 +202,45 @@ export const QueryInsightsPlugin = function (Client, config, components) {
     },
     method: 'POST',
   });
+
+  queryInsights.createSnapshotRepository = ca({
+    url: {
+      fmt: `/_snapshot/<%=repository%>`,
+      req: {
+        repository: {
+          type: 'string',
+          required: true,
+        },
+      },
+    },
+    method: 'PUT',
+    needBody: true,
+  });
+
+  queryInsights.getSnapshotRepositories = ca({
+    url: {
+      fmt: `/_snapshot/_all`,
+    },
+    method: 'GET',
+  });
+
+  queryInsights.deleteSnapshotRepository = ca({
+    url: {
+      fmt: `/_snapshot/<%=repository%>`,
+      req: {
+        repository: {
+          type: 'string',
+          required: true,
+        },
+      },
+    },
+    method: 'DELETE',
+  });
+
+  queryInsights.getCatPlugins = ca({
+    url: {
+      fmt: `/_cat/plugins?format=json`,
+    },
+    method: 'GET',
+  });
 };

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -283,6 +283,9 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
           group_by: schema.maybe(schema.string({ defaultValue: '' })),
           dataSourceId: schema.maybe(schema.string()),
           delete_after_days: schema.maybe(schema.string({ defaultValue: '' })),
+          remote_enabled: schema.maybe(schema.boolean({ defaultValue: false })),
+          remote_repository: schema.maybe(schema.string({ defaultValue: '' })),
+          remote_path: schema.maybe(schema.string({ defaultValue: '' })),
         }),
       },
     },
@@ -310,6 +313,16 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
             query.exporterType === EXPORTER_TYPE.localIndex
               ? query.exporterType
               : EXPORTER_TYPE.none;
+        }
+        params.body.persistent['search.insights.top_queries.exporter.remote.enabled'] =
+          query.remote_enabled;
+        if (query.remote_repository !== '') {
+          params.body.persistent['search.insights.top_queries.exporter.remote.repository'] =
+            query.remote_repository;
+        }
+        if (query.remote_path !== '') {
+          params.body.persistent['search.insights.top_queries.exporter.remote.path'] =
+            query.remote_path;
         }
         if (!dataSourceEnabled || !request.query?.dataSourceId) {
           const client = context.queryInsights_plugin.queryInsightsClient.asScoped(request)
@@ -534,6 +547,146 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
         return response.customError({
           statusCode: error.statusCode || 500,
           body: { message },
+        });
+      }
+    }
+  );
+
+  router.get(
+    {
+      path: '/api/snapshot/repositories',
+      validate: {
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      try {
+        if (!dataSourceEnabled || !request.query?.dataSourceId) {
+          const client = context.queryInsights_plugin.queryInsightsClient.asScoped(request)
+            .callAsCurrentUser;
+          const res = await client('queryInsights.getSnapshotRepositories');
+          return response.ok({ body: { ok: true, response: res } });
+        } else {
+          const client = context.dataSource.opensearch.legacy.getClient(
+            request.query?.dataSourceId
+          );
+          const res = await client.callAPI('queryInsights.getSnapshotRepositories', {});
+          return response.ok({ body: { ok: true, response: res } });
+        }
+      } catch (error) {
+        console.error('Unable to get snapshot repositories: ', error);
+        return response.ok({ body: { ok: false, response: error.message } });
+      }
+    }
+  );
+
+  router.get(
+    {
+      path: '/api/cat/plugins',
+      validate: {
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      try {
+        if (!dataSourceEnabled || !request.query?.dataSourceId) {
+          const client = context.queryInsights_plugin.queryInsightsClient.asScoped(request)
+            .callAsCurrentUser;
+          const res = await client('queryInsights.getCatPlugins');
+          return response.ok({ body: { ok: true, response: res } });
+        } else {
+          const client = context.dataSource.opensearch.legacy.getClient(
+            request.query?.dataSourceId
+          );
+          const res = await client.callAPI('queryInsights.getCatPlugins', {});
+          return response.ok({ body: { ok: true, response: res } });
+        }
+      } catch (error) {
+        console.error('Unable to get cat plugins: ', error);
+        return response.ok({ body: { ok: false, response: error.message } });
+      }
+    }
+  );
+
+  router.delete(
+    {
+      path: '/api/snapshot/repository/{repository}',
+      validate: {
+        params: schema.object({
+          repository: schema.string(),
+        }),
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      try {
+        const params = { repository: request.params.repository };
+        if (!dataSourceEnabled || !request.query?.dataSourceId) {
+          const client = context.queryInsights_plugin.queryInsightsClient.asScoped(request)
+            .callAsCurrentUser;
+          const res = await client('queryInsights.deleteSnapshotRepository', params);
+          return response.ok({ body: { ok: true, response: res } });
+        } else {
+          const client = context.dataSource.opensearch.legacy.getClient(
+            request.query?.dataSourceId
+          );
+          const res = await client.callAPI('queryInsights.deleteSnapshotRepository', params);
+          return response.ok({ body: { ok: true, response: res } });
+        }
+      } catch (error) {
+        console.error('Unable to delete snapshot repository: ', error);
+        return response.ok({ body: { ok: false, response: error.message } });
+      }
+    }
+  );
+
+  router.put(
+    {
+      path: '/api/snapshot/repository',
+      validate: {
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
+        body: schema.object({
+          repository: schema.string(),
+          type: schema.string(),
+          settings: schema.object({}, { unknowns: 'allow' }),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      try {
+        const { repository, type, settings } = request.body;
+        const params = {
+          repository,
+          body: { type, settings },
+        };
+        if (!dataSourceEnabled || !request.query?.dataSourceId) {
+          const client = context.queryInsights_plugin.queryInsightsClient.asScoped(request)
+            .callAsCurrentUser;
+          const res = await client('queryInsights.createSnapshotRepository', params);
+          return response.ok({ body: { ok: true, response: res } });
+        } else {
+          const client = context.dataSource.opensearch.legacy.getClient(
+            request.query?.dataSourceId
+          );
+          const res = await client.callAPI('queryInsights.createSnapshotRepository', params);
+          return response.ok({ body: { ok: true, response: res } });
+        }
+      } catch (error) {
+        console.error('Unable to create snapshot repository: ', error);
+        const errorBody = error.body || error.meta?.body;
+        return response.ok({
+          body: {
+            ok: false,
+            response: errorBody ? JSON.stringify(errorBody) : error.message,
+          },
         });
       }
     }


### PR DESCRIPTION
### Description
Added remote s3 repository exporter to configuration page: 

Located below other exporters and data retention settings (as it's independent)

<img width="3010" height="1438" alt="image" src="https://github.com/user-attachments/assets/e2fb9889-b15a-4cc5-8227-c064e2ed6eb1" />

Detects and prompts the user to install repository-s3-plugin in the backend if not installed
<img width="3007" height="1442" alt="image" src="https://github.com/user-attachments/assets/504cf661-9f54-438c-b221-1202ce1a0f0f" />

Can register new s3 repositories to be used for remote repository exporter
<img width="1512" height="740" alt="Screenshot 2026-05-05 at 2 47 52 PM" src="https://github.com/user-attachments/assets/89140e2a-b87d-474e-80c1-2cc689a64f95" />

Can be enabled with a chosen valid s3 repository and path within the repo for organizing exported files. 
<img width="3006" height="1434" alt="image" src="https://github.com/user-attachments/assets/0476c486-24b1-43d5-96f4-b786a467a11f" />

### Testing
Ran opensearch clusters:
- Without repository-s3-plugin
- With repository-s3-plugin
Ran dashboards and tested all functions of enabling and registering new repositories and existing repositories with valid and invalid repository registrations. 
Validated using a real s3 repository to confirm that data was exported. 

### Issues Resolved
Closes [#511]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
