### PR TITLE
Remove caret range for echarts-for-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@babel/runtime": "^7.26.10",
     "@babel/runtime-corejs3": "^7.22.9",
     "echarts": "^6.0.0",
-    "echarts-for-react": "^3.0.2",
+    "echarts-for-react": "3.0.6",
     "filesize": "^10.1.6",
     "form-data": "4.0.4",
     "luxon": "^3.2.1",


### PR DESCRIPTION
### Description
Remove caret range for echarts-for-react to prevent future risk of compromised packages. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
