### PR TITLE
Add WLM workload group settings UI

### DIFF
--- a/cypress/e2e/wlm-no-security/7_WLM_details.cy.js
+++ b/cypress/e2e/wlm-no-security/7_WLM_details.cy.js
@@ -131,6 +131,94 @@ describe('WLM Details Page', () => {
     });
   });
 
+  it('persists a group setting via PUT and reflects it after reload', () => {
+    cy.intercept('PUT', '**/api/_wlm/workload_group/*').as('saveGroup');
+
+    cy.get('[data-testid="wlm-tab-settings"]').click();
+
+    cy.get('[data-testid="wlm-setting-toggle-search.max_buckets"]').click();
+    cy.get('[data-testid="wlm-setting-input-search.max_buckets"]').clear().type('5000');
+
+    cy.contains('button', /^Apply Changes$/)
+      .should('not.be.disabled')
+      .click();
+
+    cy.wait('@saveGroup')
+      .its('request.body.settings')
+      .should('deep.equal', { 'search.max_buckets': 5000 });
+
+    cy.reload();
+    cy.get('[data-testid="wlm-tab-settings"]').click();
+    cy.get('[data-testid="wlm-setting-input-search.max_buckets"]').should('have.value', '5000');
+  });
+
+  it('toggling off a previously-set key sends null', () => {
+    cy.intercept('PUT', '**/api/_wlm/workload_group/*').as('saveGroupRemove');
+
+    cy.get('[data-testid="wlm-tab-settings"]').click();
+    cy.get('[data-testid="wlm-setting-toggle-search.max_buckets"]').click();
+
+    cy.contains('button', /^Apply Changes$/)
+      .should('not.be.disabled')
+      .click();
+
+    cy.wait('@saveGroupRemove')
+      .its('request.body.settings')
+      .should('deep.equal', { 'search.max_buckets': null });
+  });
+
+  it('persists override_request_values and clears it on toggle off', () => {
+    cy.intercept('PUT', '**/api/_wlm/workload_group/*').as('saveOverride');
+
+    cy.get('[data-testid="wlm-tab-settings"]').click();
+    cy.get('[data-testid="wlm-setting-toggle-override_request_values"]').click();
+
+    cy.contains('button', /^Apply Changes$/)
+      .should('not.be.disabled')
+      .click();
+
+    cy.wait('@saveOverride')
+      .its('request.body.settings')
+      .should('deep.equal', { override_request_values: true });
+
+    cy.intercept('PUT', '**/api/_wlm/workload_group/*').as('saveOverrideRemove');
+    cy.get('[data-testid="wlm-setting-toggle-override_request_values"]').click();
+
+    cy.contains('button', /^Apply Changes$/)
+      .should('not.be.disabled')
+      .click();
+
+    cy.wait('@saveOverrideRemove')
+      .its('request.body.settings')
+      .should('deep.equal', { override_request_values: null });
+  });
+
+  it('keeps Apply Changes disabled while a settings row has an invalid value', () => {
+    cy.get('[data-testid="wlm-tab-settings"]').click();
+
+    cy.get('[data-testid="wlm-setting-toggle-search.batched_reduce_size"]').click();
+    cy.get('[data-testid="wlm-setting-input-search.batched_reduce_size"]').clear().type('1');
+
+    cy.contains('button', /^Apply Changes$/).should('be.disabled');
+
+    cy.get('[data-testid="wlm-setting-input-search.batched_reduce_size"]').clear().type('512');
+    cy.contains('button', /^Apply Changes$/).should('not.be.disabled');
+  });
+
+  it('omits the settings field entirely when no toggle is on', () => {
+    cy.intercept('PUT', '**/api/_wlm/workload_group/*').as('saveNoSettings');
+
+    cy.get('[data-testid="wlm-tab-settings"]').click();
+
+    // touch resiliency to enable the Apply Changes button without altering settings
+    cy.contains('label', 'Enforced').click();
+    cy.contains('button', /^Apply Changes$/)
+      .should('not.be.disabled')
+      .click();
+
+    cy.wait('@saveNoSettings').its('request.body.settings').should('be.undefined');
+  });
+
   it('should delete the workload group successfully', () => {
     cy.contains('Delete').click();
     cy.get('input[placeholder="delete"]').type('delete');

--- a/cypress/e2e/wlm-no-security/8_WLM_create.cy.js
+++ b/cypress/e2e/wlm-no-security/8_WLM_create.cy.js
@@ -105,4 +105,22 @@ describe('WLM Create Page', () => {
     cy.get('button').contains('Cancel').click();
     cy.url().should('include', '/workloadManagement');
   });
+
+  it('includes group settings in the create PUT body when configured', () => {
+    const groupName = `wlm_gs_${Date.now()}`;
+    cy.intercept('PUT', '/api/_wlm/workload_group').as('createGroup');
+
+    cy.get('[data-testid="name-input"]').type(groupName);
+    cy.contains('Soft').click();
+    cy.get('[data-testid="memory-threshold-input"]').clear().type('1');
+
+    cy.get('[data-testid="wlm-setting-toggle-search.cancel_after_time_interval"]').click();
+    cy.get('[data-testid="wlm-setting-input-search.cancel_after_time_interval"]').type('1m');
+
+    cy.get('button').contains('Create workload group').click();
+
+    cy.wait('@createGroup')
+      .its('request.body.settings')
+      .should('deep.equal', { 'search.cancel_after_time_interval': '1m' });
+  });
 });

--- a/cypress/e2e/wlm/7_WLM_details.cy.js
+++ b/cypress/e2e/wlm/7_WLM_details.cy.js
@@ -157,6 +157,94 @@ describe('WLM Details Page', () => {
     });
   });
 
+  it('persists a group setting via PUT and reflects it after reload', () => {
+    cy.intercept('PUT', '**/api/_wlm/workload_group/*').as('saveGroup');
+
+    cy.get('[data-testid="wlm-tab-settings"]').click();
+
+    cy.get('[data-testid="wlm-setting-toggle-search.max_buckets"]').click();
+    cy.get('[data-testid="wlm-setting-input-search.max_buckets"]').clear().type('5000');
+
+    cy.contains('button', /^Apply Changes$/)
+      .should('not.be.disabled')
+      .click();
+
+    cy.wait('@saveGroup')
+      .its('request.body.settings')
+      .should('deep.equal', { 'search.max_buckets': 5000 });
+
+    cy.reload();
+    cy.get('[data-testid="wlm-tab-settings"]').click();
+    cy.get('[data-testid="wlm-setting-input-search.max_buckets"]').should('have.value', '5000');
+  });
+
+  it('toggling off a previously-set key sends null', () => {
+    cy.intercept('PUT', '**/api/_wlm/workload_group/*').as('saveGroupRemove');
+
+    cy.get('[data-testid="wlm-tab-settings"]').click();
+    cy.get('[data-testid="wlm-setting-toggle-search.max_buckets"]').click();
+
+    cy.contains('button', /^Apply Changes$/)
+      .should('not.be.disabled')
+      .click();
+
+    cy.wait('@saveGroupRemove')
+      .its('request.body.settings')
+      .should('deep.equal', { 'search.max_buckets': null });
+  });
+
+  it('persists override_request_values and clears it on toggle off', () => {
+    cy.intercept('PUT', '**/api/_wlm/workload_group/*').as('saveOverride');
+
+    cy.get('[data-testid="wlm-tab-settings"]').click();
+    cy.get('[data-testid="wlm-setting-toggle-override_request_values"]').click();
+
+    cy.contains('button', /^Apply Changes$/)
+      .should('not.be.disabled')
+      .click();
+
+    cy.wait('@saveOverride')
+      .its('request.body.settings')
+      .should('deep.equal', { override_request_values: true });
+
+    cy.intercept('PUT', '**/api/_wlm/workload_group/*').as('saveOverrideRemove');
+    cy.get('[data-testid="wlm-setting-toggle-override_request_values"]').click();
+
+    cy.contains('button', /^Apply Changes$/)
+      .should('not.be.disabled')
+      .click();
+
+    cy.wait('@saveOverrideRemove')
+      .its('request.body.settings')
+      .should('deep.equal', { override_request_values: null });
+  });
+
+  it('keeps Apply Changes disabled while a settings row has an invalid value', () => {
+    cy.get('[data-testid="wlm-tab-settings"]').click();
+
+    cy.get('[data-testid="wlm-setting-toggle-search.batched_reduce_size"]').click();
+    cy.get('[data-testid="wlm-setting-input-search.batched_reduce_size"]').clear().type('1');
+
+    cy.contains('button', /^Apply Changes$/).should('be.disabled');
+
+    cy.get('[data-testid="wlm-setting-input-search.batched_reduce_size"]').clear().type('512');
+    cy.contains('button', /^Apply Changes$/).should('not.be.disabled');
+  });
+
+  it('omits the settings field entirely when no toggle is on', () => {
+    cy.intercept('PUT', '**/api/_wlm/workload_group/*').as('saveNoSettings');
+
+    cy.get('[data-testid="wlm-tab-settings"]').click();
+
+    // touch resiliency to enable the Apply Changes button without altering settings
+    cy.contains('label', 'Enforced').click();
+    cy.contains('button', /^Apply Changes$/)
+      .should('not.be.disabled')
+      .click();
+
+    cy.wait('@saveNoSettings').its('request.body.settings').should('be.undefined');
+  });
+
   it('should delete the workload group successfully', () => {
     cy.contains('Delete').click();
     cy.get('input[placeholder="delete"]').type('delete');

--- a/cypress/e2e/wlm/8_WLM_create.cy.js
+++ b/cypress/e2e/wlm/8_WLM_create.cy.js
@@ -210,4 +210,22 @@ describe('WLM Create Page', () => {
     cy.get('button').contains('Cancel').click();
     cy.url().should('include', '/workloadManagement');
   });
+
+  it('includes group settings in the create PUT body when configured', () => {
+    const groupName = `wlm_gs_${Date.now()}`;
+    cy.intercept('PUT', '/api/_wlm/workload_group').as('createGroup');
+
+    cy.get('[data-testid="name-input"]').type(groupName);
+    cy.contains('Soft').click();
+    cy.get('[data-testid="memory-threshold-input"]').clear().type('1');
+
+    cy.get('[data-testid="wlm-setting-toggle-search.cancel_after_time_interval"]').click();
+    cy.get('[data-testid="wlm-setting-input-search.cancel_after_time_interval"]').type('1m');
+
+    cy.get('button').contains('Create workload group').click();
+
+    cy.wait('@createGroup')
+      .its('request.body.settings')
+      .should('deep.equal', { 'search.cancel_after_time_interval': '1m' });
+  });
 });

--- a/public/pages/WorkloadManagement/WLMCreate/WLMCreate.test.tsx
+++ b/public/pages/WorkloadManagement/WLMCreate/WLMCreate.test.tsx
@@ -617,3 +617,93 @@ describe('WLMCreate – rollback and created-rule cleanup', () => {
     });
   });
 });
+
+describe('WLMCreate – group settings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDataSourceManagement.ui.getDataSourceMenu.mockReturnValue(MockDataSourceMenu);
+  });
+
+  const renderWithVersion = (version: string) => {
+    coreMock.savedObjects.client.get = jest
+      .fn()
+      .mockResolvedValue({ attributes: { dataSourceVersion: version } });
+    const ds = { id: 'ds-x', name: 'ds-x', dataSourceVersion: version } as any;
+    return render(
+      <MemoryRouter>
+        <DataSourceContext.Provider value={{ dataSource: ds, setDataSource: jest.fn() }}>
+          <WLMCreate
+            core={coreMock as any}
+            depsStart={depsMock as any}
+            params={mockParams}
+            dataSourceManagement={mockDataSourceManagement}
+          />
+        </DataSourceContext.Provider>
+      </MemoryRouter>
+    );
+  };
+
+  it('hides the group settings panel on a < 3.7 cluster', async () => {
+    renderWithVersion('3.6.0');
+    await waitFor(() => expect(screen.getByTestId('name-input')).toBeInTheDocument());
+    expect(screen.queryByTestId('wlm-setting-toggle-search.max_buckets')).not.toBeInTheDocument();
+  });
+
+  it('shows the group settings panel on a >= 3.7 cluster', async () => {
+    renderWithVersion('3.7.0');
+    await waitFor(() =>
+      expect(screen.getByTestId('wlm-setting-toggle-search.max_buckets')).toBeInTheDocument()
+    );
+  });
+
+  it('includes the settings field in the create PUT body when toggled', async () => {
+    coreMock.http.put.mockResolvedValueOnce({ _id: 'g-1', name: 'g-1' });
+    renderWithVersion('3.7.0');
+    await waitFor(() =>
+      expect(screen.getByTestId('wlm-setting-toggle-search.max_buckets')).toBeInTheDocument()
+    );
+
+    await userEvent.type(screen.getByTestId('name-input'), 'g-1');
+    fireEvent.change(screen.getByTestId('cpu-threshold-input'), { target: { value: '50' } });
+    await userEvent.click(screen.getByLabelText(/Soft/i));
+
+    fireEvent.click(screen.getByTestId('wlm-setting-toggle-search.max_buckets'));
+    fireEvent.change(screen.getByTestId('wlm-setting-input-search.max_buckets'), {
+      target: { value: '5000' },
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /create workload group/i }));
+
+    await waitFor(() => {
+      const createCall = coreMock.http.put.mock.calls.find(
+        ([url]: [string]) => url === '/api/_wlm/workload_group'
+      );
+      expect(createCall).toBeDefined();
+      const sentBody = JSON.parse(createCall[1].body);
+      expect(sentBody.settings).toEqual({ 'search.max_buckets': 5000 });
+    });
+  });
+
+  it('omits settings from the body when no toggle is set', async () => {
+    coreMock.http.put.mockResolvedValueOnce({ _id: 'g-2', name: 'g-2' });
+    renderWithVersion('3.7.0');
+    await waitFor(() =>
+      expect(screen.getByTestId('wlm-setting-toggle-search.max_buckets')).toBeInTheDocument()
+    );
+
+    await userEvent.type(screen.getByTestId('name-input'), 'g-2');
+    fireEvent.change(screen.getByTestId('cpu-threshold-input'), { target: { value: '50' } });
+    await userEvent.click(screen.getByLabelText(/Soft/i));
+
+    await userEvent.click(screen.getByRole('button', { name: /create workload group/i }));
+
+    await waitFor(() => {
+      const createCall = coreMock.http.put.mock.calls.find(
+        ([url]: [string]) => url === '/api/_wlm/workload_group'
+      );
+      expect(createCall).toBeDefined();
+      const sentBody = JSON.parse(createCall[1].body);
+      expect(sentBody.settings).toBeUndefined();
+    });
+  });
+});

--- a/public/pages/WorkloadManagement/WLMCreate/WLMCreate.tsx
+++ b/public/pages/WorkloadManagement/WLMCreate/WLMCreate.tsx
@@ -29,8 +29,16 @@ import { getDataSourceEnabledUrl } from '../../../utils/datasource-utils';
 import {
   resolveDataSourceVersion,
   isSecurityAttributesSupported,
+  isWlmGroupSettingsSupported,
 } from '../../../utils/datasource-utils';
 import { AutoSizeTextArea } from '../auto_size_text_area';
+import { WLMSettingsForm } from '../WLMSettings/wlm_settings_form';
+import {
+  WlmGroupSettingsDraft,
+  emptyDraft,
+  hasInvalidSettings,
+  serializeDraft,
+} from '../WLMSettings/wlm_settings_types';
 
 interface Rule {
   index: string;
@@ -69,13 +77,16 @@ export const WLMCreate = ({
   const [dsVersion, setDsVersion] = useState<string | undefined>();
   const dataSourceEnabled = !!depsStart?.dataSource?.dataSourceEnabled;
   const showSecurity = !dataSourceEnabled || isSecurityAttributesSupported(dsVersion);
+  const showGroupSettings = !dataSourceEnabled || isWlmGroupSettingsSupported(dsVersion);
+  const [settingsDraft, setSettingsDraft] = useState<WlmGroupSettingsDraft>(emptyDraft());
 
   const isFormValid =
     name.trim() !== '' &&
     resiliencyMode !== undefined &&
     ((cpuThreshold != null && cpuThreshold > 0 && cpuThreshold <= 100) ||
       (memThreshold != null && memThreshold > 0 && memThreshold <= 100)) &&
-    indexErrors.every((error) => error === null);
+    indexErrors.every((error) => error === null) &&
+    !hasInvalidSettings(settingsDraft);
 
   useEffect(() => {
     core.chrome.setBreadcrumbs([
@@ -137,6 +148,11 @@ export const WLMCreate = ({
 
       if (Object.keys(resourceLimits).length > 0) {
         body.resource_limits = resourceLimits;
+      }
+
+      const settingsPayload = serializeDraft(settingsDraft);
+      if (settingsPayload !== undefined) {
+        body.settings = settingsPayload;
       }
 
       const res = await core.http.put('/api/_wlm/workload_group', {
@@ -551,6 +567,32 @@ export const WLMCreate = ({
           </>
         </EuiFormRow>
       </EuiPanel>
+
+      {showGroupSettings && (
+        <>
+          <EuiSpacer size="l" />
+          <EuiPanel paddingSize="l">
+            <EuiTitle size="m">
+              <h2>Group settings</h2>
+            </EuiTitle>
+            <EuiText size="xs" color="subdued">
+              <p>
+                Optional per-group overrides applied to every request routed to this workload group.
+                If the same setting is defined in multiple places, the default precedence (most
+                specific first) is: request parameter &gt; WLM group setting &gt; cluster setting.
+                Turn on <code>override_request_values</code> to make the group setting win over the
+                request parameter.
+              </p>
+            </EuiText>
+            <EuiSpacer size="m" />
+            <WLMSettingsForm
+              initialSettings={undefined}
+              draft={settingsDraft}
+              onChange={setSettingsDraft}
+            />
+          </EuiPanel>
+        </>
+      )}
 
       <EuiSpacer size="l" />
       <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px' }}>

--- a/public/pages/WorkloadManagement/WLMDetails/WLMDetails.test.tsx
+++ b/public/pages/WorkloadManagement/WLMDetails/WLMDetails.test.tsx
@@ -1124,4 +1124,125 @@ describe('WLMDetails Component', () => {
       );
     });
   });
+
+  describe('Group settings tab', () => {
+    const renderWithVersion = (version: string, name = 'test-group') => {
+      (mockCore.savedObjects.client.get as jest.Mock).mockResolvedValue({
+        attributes: { dataSourceVersion: version },
+      });
+      const ds = { id: 'ds-x', name: 'ds-x', dataSourceVersion: version } as any;
+      render(
+        <MemoryRouter initialEntries={[`/wlm-details?name=${name}`]}>
+          <DataSourceContext.Provider value={{ dataSource: ds, setDataSource: jest.fn() }}>
+            <WLMDetails
+              core={mockCore}
+              depsStart={{ dataSource: { dataSourceEnabled: true } } as any}
+              params={mockParams}
+              dataSourceManagement={mockDataSourceManagement}
+            />
+          </DataSourceContext.Provider>
+        </MemoryRouter>
+      );
+    };
+
+    it('hides the group settings section on a < 3.7 cluster', async () => {
+      await act(async () => {
+        renderWithVersion('3.6.0');
+        await new Promise((r) => setTimeout(r, 50));
+      });
+      await waitFor(() => expect(screen.getByText(/Workload group name/i)).toBeInTheDocument());
+      fireEvent.click(screen.getByTestId('wlm-tab-settings'));
+      expect(screen.queryByTestId('wlm-setting-toggle-search.max_buckets')).not.toBeInTheDocument();
+    });
+
+    it('shows the group settings section on a >= 3.7 cluster', async () => {
+      await act(async () => {
+        renderWithVersion('3.7.0');
+        await new Promise((r) => setTimeout(r, 50));
+      });
+      fireEvent.click(screen.getByTestId('wlm-tab-settings'));
+      await waitFor(() =>
+        expect(screen.getByTestId('wlm-setting-toggle-search.max_buckets')).toBeInTheDocument()
+      );
+    });
+
+    it('parses settings from GET response and populates the form', async () => {
+      (mockCore.http.get as jest.Mock).mockImplementation((path: string) => {
+        if (path.startsWith('/api/_wlm/workload_group/test-group')) {
+          return Promise.resolve({
+            workload_groups: [
+              {
+                _id: 'wg-123',
+                name: 'test-group',
+                resource_limits: { cpu: 0.5, memory: 0.5 },
+                resiliency_mode: 'SOFT',
+                settings: { 'search.max_buckets': '10000' },
+              },
+            ],
+          });
+        }
+        if (path === '/api/_rules/workload_group') return Promise.resolve({ rules: [] });
+        if (path.startsWith('/api/_wlm/stats')) return Promise.resolve({});
+        return Promise.resolve({ body: {} });
+      });
+
+      await act(async () => {
+        renderWithVersion('3.7.0');
+        await new Promise((r) => setTimeout(r, 50));
+      });
+      fireEvent.click(screen.getByTestId('wlm-tab-settings'));
+      await waitFor(() => {
+        const toggle = screen.getByTestId('wlm-setting-toggle-search.max_buckets');
+        const isOn =
+          (toggle as HTMLInputElement).checked || toggle.getAttribute('aria-checked') === 'true';
+        expect(isOn).toBe(true);
+      });
+      const input = screen.getByTestId('wlm-setting-input-search.max_buckets') as HTMLInputElement;
+      expect(input.value).toBe('10000');
+    });
+
+    it('sends serialized settings on Apply Changes', async () => {
+      (mockCore.http.get as jest.Mock).mockImplementation((path: string) => {
+        if (path.startsWith('/api/_wlm/workload_group/test-group')) {
+          return Promise.resolve({
+            workload_groups: [
+              {
+                _id: 'wg-123',
+                name: 'test-group',
+                resource_limits: { cpu: 0.5, memory: 0.5 },
+                resiliency_mode: 'SOFT',
+              },
+            ],
+          });
+        }
+        if (path === '/api/_rules/workload_group') return Promise.resolve({ rules: [] });
+        if (path.startsWith('/api/_wlm/stats')) return Promise.resolve({});
+        return Promise.resolve({ body: {} });
+      });
+      (mockCore.http.put as jest.Mock).mockResolvedValue({});
+
+      await act(async () => {
+        renderWithVersion('3.7.0');
+        await new Promise((r) => setTimeout(r, 50));
+      });
+      fireEvent.click(screen.getByTestId('wlm-tab-settings'));
+
+      const toggle = await screen.findByTestId('wlm-setting-toggle-search.max_buckets');
+      fireEvent.click(toggle);
+      const input = screen.getByTestId('wlm-setting-input-search.max_buckets');
+      fireEvent.change(input, { target: { value: '5000' } });
+
+      fireEvent.click(screen.getByRole('button', { name: /apply changes/i }));
+
+      await waitFor(() => {
+        const putCalls = (mockCore.http.put as jest.Mock).mock.calls;
+        const updateCall = putCalls.find(
+          ([url]: [string]) => url === '/api/_wlm/workload_group/test-group'
+        );
+        expect(updateCall).toBeDefined();
+        const sentBody = JSON.parse(updateCall![1].body);
+        expect(sentBody.settings).toEqual({ 'search.max_buckets': 5000 });
+      });
+    });
+  });
 });

--- a/public/pages/WorkloadManagement/WLMDetails/WLMDetails.tsx
+++ b/public/pages/WorkloadManagement/WLMDetails/WLMDetails.tsx
@@ -35,9 +35,20 @@ import { getDataSourceEnabledUrl } from '../../../utils/datasource-utils';
 import {
   resolveDataSourceVersion,
   isSecurityAttributesSupported,
+  isWlmGroupSettingsSupported,
 } from '../../../utils/datasource-utils';
 import { DEFAULT_WORKLOAD_GROUP } from '../../../../common/constants';
 import { AutoSizeTextArea } from '../auto_size_text_area';
+import { WLMSettingsForm } from '../WLMSettings/wlm_settings_form';
+import {
+  WlmGroupSettings,
+  WlmGroupSettingsDraft,
+  emptyDraft,
+  hasInvalidSettings,
+  parseRawSettings,
+  serializeDraft,
+  toDraft,
+} from '../WLMSettings/wlm_settings_types';
 
 // === Constants & Types ===
 const DEFAULT_RESOURCE_LIMIT = 100;
@@ -85,6 +96,7 @@ interface WorkloadGroup {
     memory?: number;
   };
   resiliency_mode?: string;
+  settings?: Record<string, unknown>;
 }
 
 interface WorkloadGroupByNameResponse {
@@ -177,6 +189,9 @@ export const WLMDetails = ({
   const [dsVersion, setDsVersion] = useState<string | undefined>();
   const dataSourceEnabled = !!depsStart?.dataSource?.dataSourceEnabled;
   const showSecurity = !dataSourceEnabled || isSecurityAttributesSupported(dsVersion);
+  const showGroupSettings = !dataSourceEnabled || isWlmGroupSettingsSupported(dsVersion);
+  const [, setOriginalSettings] = useState<WlmGroupSettings>({});
+  const [settingsDraft, setSettingsDraft] = useState<WlmGroupSettingsDraft>(emptyDraft());
 
   // === Helpers ===
   const resiliencyOptions = [
@@ -288,6 +303,9 @@ export const WLMDetails = ({
         setOriginalMemoryLimit(formatLimit(workload.resource_limits?.memory));
         setCpuLimit(formatLimit(workload.resource_limits?.cpu));
         setMemoryLimit(formatLimit(workload.resource_limits?.memory));
+        const parsed = parseRawSettings(workload.settings);
+        setOriginalSettings(parsed);
+        setSettingsDraft(toDraft(parsed));
       }
     } catch (err) {
       console.error('Failed to fetch workload group details:', err);
@@ -451,6 +469,11 @@ export const WLMDetails = ({
       body.resource_limits = resourceLimits;
     }
 
+    const settingsPayload = serializeDraft(settingsDraft);
+    if (settingsPayload !== undefined) {
+      body.settings = settingsPayload;
+    }
+
     try {
       await core.http.put(`/api/_wlm/workload_group/${groupName}`, {
         query: { dataSourceId: dataSource.id },
@@ -509,9 +532,8 @@ export const WLMDetails = ({
       setIsSaved(true);
       core.notifications.toasts.addSuccess(`Saved changes for "${groupName}"`);
 
-      setTimeout(() => {
-        window.location.reload();
-      }, 1000);
+      await fetchGroupDetails();
+      await updateStats();
     } catch (err) {
       const errorMessage = err?.body?.message || err?.message || String(err);
       core.notifications.toasts.addDanger(`Failed to save changes: ${errorMessage}`);
@@ -1175,10 +1197,44 @@ export const WLMDetails = ({
                 </>
               </EuiFormRow>
 
+              {showGroupSettings && (
+                <>
+                  <EuiSpacer size="l" />
+
+                  <EuiTitle size="s">
+                    <h2>Group settings</h2>
+                  </EuiTitle>
+                  <EuiText size="xs" color="subdued">
+                    <p>
+                      Optional per-group overrides applied to every request routed to this workload
+                      group. If the same setting is defined in multiple places, the default
+                      precedence (most specific first) is: request parameter &gt; WLM group setting
+                      &gt; cluster setting. Turn on <code>override_request_values</code> to make the
+                      group setting win over the request parameter.
+                    </p>
+                  </EuiText>
+
+                  <EuiSpacer size="s" />
+
+                  <WLMSettingsForm
+                    initialSettings={undefined}
+                    draft={settingsDraft}
+                    onChange={(next) => {
+                      setSettingsDraft(next);
+                      setIsSaved(false);
+                    }}
+                  />
+                </>
+              )}
+
               <EuiSpacer size="m" />
 
               {/* Apply Changes Button */}
-              <EuiButton onClick={saveChanges} color="primary" isDisabled={isSaved || isInvalid}>
+              <EuiButton
+                onClick={saveChanges}
+                color="primary"
+                isDisabled={isSaved || isInvalid || hasInvalidSettings(settingsDraft)}
+              >
                 Apply Changes
               </EuiButton>
             </>

--- a/public/pages/WorkloadManagement/WLMSettings/wlm_settings_form.test.tsx
+++ b/public/pages/WorkloadManagement/WLMSettings/wlm_settings_form.test.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { WLMSettingsForm } from './wlm_settings_form';
+import { WLM_SETTING_DEFS, emptyDraft, WlmGroupSettingsDraft } from './wlm_settings_types';
+
+const renderForm = (override?: Partial<WlmGroupSettingsDraft>) => {
+  const draft = { ...emptyDraft(), ...override };
+  const onChange = jest.fn();
+  const utils = render(
+    <WLMSettingsForm initialSettings={undefined} draft={draft} onChange={onChange} />
+  );
+  return { ...utils, draft, onChange };
+};
+
+describe('WLMSettingsForm', () => {
+  it('renders one row per defined setting key', () => {
+    renderForm();
+    const expectedToggles = WLM_SETTING_DEFS.map((def) => `wlm-setting-toggle-${def.key}`);
+    const expectedInputs = WLM_SETTING_DEFS.filter((def) => def.kind !== 'boolean').map(
+      (def) => `wlm-setting-input-${def.key}`
+    );
+    expect(expectedToggles.every((id) => screen.queryByTestId(id) !== null)).toBe(true);
+    expect(expectedInputs.every((id) => screen.queryByTestId(id) !== null)).toBe(true);
+    expect(
+      screen.queryByTestId('wlm-setting-input-override_request_values')
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps inputs disabled when the toggle is off', () => {
+    renderForm();
+    const input = screen.getByTestId('wlm-setting-input-search.max_buckets');
+    expect(input).toBeDisabled();
+  });
+
+  it('fires onChange enabling a key when the toggle is clicked', () => {
+    const { onChange } = renderForm();
+    const toggle = screen.getByTestId('wlm-setting-toggle-search.max_buckets');
+    fireEvent.click(toggle);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const next = onChange.mock.calls[0][0];
+    expect(next['search.max_buckets'].enabled).toBe(true);
+  });
+
+  it('fires onChange flipping override_request_values value when toggled', () => {
+    const { onChange } = renderForm();
+    const toggle = screen.getByTestId('wlm-setting-toggle-override_request_values');
+    fireEvent.click(toggle);
+    const next = onChange.mock.calls[0][0];
+    expect(next.override_request_values).toEqual({
+      enabled: true,
+      value: 'true',
+      wasSetOnServer: false,
+    });
+  });
+
+  it('shows a validation error when an enabled int row has an invalid value', () => {
+    const draftOverride: Partial<WlmGroupSettingsDraft> = {
+      'search.batched_reduce_size': { enabled: true, value: '1', wasSetOnServer: false },
+    };
+    renderForm(draftOverride);
+    expect(screen.getByText(/Must be ≥ 2/)).toBeInTheDocument();
+  });
+
+  it('forwards typed values via onChange', () => {
+    const draftOverride: Partial<WlmGroupSettingsDraft> = {
+      'search.max_buckets': { enabled: true, value: '', wasSetOnServer: false },
+    };
+    const { onChange } = renderForm(draftOverride);
+    const input = screen.getByTestId('wlm-setting-input-search.max_buckets');
+    fireEvent.change(input, { target: { value: '5000' } });
+    const next = onChange.mock.calls[0][0];
+    expect(next['search.max_buckets'].value).toBe('5000');
+  });
+});

--- a/public/pages/WorkloadManagement/WLMSettings/wlm_settings_form.tsx
+++ b/public/pages/WorkloadManagement/WLMSettings/wlm_settings_form.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import {
+  EuiFieldNumber,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiSpacer,
+  EuiSwitch,
+  EuiText,
+} from '@elastic/eui';
+import {
+  WLM_SETTING_DEFS,
+  WlmGroupSettings,
+  WlmGroupSettingsDraft,
+  WlmGroupSettingsDraftEntry,
+  WlmGroupSettingsKey,
+  WlmSettingDef,
+  validateSetting,
+} from './wlm_settings_types';
+
+export interface WLMSettingsFormProps {
+  initialSettings: WlmGroupSettings | undefined;
+  draft: WlmGroupSettingsDraft;
+  onChange: (next: WlmGroupSettingsDraft) => void;
+  disabled?: boolean;
+}
+
+const updateEntry = (
+  draft: WlmGroupSettingsDraft,
+  key: WlmGroupSettingsKey,
+  patch: Partial<WlmGroupSettingsDraftEntry>
+): WlmGroupSettingsDraft => ({
+  ...draft,
+  [key]: { ...draft[key], ...patch },
+});
+
+const renderInput = (
+  def: WlmSettingDef,
+  entry: WlmGroupSettingsDraftEntry,
+  disabled: boolean,
+  onValueChange: (value: string) => void
+) => {
+  if (def.kind === 'boolean') return null;
+  const isDisabled = disabled || !entry.enabled;
+  if (def.kind === 'int') {
+    return (
+      <EuiFieldNumber
+        data-testid={`wlm-setting-input-${def.key}`}
+        value={entry.value === '' ? '' : Number(entry.value)}
+        disabled={isDisabled}
+        min={def.min}
+        max={def.max}
+        onChange={(e) => onValueChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (['e', 'E', '+', '-', '.'].includes(e.key)) {
+            e.preventDefault();
+          }
+        }}
+      />
+    );
+  }
+  return (
+    <EuiFieldText
+      data-testid={`wlm-setting-input-${def.key}`}
+      value={entry.value}
+      disabled={isDisabled}
+      placeholder="e.g. 30s"
+      onChange={(e) => onValueChange(e.target.value)}
+    />
+  );
+};
+
+export const WLMSettingsForm: React.FC<WLMSettingsFormProps> = ({
+  draft,
+  onChange,
+  disabled = false,
+}) => {
+  return (
+    <div>
+      {WLM_SETTING_DEFS.map((def, idx) => {
+        const entry = draft[def.key];
+        const isBoolean = def.kind === 'boolean';
+        const error = entry.enabled && !isBoolean ? validateSetting(def.key, entry.value) : null;
+
+        const onToggle = (checked: boolean) => {
+          if (isBoolean) {
+            onChange(
+              updateEntry(draft, def.key, {
+                enabled: checked,
+                value: checked ? 'true' : 'false',
+              })
+            );
+          } else {
+            onChange(updateEntry(draft, def.key, { enabled: checked }));
+          }
+        };
+
+        return (
+          <React.Fragment key={def.key}>
+            {idx > 0 && <EuiSpacer size="m" />}
+            <EuiFlexGroup alignItems="flexStart" gutterSize="l">
+              <EuiFlexItem grow={3}>
+                <EuiText size="m">
+                  <code style={{ fontWeight: 600 }}>{def.key}</code>
+                </EuiText>
+                <EuiText size="xs" color="subdued">
+                  {def.description}
+                </EuiText>
+              </EuiFlexItem>
+              <EuiFlexItem grow={2}>
+                <EuiFlexGroup alignItems="center" gutterSize="m">
+                  <EuiFlexItem grow={false}>
+                    <EuiSwitch
+                      label="Enabled"
+                      data-testid={`wlm-setting-toggle-${def.key}`}
+                      checked={entry.enabled}
+                      disabled={disabled}
+                      onChange={(e) => onToggle(e.target.checked)}
+                    />
+                  </EuiFlexItem>
+                  {!isBoolean && (
+                    <EuiFlexItem>
+                      <EuiFormRow isInvalid={Boolean(error)} error={error || undefined} fullWidth>
+                        {renderInput(def, entry, disabled, (value) =>
+                          onChange(updateEntry(draft, def.key, { value }))
+                        )}
+                      </EuiFormRow>
+                    </EuiFlexItem>
+                  )}
+                </EuiFlexGroup>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+};

--- a/public/pages/WorkloadManagement/WLMSettings/wlm_settings_types.test.ts
+++ b/public/pages/WorkloadManagement/WLMSettings/wlm_settings_types.test.ts
@@ -1,0 +1,202 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  WLM_SETTING_DEFS,
+  emptyDraft,
+  hasInvalidSettings,
+  parseRawSettings,
+  serializeDraft,
+  toDraft,
+  validateSetting,
+} from './wlm_settings_types';
+
+describe('wlm_settings_types', () => {
+  describe('emptyDraft', () => {
+    it('returns one entry per defined key, all disabled', () => {
+      const draft = emptyDraft();
+      for (const def of WLM_SETTING_DEFS) {
+        expect(draft[def.key]).toEqual({ enabled: false, value: '', wasSetOnServer: false });
+      }
+    });
+  });
+
+  describe('parseRawSettings', () => {
+    it('returns {} for undefined or null', () => {
+      expect(parseRawSettings(undefined)).toEqual({});
+      expect(parseRawSettings(null)).toEqual({});
+    });
+
+    it('parses int strings as numbers', () => {
+      const parsed = parseRawSettings({ 'search.max_buckets': '10000' });
+      expect(parsed).toEqual({ 'search.max_buckets': 10000 });
+    });
+
+    it('parses boolean strings', () => {
+      expect(parseRawSettings({ override_request_values: 'true' })).toEqual({
+        override_request_values: true,
+      });
+      expect(parseRawSettings({ override_request_values: 'false' })).toEqual({
+        override_request_values: false,
+      });
+    });
+
+    it('drops the search.default_search_timeout sentinel "-1"', () => {
+      expect(parseRawSettings({ 'search.default_search_timeout': '-1' })).toEqual({});
+    });
+
+    it('keeps other time values verbatim', () => {
+      expect(parseRawSettings({ 'search.default_search_timeout': '30s' })).toEqual({
+        'search.default_search_timeout': '30s',
+      });
+    });
+
+    it('ignores unknown keys', () => {
+      expect(parseRawSettings({ 'something.unknown': '5' })).toEqual({});
+    });
+  });
+
+  describe('toDraft', () => {
+    it('marks a returned int setting as enabled and wasSetOnServer', () => {
+      const draft = toDraft({ 'search.max_buckets': 10000 });
+      expect(draft['search.max_buckets']).toEqual({
+        enabled: true,
+        value: '10000',
+        wasSetOnServer: true,
+      });
+    });
+
+    it('treats override_request_values=false as not user-set', () => {
+      const draft = toDraft({ override_request_values: false });
+      expect(draft.override_request_values).toEqual({
+        enabled: false,
+        value: 'false',
+        wasSetOnServer: false,
+      });
+    });
+
+    it('treats override_request_values=true as user-set', () => {
+      const draft = toDraft({ override_request_values: true });
+      expect(draft.override_request_values).toEqual({
+        enabled: true,
+        value: 'true',
+        wasSetOnServer: true,
+      });
+    });
+  });
+
+  describe('validateSetting', () => {
+    it('accepts valid time values', () => {
+      expect(validateSetting('search.default_search_timeout', '30s')).toBeNull();
+      expect(validateSetting('search.default_search_timeout', '1m')).toBeNull();
+      expect(validateSetting('search.default_search_timeout', '250ms')).toBeNull();
+    });
+
+    it('rejects bare numeric time values', () => {
+      expect(validateSetting('search.default_search_timeout', '30')).not.toBeNull();
+    });
+
+    it('rejects empty time values', () => {
+      expect(validateSetting('search.default_search_timeout', '')).not.toBeNull();
+    });
+
+    it('enforces int minimums', () => {
+      expect(validateSetting('search.batched_reduce_size', '2')).toBeNull();
+      expect(validateSetting('search.batched_reduce_size', '1')).not.toBeNull();
+      expect(validateSetting('search.max_concurrent_shard_requests', '1')).toBeNull();
+      expect(validateSetting('search.max_concurrent_shard_requests', '0')).not.toBeNull();
+      expect(validateSetting('search.max_buckets', '0')).toBeNull();
+      expect(validateSetting('search.max_buckets', '-1')).not.toBeNull();
+    });
+
+    it('rejects non-integer ints', () => {
+      expect(validateSetting('search.max_buckets', '1.5')).not.toBeNull();
+      expect(validateSetting('search.max_buckets', 'abc')).not.toBeNull();
+    });
+
+    it('enforces int maximum (Integer.MAX_VALUE)', () => {
+      expect(validateSetting('search.max_buckets', '2147483647')).toBeNull();
+      expect(validateSetting('search.max_buckets', '2147483648')).not.toBeNull();
+      expect(validateSetting('search.max_concurrent_shard_requests', '2147483648')).not.toBeNull();
+      expect(validateSetting('search.batched_reduce_size', '999999999999')).not.toBeNull();
+    });
+
+    it('treats boolean keys as always valid', () => {
+      expect(validateSetting('override_request_values', '')).toBeNull();
+    });
+  });
+
+  describe('hasInvalidSettings', () => {
+    it('is false when nothing is enabled', () => {
+      expect(hasInvalidSettings(emptyDraft())).toBe(false);
+    });
+
+    it('is true when an enabled row has an invalid value', () => {
+      const draft = emptyDraft();
+      draft['search.batched_reduce_size'] = { enabled: true, value: '1', wasSetOnServer: false };
+      expect(hasInvalidSettings(draft)).toBe(true);
+    });
+
+    it('ignores invalid values on disabled rows', () => {
+      const draft = emptyDraft();
+      draft['search.batched_reduce_size'] = { enabled: false, value: '1', wasSetOnServer: false };
+      expect(hasInvalidSettings(draft)).toBe(false);
+    });
+  });
+
+  describe('serializeDraft', () => {
+    it('returns undefined for empty draft', () => {
+      expect(serializeDraft(emptyDraft())).toBeUndefined();
+    });
+
+    it('emits typed values for enabled rows', () => {
+      const draft = emptyDraft();
+      draft['search.max_buckets'] = { enabled: true, value: '5000', wasSetOnServer: false };
+      draft['search.default_search_timeout'] = {
+        enabled: true,
+        value: '30s',
+        wasSetOnServer: false,
+      };
+      expect(serializeDraft(draft)).toEqual({
+        'search.max_buckets': 5000,
+        'search.default_search_timeout': '30s',
+      });
+    });
+
+    it('emits null for previously-set keys that are toggled off', () => {
+      const draft = emptyDraft();
+      draft['search.max_buckets'] = { enabled: false, value: '10000', wasSetOnServer: true };
+      expect(serializeDraft(draft)).toEqual({ 'search.max_buckets': null });
+    });
+
+    it('omits never-set keys that remain off', () => {
+      const draft = emptyDraft();
+      draft['search.max_buckets'] = { enabled: false, value: '', wasSetOnServer: false };
+      expect(serializeDraft(draft)).toBeUndefined();
+    });
+
+    it('emits boolean true when override_request_values is enabled', () => {
+      const draft = emptyDraft();
+      draft.override_request_values = { enabled: true, value: 'true', wasSetOnServer: false };
+      expect(serializeDraft(draft)).toEqual({ override_request_values: true });
+    });
+
+    it('emits null when override_request_values was true and is toggled off', () => {
+      const draft = emptyDraft();
+      draft.override_request_values = { enabled: false, value: 'true', wasSetOnServer: true };
+      expect(serializeDraft(draft)).toEqual({ override_request_values: null });
+    });
+
+    it('mixes set and removal in one payload', () => {
+      const draft = emptyDraft();
+      draft['search.max_buckets'] = { enabled: true, value: '9999', wasSetOnServer: true };
+      draft['search.batched_reduce_size'] = { enabled: false, value: '512', wasSetOnServer: true };
+      expect(serializeDraft(draft)).toEqual({
+        'search.max_buckets': 9999,
+        'search.batched_reduce_size': null,
+      });
+    });
+  });
+});

--- a/public/pages/WorkloadManagement/WLMSettings/wlm_settings_types.ts
+++ b/public/pages/WorkloadManagement/WLMSettings/wlm_settings_types.ts
@@ -1,0 +1,213 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type WlmGroupSettingsKey =
+  | 'search.default_search_timeout'
+  | 'search.cancel_after_time_interval'
+  | 'search.max_concurrent_shard_requests'
+  | 'search.batched_reduce_size'
+  | 'search.max_buckets'
+  | 'override_request_values';
+
+export type WlmSettingKind = 'time' | 'int' | 'boolean';
+
+export interface WlmSettingDef {
+  key: WlmGroupSettingsKey;
+  kind: WlmSettingKind;
+  description: string;
+  min?: number;
+  max?: number;
+  implicitDefault?: string;
+}
+
+export const INT_MAX = 2147483647;
+
+export const WLM_SETTING_DEFS: readonly WlmSettingDef[] = [
+  {
+    key: 'search.default_search_timeout',
+    kind: 'time',
+    description: 'Hard cap on per-shard search execution time.',
+    implicitDefault: '-1',
+  },
+  {
+    key: 'search.cancel_after_time_interval',
+    kind: 'time',
+    description: 'Coordinator-side deadline after which a search request is cancelled.',
+  },
+  {
+    key: 'search.max_concurrent_shard_requests',
+    kind: 'int',
+    description: 'Maximum number of concurrent shard requests per node for a single search.',
+    min: 1,
+    max: INT_MAX,
+    implicitDefault: '5',
+  },
+  {
+    key: 'search.batched_reduce_size',
+    kind: 'int',
+    description: 'Maximum number of shard results to reduce per batch on the coordinator.',
+    min: 2,
+    max: INT_MAX,
+    implicitDefault: '512',
+  },
+  {
+    key: 'search.max_buckets',
+    kind: 'int',
+    description: 'Maximum number of aggregation buckets allowed in a single response.',
+    min: 0,
+    max: INT_MAX,
+  },
+  {
+    key: 'override_request_values',
+    kind: 'boolean',
+    description: 'Enable to allow group settings to override caller-supplied request parameters.',
+    implicitDefault: 'false',
+  },
+];
+
+const KEY_TO_DEF: Record<WlmGroupSettingsKey, WlmSettingDef> = WLM_SETTING_DEFS.reduce(
+  (acc, def) => {
+    acc[def.key] = def;
+    return acc;
+  },
+  {} as Record<WlmGroupSettingsKey, WlmSettingDef>
+);
+
+export type WlmGroupSettings = Partial<{
+  'search.default_search_timeout': string;
+  'search.cancel_after_time_interval': string;
+  'search.max_concurrent_shard_requests': number;
+  'search.batched_reduce_size': number;
+  'search.max_buckets': number;
+  override_request_values: boolean;
+}>;
+
+export interface WlmGroupSettingsDraftEntry {
+  enabled: boolean;
+  value: string;
+  wasSetOnServer: boolean;
+}
+
+export type WlmGroupSettingsDraft = Record<WlmGroupSettingsKey, WlmGroupSettingsDraftEntry>;
+
+export function emptyDraft(): WlmGroupSettingsDraft {
+  return WLM_SETTING_DEFS.reduce((acc, def) => {
+    acc[def.key] = { enabled: false, value: '', wasSetOnServer: false };
+    return acc;
+  }, {} as WlmGroupSettingsDraft);
+}
+
+const TIME_VALUE_REGEX = /^\d+(?:\.\d+)?(ms|s|m|h|d)$/;
+
+function parseBoolean(raw: unknown): boolean {
+  if (typeof raw === 'boolean') return raw;
+  if (typeof raw === 'string') return raw.toLowerCase() === 'true';
+  return false;
+}
+
+function parseInteger(raw: unknown): number {
+  if (typeof raw === 'number') return raw;
+  if (typeof raw === 'string') return Number(raw);
+  return NaN;
+}
+
+export function parseRawSettings(
+  raw: Record<string, unknown> | undefined | null
+): WlmGroupSettings {
+  if (!raw || typeof raw !== 'object') return {};
+  const out: WlmGroupSettings = {};
+  for (const def of WLM_SETTING_DEFS) {
+    if (!(def.key in raw)) continue;
+    const value = (raw as Record<string, unknown>)[def.key];
+    if (value === null || value === undefined) continue;
+    if (def.kind === 'time') {
+      const s = String(value);
+      if (def.key === 'search.default_search_timeout' && s === '-1') continue;
+      (out as Record<string, unknown>)[def.key] = s;
+    } else if (def.kind === 'int') {
+      const n = parseInteger(value);
+      if (Number.isFinite(n)) (out as Record<string, unknown>)[def.key] = n;
+    } else {
+      (out as Record<string, unknown>)[def.key] = parseBoolean(value);
+    }
+  }
+  return out;
+}
+
+export function toDraft(parsed: WlmGroupSettings): WlmGroupSettingsDraft {
+  const draft = emptyDraft();
+  for (const def of WLM_SETTING_DEFS) {
+    const parsedValue = (parsed as Record<string, unknown>)[def.key];
+    if (parsedValue === undefined) continue;
+
+    if (def.kind === 'boolean') {
+      const booleanValue = parsedValue === true;
+      const matchesImplicitDefault =
+        def.implicitDefault !== undefined && String(booleanValue) === def.implicitDefault;
+      draft[def.key] = {
+        enabled: booleanValue,
+        value: booleanValue ? 'true' : 'false',
+        wasSetOnServer: !matchesImplicitDefault && booleanValue,
+      };
+    } else {
+      draft[def.key] = {
+        enabled: true,
+        value: String(parsedValue),
+        wasSetOnServer: true,
+      };
+    }
+  }
+  return draft;
+}
+
+export function validateSetting(key: WlmGroupSettingsKey, rawValue: string): string | null {
+  const def = KEY_TO_DEF[key];
+  if (!def) return null;
+  const trimmed = (rawValue ?? '').trim();
+  if (def.kind === 'boolean') return null;
+  if (trimmed === '') return 'Value is required.';
+  if (def.kind === 'time') {
+    return TIME_VALUE_REGEX.test(trimmed) ? null : 'Use a duration like 250ms, 30s, or 1m.';
+  }
+  if (def.kind === 'int') {
+    const n = Number(trimmed);
+    if (!Number.isFinite(n) || !Number.isInteger(n)) return 'Must be an integer.';
+    if (def.min !== undefined && n < def.min) return `Must be ≥ ${def.min}.`;
+    if (def.max !== undefined && n > def.max) return `Must be ≤ ${def.max}.`;
+    return null;
+  }
+  return null;
+}
+
+export function hasInvalidSettings(draft: WlmGroupSettingsDraft): boolean {
+  return WLM_SETTING_DEFS.some((def) => {
+    const entry = draft[def.key];
+    if (!entry || !entry.enabled) return false;
+    return validateSetting(def.key, entry.value) !== null;
+  });
+}
+
+export type WlmSettingsPayloadValue = string | number | boolean | null;
+export type WlmSettingsPayload = Record<string, WlmSettingsPayloadValue>;
+
+export function serializeDraft(draft: WlmGroupSettingsDraft): WlmSettingsPayload | undefined {
+  const out: WlmSettingsPayload = {};
+  for (const def of WLM_SETTING_DEFS) {
+    const entry = draft[def.key];
+    if (!entry) continue;
+    if (entry.enabled) {
+      if (def.kind === 'time') {
+        out[def.key] = entry.value.trim();
+      } else if (def.kind === 'int') {
+        out[def.key] = Number(entry.value);
+      } else {
+        out[def.key] = true;
+      }
+    } else if (entry.wasSetOnServer) {
+      out[def.key] = null;
+    }
+  }
+  return Object.keys(out).length === 0 ? undefined : out;
+}

--- a/public/utils/datasource-utils.ts
+++ b/public/utils/datasource-utils.ts
@@ -138,3 +138,9 @@ export function isSecurityAttributesSupported(version?: string): boolean {
   const v = version && semver.valid(version) ? version : semver.coerce(version || '')?.version;
   return !!v && semver.gte(v, '3.3.0');
 }
+
+/** Whether per-workload-group settings are supported (>= 3.7.0). */
+export function isWlmGroupSettingsSupported(version?: string): boolean {
+  const v = version && semver.valid(version) ? version : semver.coerce(version || '')?.version;
+  return !!v && semver.gte(v, '3.7.0');
+}

--- a/server/routes/wlmRoutes.test.tsx
+++ b/server/routes/wlmRoutes.test.tsx
@@ -313,6 +313,27 @@ describe.each<[boolean]>([[true], [false]])(
       expectNoMeta(payload);
     });
 
+    test('PUT /api/_wlm/workload_group forwards settings field', async () => {
+      const handler = REG['PUT /api/_wlm/workload_group'];
+      const { ctx, mockWlmCall } = makeCtx();
+      const res = makeRes();
+      const bodyIn = {
+        name: 'g',
+        resiliency_mode: 'soft',
+        settings: {
+          'search.max_buckets': 5000,
+          'search.default_search_timeout': '30s',
+          override_request_values: true,
+        },
+      };
+
+      mockWlmCall.mockResolvedValue({ acknowledged: true, id: 'g' });
+
+      await handler(ctx, { body: bodyIn, query: {} }, res);
+
+      expect(mockWlmCall.mock.calls).toEqual([['wlm.createWorkloadGroup', { body: bodyIn }]]);
+    });
+
     //
     // 6) PUT /api/_wlm/workload_group/{name}
     //
@@ -365,6 +386,58 @@ describe.each<[boolean]>([[true], [false]])(
       const payload = res.ok.mock.calls[0][0].body;
       expect(payload).toEqual({ updated: true });
       expectNoMeta(payload);
+    });
+
+    test('PUT /api/_wlm/workload_group/{name} forwards settings with null removals', async () => {
+      const handler = REG['PUT /api/_wlm/workload_group/{name}'];
+      const { ctx, mockWlmCall } = makeCtx();
+      const res = makeRes();
+      const params = { name: 'g' };
+      const bodyIn = {
+        resiliency_mode: 'soft',
+        settings: {
+          'search.max_buckets': 9999,
+          'search.batched_reduce_size': null,
+        },
+      };
+
+      mockWlmCall.mockResolvedValue({ updated: true });
+
+      await handler(ctx, { params, body: bodyIn, query: {} }, res);
+
+      expect(mockWlmCall.mock.calls).toEqual([
+        ['wlm.updateWorkloadGroup', { name: 'g', body: bodyIn }],
+      ]);
+    });
+
+    test('PUT /api/_wlm/workload_group forwards core status code on validation errors', async () => {
+      const handler = REG['PUT /api/_wlm/workload_group'];
+      const { ctx, mockWlmCall } = makeCtx();
+      const res = makeRes();
+      const err = Object.assign(new Error('Invalid value'), {
+        meta: {
+          statusCode: 400,
+          body: { error: { reason: "Invalid value '-1' for search.max_buckets" } },
+        },
+      });
+      mockWlmCall.mockRejectedValue(err);
+
+      await handler(
+        ctx,
+        {
+          body: { name: 'g', resiliency_mode: 'soft', settings: { 'search.max_buckets': -1 } },
+          query: {},
+        },
+        res
+      );
+
+      expect(res.customError).toHaveBeenCalledWith({
+        statusCode: 400,
+        body: {
+          message: expect.stringContaining("Invalid value '-1' for search.max_buckets"),
+        },
+      });
+      expect(res.internalError).not.toHaveBeenCalled();
     });
 
     //

--- a/server/routes/wlmRoutes.ts
+++ b/server/routes/wlmRoutes.ts
@@ -6,6 +6,26 @@
 import { schema } from '@osd/config-schema';
 import { IRouter } from '../../../../src/core/server';
 
+const wlmSettingsBodySchema = schema.maybe(
+  schema.recordOf(
+    schema.string(),
+    schema.nullable(schema.oneOf([schema.string(), schema.number(), schema.boolean()]))
+  )
+);
+
+const extractErrorStatus = (e: any): number =>
+  e?.meta?.statusCode ?? e?.statusCode ?? e?.status ?? 500;
+
+const extractErrorMessage = (e: any, prefix: string): string => {
+  const reason =
+    e?.meta?.body?.error?.reason ??
+    e?.meta?.body?.message ??
+    e?.body?.message ??
+    e?.message ??
+    'Unexpected error';
+  return `${prefix}: ${reason}`;
+};
+
 export function defineWlmRoutes(router: IRouter, dataSourceEnabled: boolean) {
   // Get WLM stats across all nodes in the cluster
   router.get(
@@ -151,10 +171,13 @@ export function defineWlmRoutes(router: IRouter, dataSourceEnabled: boolean) {
         body: schema.object({
           name: schema.string(),
           resiliency_mode: schema.string(),
-          resource_limits: schema.object({
-            cpu: schema.maybe(schema.number()),
-            memory: schema.maybe(schema.number()),
-          }),
+          resource_limits: schema.maybe(
+            schema.object({
+              cpu: schema.maybe(schema.number()),
+              memory: schema.maybe(schema.number()),
+            })
+          ),
+          settings: wlmSettingsBodySchema,
         }),
         query: schema.object({
           dataSourceId: schema.maybe(schema.string()),
@@ -175,8 +198,9 @@ export function defineWlmRoutes(router: IRouter, dataSourceEnabled: boolean) {
         return response.ok({ body: result });
       } catch (e: any) {
         console.error('Failed to create workload group:', e);
-        return response.internalError({
-          body: { message: `Failed to create workload group: ${e.message}` },
+        return response.customError({
+          statusCode: extractErrorStatus(e),
+          body: { message: extractErrorMessage(e, 'Failed to create workload group') },
         });
       }
     }
@@ -192,10 +216,13 @@ export function defineWlmRoutes(router: IRouter, dataSourceEnabled: boolean) {
         }),
         body: schema.object({
           resiliency_mode: schema.string(),
-          resource_limits: schema.object({
-            cpu: schema.maybe(schema.number()),
-            memory: schema.maybe(schema.number()),
-          }),
+          resource_limits: schema.maybe(
+            schema.object({
+              cpu: schema.maybe(schema.number()),
+              memory: schema.maybe(schema.number()),
+            })
+          ),
+          settings: wlmSettingsBodySchema,
         }),
         query: schema.object({
           dataSourceId: schema.maybe(schema.string()),
@@ -217,8 +244,9 @@ export function defineWlmRoutes(router: IRouter, dataSourceEnabled: boolean) {
         return response.ok({ body: result });
       } catch (e: any) {
         console.error('Failed to update workload group:', e);
-        return response.internalError({
-          body: { message: `Failed to update workload group: ${e.message}` },
+        return response.customError({
+          statusCode: extractErrorStatus(e),
+          body: { message: extractErrorMessage(e, 'Failed to update workload group') },
         });
       }
     }
@@ -251,9 +279,13 @@ export function defineWlmRoutes(router: IRouter, dataSourceEnabled: boolean) {
         return response.ok({ body: result });
       } catch (e: any) {
         console.error(`Failed to delete workload group '${request.params.name}':`, e);
-        return response.internalError({
+        return response.customError({
+          statusCode: extractErrorStatus(e),
           body: {
-            message: `Failed to delete workload group '${request.params.name}': ${e.message}`,
+            message: extractErrorMessage(
+              e,
+              `Failed to delete workload group '${request.params.name}'`
+            ),
           },
         });
       }
@@ -366,8 +398,9 @@ export function defineWlmRoutes(router: IRouter, dataSourceEnabled: boolean) {
         return response.ok({ body: result });
       } catch (e: any) {
         console.error('Failed to fetch rules:', e);
-        return response.internalError({
-          body: { message: `Failed to fetch rules: ${e.message}` },
+        return response.customError({
+          statusCode: extractErrorStatus(e),
+          body: { message: extractErrorMessage(e, 'Failed to fetch rules') },
         });
       }
     }
@@ -400,8 +433,11 @@ export function defineWlmRoutes(router: IRouter, dataSourceEnabled: boolean) {
         return response.ok({ body: result });
       } catch (e: any) {
         console.error(`Failed to delete index rule ${ruleId}:`, e);
-        return response.internalError({
-          body: { message: `Failed to delete index rule ${ruleId}: ${e.message}` },
+        return response.customError({
+          statusCode: extractErrorStatus(e),
+          body: {
+            message: extractErrorMessage(e, `Failed to delete index rule ${ruleId}`),
+          },
         });
       }
     }


### PR DESCRIPTION
### Description

Adds dashboard support for the per-workload-group `settings` block introduced in OpenSearch 3.7 ([#20536], [#21143], [#21523], [#21721]). Administrators can now set, update, and remove the six supported keys directly from the WLM Workload Management UI on both the create and edit flows.

[#20536]: https://github.com/opensearch-project/OpenSearch/pull/20536
[#21143]: https://github.com/opensearch-project/OpenSearch/pull/21143
[#21523]: https://github.com/opensearch-project/OpenSearch/pull/21523
[#21721]: https://github.com/opensearch-project/OpenSearch/pull/21721

Documentation: opensearch-project/documentation-website#12444

### What's new

**A new `Group settings` section on the Settings tab** of the WLM details page, mirrored as a panel on the create page. Each row carries the raw API key (`search.max_buckets`, `override_request_values`, etc.), a short description, a `Set` toggle, and a typed input.

<img width="1613" height="1575" alt="Screenshot 2026-05-27 at 1 59 07 PM" src="https://github.com/user-attachments/assets/bf0bb6c9-1f47-44a5-bd54-27d92c1d48d2" />


### Things to note

- **Version gate.** New `isWlmGroupSettingsSupported(version)` helper hides the section on data sources < 3.7, mirroring the existing `isSecurityAttributesSupported` ≥ 3.3 pattern.
- **Live validation.** Each input is validated as the user types — `search.max_buckets ≥ 0`, time values match `250ms` / `30s` / `1m`, integers respect their per-key minimum. Invalid rows show an inline error and disable `Apply Changes`. Constraints live in a single table (`WLM_SETTING_DEFS`) — adding a new key is a one-row append.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
