### PR TITLE
Fix catch block variable references in index.ts as error is being used

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -41,7 +41,7 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
             },
           });
         }
-      } catch (_error) {
+      } catch (error) {
         console.error('Unable to get top queries: ', error);
         return response.ok({
           body: {
@@ -98,7 +98,7 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
             },
           });
         }
-      } catch (_error) {
+      } catch (error) {
         console.error('Unable to get top queries (latency): ', error);
         return response.ok({
           body: {
@@ -156,7 +156,7 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
             },
           });
         }
-      } catch (_error) {
+      } catch (error) {
         console.error('Unable to get top queries (cpu): ', error);
         return response.ok({
           body: {
@@ -213,7 +213,7 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
             },
           });
         }
-      } catch (_error) {
+      } catch (error) {
         console.error('Unable to get top queries (memory): ', error);
         return response.ok({
           body: {
@@ -258,7 +258,7 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
             },
           });
         }
-      } catch (_error) {
+      } catch (error) {
         console.error('Unable to get top queries: ', error);
         return response.ok({
           body: {
@@ -333,7 +333,7 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
             },
           });
         }
-      } catch (_error) {
+      } catch (error) {
         console.error('Unable to set settings: ', error);
         return response.ok({
           body: {
@@ -388,7 +388,7 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
             response: res,
           },
         });
-      } catch (_error) {
+      } catch (error) {
         console.error('Unable to get live queries: ', error);
         return response.customError({
           statusCode: error.statusCode ?? 500,
@@ -424,7 +424,7 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
         }
 
         return response.ok({ body: { ok: true, res } });
-      } catch (_error) {
+      } catch (error) {
         console.error(error);
         return response.customError({
           statusCode: error.statusCode ?? 500,
@@ -453,7 +453,7 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
             version,
           },
         });
-      } catch (_error) {
+      } catch (error) {
         console.error('Unable to get cluster version: ', error);
         return response.ok({
           body: {
@@ -523,7 +523,7 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
         }
 
         return response.ok({ body: JSON.stringify(result, null, 2) });
-      } catch (_error) {
+      } catch (error) {
         logger.error(`Profiler proxy error: ${error.message}`);
         // Extract meaningful message from OpenSearch/DataSource error
         const cause = error.body || error.meta?.body;


### PR DESCRIPTION
### Description
The typescript 6.0.2 migration renamed the `catch(error)` to `catch(_error)` as the standard was to prefix unused catch variables with `_` to fix `@typescript-eslint/no-unused-vars errors` but since these `error` variables are actively being used in every catch block, we want to revert back. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
