### PR TITLE
Move WLM description to per-rule field (#525)

### DIFF
--- a/cypress/e2e/wlm-no-security/7_WLM_details.cy.js
+++ b/cypress/e2e/wlm-no-security/7_WLM_details.cy.js
@@ -81,7 +81,7 @@ describe('WLM Details Page', () => {
     cy.get('[data-testid="wlm-tab-settings"]').click();
     cy.contains('+ Add another rule').click();
 
-    cy.get('textarea[data-testid="indexInput"]').last().type(i1);
+    cy.get('[data-testid="indexInput"]').last().type(i1);
 
     cy.contains('button', /^Apply Changes$/)
       .should('not.be.disabled')
@@ -92,13 +92,12 @@ describe('WLM Details Page', () => {
     cy.wait('@listRules');
     cy.get('[data-testid="wlm-tab-settings"]').click();
 
-    cy.contains(i1, { timeout: 20000 }).should('exist');
+    cy.get('[data-testid="indexInput"]', { timeout: 20000 }).should(($els) => {
+      const values = Array.from($els, (el) => (el.value || '').trim());
+      expect(values).to.include(i1);
+    });
 
-    cy.get('textarea[data-testid="indexInput"]')
-      .last()
-      .type('{selectAll}{backspace}')
-      .type(i2)
-      .blur();
+    cy.get('[data-testid="indexInput"]').last().type('{selectAll}{backspace}').type(i2).blur();
 
     cy.contains('button', /^Apply Changes$/)
       .should('not.be.disabled')
@@ -109,8 +108,11 @@ describe('WLM Details Page', () => {
     cy.wait('@listRules');
     cy.get('[data-testid="wlm-tab-settings"]').click();
 
-    cy.contains(i2, { timeout: 20000 }).should('exist');
-    cy.contains(i1).should('not.exist');
+    cy.get('[data-testid="indexInput"]', { timeout: 20000 }).should(($els) => {
+      const values = Array.from($els, (el) => (el.value || '').trim());
+      expect(values).to.include(i2);
+      expect(values).to.not.include(i1);
+    });
 
     cy.get('button[aria-label="Delete rule"]', { timeout: 20000 }).last().click({ force: true });
 
@@ -123,7 +125,7 @@ describe('WLM Details Page', () => {
     cy.wait('@listRules');
     cy.get('[data-testid="wlm-tab-settings"]').click();
 
-    cy.get('textarea[data-testid="indexInput"]').should(($areas) => {
+    cy.get('[data-testid="indexInput"]').should(($areas) => {
       const values = Array.from($areas, (el) => (el.value || '').trim());
       expect(values).to.not.include(i2);
     });

--- a/cypress/e2e/wlm/7_WLM_details.cy.js
+++ b/cypress/e2e/wlm/7_WLM_details.cy.js
@@ -77,9 +77,9 @@ describe('WLM Details Page', () => {
     cy.get('[data-testid="wlm-tab-settings"]').click();
     cy.contains('+ Add another rule').click();
 
-    cy.get('textarea[placeholder="Enter username"]').last().type(u1);
-    cy.get('textarea[placeholder="Enter role"]').last().type(r1);
-    cy.get('textarea[data-testid="indexInput"]').last().type(i1);
+    cy.get('[placeholder="Enter username"]').last().type(u1);
+    cy.get('[placeholder="Enter role"]').last().type(r1);
+    cy.get('[data-testid="indexInput"]').last().type(i1);
 
     cy.contains('button', /^Apply Changes$/)
       .should('not.be.disabled')
@@ -90,25 +90,22 @@ describe('WLM Details Page', () => {
     cy.wait('@listRules');
     cy.get('[data-testid="wlm-tab-settings"]').click();
 
-    cy.contains(u1, { timeout: 20000 }).should('exist');
-    cy.contains(r1, { timeout: 20000 }).should('exist');
-    cy.contains(i1, { timeout: 20000 }).should('exist');
+    cy.get('[placeholder="Enter username"]', { timeout: 20000 }).should(($els) => {
+      const values = Array.from($els, (el) => (el.value || '').trim());
+      expect(values).to.include(u1);
+    });
+    cy.get('[placeholder="Enter role"]', { timeout: 20000 }).should(($els) => {
+      const values = Array.from($els, (el) => (el.value || '').trim());
+      expect(values).to.include(r1);
+    });
+    cy.get('[data-testid="indexInput"]', { timeout: 20000 }).should(($els) => {
+      const values = Array.from($els, (el) => (el.value || '').trim());
+      expect(values).to.include(i1);
+    });
 
-    cy.get('textarea[placeholder="Enter username"]')
-      .last()
-      .type('{selectAll}{backspace}')
-      .type(u2)
-      .blur();
-    cy.get('textarea[placeholder="Enter role"]')
-      .last()
-      .type('{selectAll}{backspace}')
-      .type(r2)
-      .blur();
-    cy.get('textarea[data-testid="indexInput"]')
-      .last()
-      .type('{selectAll}{backspace}')
-      .type(i2)
-      .blur();
+    cy.get('[placeholder="Enter username"]').last().type('{selectAll}{backspace}').type(u2).blur();
+    cy.get('[placeholder="Enter role"]').last().type('{selectAll}{backspace}').type(r2).blur();
+    cy.get('[data-testid="indexInput"]').last().type('{selectAll}{backspace}').type(i2).blur();
 
     cy.contains('button', /^Apply Changes$/)
       .should('not.be.disabled')
@@ -119,12 +116,21 @@ describe('WLM Details Page', () => {
     cy.wait('@listRules');
     cy.get('[data-testid="wlm-tab-settings"]').click();
 
-    cy.contains(u2, { timeout: 20000 }).should('exist');
-    cy.contains(r2, { timeout: 20000 }).should('exist');
-    cy.contains(i2, { timeout: 20000 }).should('exist');
-    cy.contains(u1).should('not.exist');
-    cy.contains(r1).should('not.exist');
-    cy.contains(i1).should('not.exist');
+    cy.get('[placeholder="Enter username"]', { timeout: 20000 }).should(($els) => {
+      const values = Array.from($els, (el) => (el.value || '').trim());
+      expect(values).to.include(u2);
+      expect(values).to.not.include(u1);
+    });
+    cy.get('[placeholder="Enter role"]', { timeout: 20000 }).should(($els) => {
+      const values = Array.from($els, (el) => (el.value || '').trim());
+      expect(values).to.include(r2);
+      expect(values).to.not.include(r1);
+    });
+    cy.get('[data-testid="indexInput"]', { timeout: 20000 }).should(($els) => {
+      const values = Array.from($els, (el) => (el.value || '').trim());
+      expect(values).to.include(i2);
+      expect(values).to.not.include(i1);
+    });
 
     cy.get('button[aria-label="Delete rule"]', { timeout: 20000 }).last().click({ force: true });
 
@@ -137,15 +143,15 @@ describe('WLM Details Page', () => {
     cy.wait('@listRules');
     cy.get('[data-testid="wlm-tab-settings"]').click();
 
-    cy.get('textarea[placeholder="Enter username"]').should(($areas) => {
+    cy.get('[placeholder="Enter username"]').should(($areas) => {
       const values = Array.from($areas, (el) => (el.value || '').trim());
       expect(values).to.not.include(u2);
     });
-    cy.get('textarea[placeholder="Enter role"]').should(($areas) => {
+    cy.get('[placeholder="Enter role"]').should(($areas) => {
       const values = Array.from($areas, (el) => (el.value || '').trim());
       expect(values).to.not.include(r2);
     });
-    cy.get('textarea[data-testid="indexInput"]').should(($areas) => {
+    cy.get('[data-testid="indexInput"]').should(($areas) => {
       const values = Array.from($areas, (el) => (el.value || '').trim());
       expect(values).to.not.include(i2);
     });

--- a/public/pages/WorkloadManagement/WLMCreate/WLMCreate.tsx
+++ b/public/pages/WorkloadManagement/WLMCreate/WLMCreate.tsx
@@ -8,7 +8,6 @@ import {
   EuiTitle,
   EuiSpacer,
   EuiFieldText,
-  EuiTextArea,
   EuiFormRow,
   EuiButton,
   EuiPanel,
@@ -16,6 +15,8 @@ import {
   EuiFieldNumber,
   EuiText,
   EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
 } from '@elastic/eui';
 import { useHistory } from 'react-router-dom';
 import { CoreStart, AppMountParameters } from 'opensearch-dashboards/public';
@@ -34,6 +35,7 @@ interface Rule {
   index: string;
   username: string;
   role: string;
+  description: string;
 }
 
 export const WLMCreate = ({
@@ -50,11 +52,12 @@ export const WLMCreate = ({
   const history = useHistory();
 
   const [name, setName] = useState('');
-  const [description, setDescription] = useState('');
   const [resiliencyMode, setResiliencyMode] = useState<'soft' | 'enforced'>();
   const [cpuThreshold, setCpuThreshold] = useState<number | undefined>();
   const [memThreshold, setMemThreshold] = useState<number | undefined>();
-  const [rules, setRules] = useState<Rule[]>([{ index: '', username: '', role: '' }]);
+  const [rules, setRules] = useState<Rule[]>([
+    { index: '', username: '', role: '', description: '' },
+  ]);
   const [indexErrors, setIndexErrors] = useState<Array<string | null>>([]);
   const [usernameErrors, setUsernameErrors] = useState<Array<string | null>>([]);
   const [roleErrors, setRoleErrors] = useState<Array<string | null>>([]);
@@ -158,7 +161,7 @@ export const WLMCreate = ({
           if (!hasIndexes && !hasUsernames && !hasRoles) return null;
 
           return {
-            description: (description || '-').trim(),
+            description: (rule.description || '-').trim(),
             ...(hasUsernames || hasRoles
               ? {
                   principal: {
@@ -288,22 +291,6 @@ export const WLMCreate = ({
             />
           </>
         </EuiFormRow>
-
-        <EuiFormRow>
-          <>
-            <EuiText size="m" style={{ fontWeight: 600 }}>
-              Description – Optional
-            </EuiText>
-            <EuiText size="xs" color="subdued" style={{ marginBottom: 4 }}>
-              Describe the purpose of the workload group.
-            </EuiText>
-            <EuiTextArea
-              placeholder="Describe the workload group"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-            />
-          </>
-        </EuiFormRow>
       </EuiPanel>
 
       <EuiSpacer size="l" />
@@ -345,90 +332,35 @@ export const WLMCreate = ({
               <p>Define your rule using any combination of username, role, or index.</p>
             </EuiText>
 
-            <EuiFormRow isInvalid={Boolean(indexErrors[idx])} error={indexErrors[idx]}>
-              <>
-                {/* ---- Username / Role (gated by showSecurity) ---- */}
-                <div>
-                  <EuiText size="m" style={{ fontWeight: 600 }}>
-                    Username
-                  </EuiText>
-                  <EuiFormRow
-                    fullWidth
-                    isInvalid={Boolean(usernameErrors[idx])}
-                    error={usernameErrors[idx] || undefined}
-                  >
-                    <EuiTextArea
-                      data-testid={`username-input-${idx}`}
-                      placeholder="Enter username"
-                      value={rule.username}
-                      onChange={(e) => {
-                        const value = e.target.value;
-
-                        const updatedRules = [...rules];
-                        const updatedErrors = [...usernameErrors];
-
-                        updatedRules[idx].username = value;
-                        updatedErrors[idx] =
-                          value.length > 100 ? 'Maximum total length is 100 characters.' : null;
-
-                        setRules(updatedRules);
-                        setUsernameErrors(updatedErrors);
-                      }}
-                      disabled={!showSecurity}
-                      isInvalid={Boolean(usernameErrors[idx])}
-                    />
-                  </EuiFormRow>
-                  <EuiText size="xs" color="subdued" style={{ marginBottom: 4 }}>
-                    {!showSecurity
-                      ? 'Username rules require data source ≥ 3.3.'
-                      : 'You can use (,) to add multiple usernames.'}
-                  </EuiText>
-                </div>
-
-                <div style={{ marginTop: 16 }}>
-                  <EuiText size="m" style={{ fontWeight: 600 }}>
-                    Role
-                  </EuiText>
-                  <EuiFormRow
-                    fullWidth
-                    isInvalid={Boolean(roleErrors[idx])}
-                    error={roleErrors[idx] || undefined}
-                  >
-                    <EuiTextArea
-                      data-testid={`role-input-${idx}`}
-                      placeholder="Enter role"
-                      value={rule.role}
-                      onChange={(e) => {
-                        const value = e.target.value;
-
-                        const updatedRules = [...rules];
-                        const updatedErrors = [...roleErrors];
-
-                        updatedRules[idx].role = value;
-                        updatedErrors[idx] =
-                          value.length > 100 ? 'Maximum total length is 100 characters.' : null;
-
-                        setRules(updatedRules);
-                        setRoleErrors(updatedErrors);
-                      }}
-                      disabled={!showSecurity}
-                      isInvalid={Boolean(roleErrors[idx])}
-                    />
-                  </EuiFormRow>
-                  <EuiText size="xs" color="subdued" style={{ marginBottom: 4 }}>
-                    {!showSecurity
-                      ? 'Role rules require data source ≥ 3.3.'
-                      : 'You can use (,) to add multiple roles.'}
-                  </EuiText>
-                </div>
-
-                {/* ---- Index (always available) ---- */}
-                <div style={{ marginTop: 16 }}>
-                  <EuiText size="m" style={{ fontWeight: 600 }}>
-                    Index wildcard
-                  </EuiText>
-                  <EuiSpacer size="s" />
-                  <EuiTextArea
+            <EuiFlexGroup gutterSize="m">
+              <EuiFlexItem>
+                {/* ---- Description (per-rule) ---- */}
+                <EuiText size="m" style={{ fontWeight: 600 }}>
+                  Description – Optional
+                </EuiText>
+                <EuiFieldText
+                  data-testid={`description-input-${idx}`}
+                  placeholder="Describe the rule"
+                  value={rule.description}
+                  onChange={(e) => {
+                    const updatedRules = [...rules];
+                    updatedRules[idx].description = e.target.value;
+                    setRules(updatedRules);
+                  }}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem>
+                {/* ---- Index wildcard ---- */}
+                <EuiText size="m" style={{ fontWeight: 600 }}>
+                  Index wildcard
+                </EuiText>
+                <EuiFormRow
+                  fullWidth
+                  isInvalid={Boolean(indexErrors[idx])}
+                  error={indexErrors[idx] || undefined}
+                  helpText="You can use (,) to add multiple indexes."
+                >
+                  <EuiFieldText
                     data-testid="indexInput"
                     placeholder="Enter index"
                     value={rule.index}
@@ -448,12 +380,88 @@ export const WLMCreate = ({
                     }}
                     isInvalid={Boolean(indexErrors[idx])}
                   />
-                  <EuiText size="xs" color="subdued" style={{ marginBottom: 4 }}>
-                    You can use (,) to add multiple indexes.
-                  </EuiText>
-                </div>
-              </>
-            </EuiFormRow>
+                </EuiFormRow>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+
+            <EuiSpacer size="m" />
+
+            <EuiFlexGroup gutterSize="m">
+              <EuiFlexItem>
+                {/* ---- Username (gated by showSecurity) ---- */}
+                <EuiText size="m" style={{ fontWeight: 600 }}>
+                  Username
+                </EuiText>
+                <EuiFormRow
+                  fullWidth
+                  isInvalid={Boolean(usernameErrors[idx])}
+                  error={usernameErrors[idx] || undefined}
+                  helpText={
+                    !showSecurity
+                      ? 'Username rules require data source ≥ 3.3.'
+                      : 'You can use (,) to add multiple usernames.'
+                  }
+                >
+                  <EuiFieldText
+                    data-testid={`username-input-${idx}`}
+                    placeholder="Enter username"
+                    value={rule.username}
+                    onChange={(e) => {
+                      const value = e.target.value;
+
+                      const updatedRules = [...rules];
+                      const updatedErrors = [...usernameErrors];
+
+                      updatedRules[idx].username = value;
+                      updatedErrors[idx] =
+                        value.length > 100 ? 'Maximum total length is 100 characters.' : null;
+
+                      setRules(updatedRules);
+                      setUsernameErrors(updatedErrors);
+                    }}
+                    disabled={!showSecurity}
+                    isInvalid={Boolean(usernameErrors[idx])}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                {/* ---- Role (gated by showSecurity) ---- */}
+                <EuiText size="m" style={{ fontWeight: 600 }}>
+                  Role
+                </EuiText>
+                <EuiFormRow
+                  fullWidth
+                  isInvalid={Boolean(roleErrors[idx])}
+                  error={roleErrors[idx] || undefined}
+                  helpText={
+                    !showSecurity
+                      ? 'Role rules require data source ≥ 3.3.'
+                      : 'You can use (,) to add multiple roles.'
+                  }
+                >
+                  <EuiFieldText
+                    data-testid={`role-input-${idx}`}
+                    placeholder="Enter role"
+                    value={rule.role}
+                    onChange={(e) => {
+                      const value = e.target.value;
+
+                      const updatedRules = [...rules];
+                      const updatedErrors = [...roleErrors];
+
+                      updatedRules[idx].role = value;
+                      updatedErrors[idx] =
+                        value.length > 100 ? 'Maximum total length is 100 characters.' : null;
+
+                      setRules(updatedRules);
+                      setRoleErrors(updatedErrors);
+                    }}
+                    disabled={!showSecurity}
+                    isInvalid={Boolean(roleErrors[idx])}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+            </EuiFlexGroup>
 
             <EuiSpacer size="s" />
 
@@ -469,7 +477,7 @@ export const WLMCreate = ({
 
         <EuiButton
           onClick={() => {
-            setRules((prev) => [...prev, { index: '', username: '', role: '' }]);
+            setRules((prev) => [...prev, { index: '', username: '', role: '', description: '' }]);
             setIndexErrors((prev) => [...prev, null]);
           }}
           disabled={rules.length >= 5}

--- a/public/pages/WorkloadManagement/WLMCreate/WLMCreate.tsx
+++ b/public/pages/WorkloadManagement/WLMCreate/WLMCreate.tsx
@@ -30,6 +30,7 @@ import {
   resolveDataSourceVersion,
   isSecurityAttributesSupported,
 } from '../../../utils/datasource-utils';
+import { AutoSizeTextArea } from '../auto_size_text_area';
 
 interface Rule {
   index: string;
@@ -338,7 +339,7 @@ export const WLMCreate = ({
                 <EuiText size="m" style={{ fontWeight: 600 }}>
                   Description – Optional
                 </EuiText>
-                <EuiFieldText
+                <AutoSizeTextArea
                   data-testid={`description-input-${idx}`}
                   placeholder="Describe the rule"
                   value={rule.description}
@@ -360,7 +361,7 @@ export const WLMCreate = ({
                   error={indexErrors[idx] || undefined}
                   helpText="You can use (,) to add multiple indexes."
                 >
-                  <EuiFieldText
+                  <AutoSizeTextArea
                     data-testid="indexInput"
                     placeholder="Enter index"
                     value={rule.index}
@@ -402,7 +403,7 @@ export const WLMCreate = ({
                       : 'You can use (,) to add multiple usernames.'
                   }
                 >
-                  <EuiFieldText
+                  <AutoSizeTextArea
                     data-testid={`username-input-${idx}`}
                     placeholder="Enter username"
                     value={rule.username}
@@ -439,7 +440,7 @@ export const WLMCreate = ({
                       : 'You can use (,) to add multiple roles.'
                   }
                 >
-                  <EuiFieldText
+                  <AutoSizeTextArea
                     data-testid={`role-input-${idx}`}
                     placeholder="Enter role"
                     value={rule.role}

--- a/public/pages/WorkloadManagement/WLMDetails/WLMDetails.test.tsx
+++ b/public/pages/WorkloadManagement/WLMDetails/WLMDetails.test.tsx
@@ -195,7 +195,7 @@ describe('WLMDetails Component', () => {
     renderComponent();
 
     expect(screen.getByText(/Workload group name/i)).toBeInTheDocument();
-    expect(screen.getByText(/Description/i)).toBeInTheDocument();
+    expect(screen.getByText(/Resiliency mode/i)).toBeInTheDocument();
     expect(screen.getByText(/CPU usage limit/i)).toBeInTheDocument();
     expect(screen.getByText(/Memory usage limit/i)).toBeInTheDocument();
   });
@@ -520,7 +520,7 @@ describe('WLMDetails Component', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('System default workload group')).toBeInTheDocument();
+      expect(screen.getAllByText('DEFAULT_WORKLOAD_GROUP').length).toBeGreaterThan(0);
       expect(screen.getByText('soft')).toBeInTheDocument();
     });
   });
@@ -725,7 +725,7 @@ describe('WLMDetails Component', () => {
       );
       const body = JSON.parse(options.body);
       expect(body).toEqual({
-        description: '-',
+        description: 'd',
         index_pattern: ['keep-updated-*'],
         workload_group: 'wg-123',
       });
@@ -778,7 +778,7 @@ describe('WLMDetails Component', () => {
     // Make unsaved change -> isSaved = false stops interval
     fireEvent.click(screen.getByTestId('wlm-tab-settings'));
     await waitFor(() => expect(screen.getByText(/Workload group settings/i)).toBeInTheDocument());
-    fireEvent.change(screen.getByPlaceholderText(/Describe the workload group/i), {
+    fireEvent.change(screen.getAllByPlaceholderText(/Describe the rule/i)[0], {
       target: { value: 'changed' },
     });
 

--- a/public/pages/WorkloadManagement/WLMDetails/WLMDetails.tsx
+++ b/public/pages/WorkloadManagement/WLMDetails/WLMDetails.tsx
@@ -37,6 +37,7 @@ import {
   isSecurityAttributesSupported,
 } from '../../../utils/datasource-utils';
 import { DEFAULT_WORKLOAD_GROUP } from '../../../../common/constants';
+import { AutoSizeTextArea } from '../auto_size_text_area';
 
 // === Constants & Types ===
 const DEFAULT_RESOURCE_LIMIT = 100;
@@ -857,7 +858,7 @@ export const WLMDetails = ({
                       <EuiText size="m" style={{ fontWeight: 600 }}>
                         Description – Optional
                       </EuiText>
-                      <EuiFieldText
+                      <AutoSizeTextArea
                         data-testid={`description-input-${idx}`}
                         placeholder="Describe the rule"
                         value={rule.description}
@@ -879,7 +880,7 @@ export const WLMDetails = ({
                         error={indexErrors[idx] || undefined}
                         helpText="You can use (,) to add multiple indexes."
                       >
-                        <EuiFieldText
+                        <AutoSizeTextArea
                           data-testid="indexInput"
                           placeholder="Enter Index"
                           value={rule.index}
@@ -953,7 +954,7 @@ export const WLMDetails = ({
                             : 'You can use (,) to add multiple usernames.'
                         }
                       >
-                        <EuiFieldText
+                        <AutoSizeTextArea
                           placeholder="Enter username"
                           value={rule.username}
                           onChange={(e) => {
@@ -1001,7 +1002,7 @@ export const WLMDetails = ({
                             : 'You can use (,) to add multiple roles.'
                         }
                       >
-                        <EuiFieldText
+                        <AutoSizeTextArea
                           placeholder="Enter role"
                           value={rule.role}
                           onChange={(e) => {

--- a/public/pages/WorkloadManagement/WLMDetails/WLMDetails.tsx
+++ b/public/pages/WorkloadManagement/WLMDetails/WLMDetails.tsx
@@ -23,7 +23,6 @@ import {
   EuiRadioGroup,
   EuiFieldNumber,
   EuiConfirmModal,
-  EuiTextArea,
   EuiButtonIcon,
 } from '@elastic/eui';
 import { useHistory, useLocation } from 'react-router-dom';
@@ -124,6 +123,7 @@ interface Rule {
   indexId: string;
   role: string;
   username: string;
+  description: string;
 }
 
 // === Main Component ===
@@ -152,10 +152,11 @@ export const WLMDetails = ({
   const [memoryLimit, setMemoryLimit] = useState<number | undefined>();
   const [originalCpuLimit, setOriginalCpuLimit] = useState<number | undefined>(undefined);
   const [originalMemoryLimit, setOriginalMemoryLimit] = useState<number | undefined>(undefined);
-  const [description, setDescription] = useState<string>();
-  const [rules, setRules] = useState<Rule[]>([{ index: '', indexId: '', role: '', username: '' }]);
+  const [rules, setRules] = useState<Rule[]>([
+    { index: '', indexId: '', role: '', username: '', description: '' },
+  ]);
   const [existingRules, setExistingRules] = useState<Rule[]>([
-    { index: '', indexId: '', role: '', username: '' },
+    { index: '', indexId: '', role: '', username: '', description: '' },
   ]);
   const [indexErrors, setIndexErrors] = useState<Array<string | null>>([]);
   const [isSaved, setIsSaved] = useState(true);
@@ -331,31 +332,19 @@ export const WLMDetails = ({
         const allRules = rulesRes?.rules ?? [];
 
         const matchedRules = allRules.filter((rule: any) => rule.workload_group === groupId);
-        setRules(
-          matchedRules.map((rule: any) => ({
-            index: (rule?.index_pattern ?? []).join(','),
-            indexId: rule.id,
-            role: (rule?.principal?.role ?? []).join(','),
-            username: (rule?.principal?.username ?? []).join(','),
-          }))
-        );
-
-        setExistingRules(
-          matchedRules.map((rule: any) => ({
-            index: (rule?.index_pattern ?? []).join(','),
-            indexId: rule.id,
-            role: (rule?.principal?.role ?? []).join(','),
-            username: (rule?.principal?.username ?? []).join(','),
-          }))
-        );
-
-        extractDescriptionFromRules(rulesRes, groupId);
+        const toRule = (rule: any): Rule => ({
+          index: (rule?.index_pattern ?? []).join(','),
+          indexId: rule.id,
+          role: (rule?.principal?.role ?? []).join(','),
+          username: (rule?.principal?.username ?? []).join(','),
+          description: rule?.description ?? '',
+        });
+        setRules(matchedRules.map(toRule));
+        setExistingRules(matchedRules.map(toRule));
       } catch (err) {
         console.error('Failed to fetch group stats', err);
         core.notifications.toasts.addDanger('Could not load rules.', err);
       }
-    } else {
-      setDescription('System default workload group');
     }
 
     try {
@@ -390,14 +379,6 @@ export const WLMDetails = ({
     }
   };
 
-  const extractDescriptionFromRules = (rulesRes: any, groupId: string) => {
-    const allRules = rulesRes?.body?.rules ?? [];
-
-    const matchedRule = allRules.find((rule: any) => rule.workload_group === groupId);
-
-    setDescription(matchedRule?.description ?? '-');
-  };
-
   // === Actions ===
   const splitCSV = (v?: string | null) =>
     (v ?? '')
@@ -414,8 +395,12 @@ export const WLMDetails = ({
 
   const buildRulePayload = (
     currentGroupId: string,
-    rule: { index?: string | null; username?: string | null; role?: string | null },
-    currentDescription?: string | null
+    rule: {
+      index?: string | null;
+      username?: string | null;
+      role?: string | null;
+      description?: string | null;
+    }
   ): RulePayload | null => {
     const indexPattern = splitCSV(rule.index);
     const usernames = showSecurity ? splitCSV(rule.username) : [];
@@ -428,7 +413,7 @@ export const WLMDetails = ({
     if (!hasIndexes && !hasUsernames && !hasRoles) return null; // skip blank rule
 
     return {
-      description: (currentDescription || '-').trim(),
+      description: (rule.description || '-').trim(),
       ...(hasUsernames || hasRoles
         ? {
             principal: {
@@ -493,7 +478,7 @@ export const WLMDetails = ({
       }
 
       for (const rule of rulesToCreate) {
-        const response = buildRulePayload(currentId!, rule, description);
+        const response = buildRulePayload(currentId!, rule);
         if (!response) continue;
 
         await core.http.put(`/api/_rules/workload_group`, {
@@ -504,7 +489,7 @@ export const WLMDetails = ({
       }
 
       for (const rule of rulesToUpdate) {
-        const response = buildRulePayload(currentId!, rule, description);
+        const response = buildRulePayload(currentId!, rule);
         if (!response) continue;
 
         await core.http.put(`/api/_rules/workload_group/${rule.indexId}`, {
@@ -659,12 +644,6 @@ export const WLMDetails = ({
               <strong>Workload group name</strong>
             </EuiText>
             <EuiText size="m">{workloadGroup.name}</EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiText size="s">
-              <strong>Description</strong>
-            </EuiText>
-            <EuiText size="s">{description}</EuiText>
           </EuiFlexItem>
           <EuiFlexItem>
             <EuiText size="s">
@@ -836,25 +815,6 @@ export const WLMDetails = ({
               </EuiTitle>
               <EuiHorizontalRule />
 
-              <EuiFormRow>
-                <>
-                  <EuiText size="m" style={{ fontWeight: 600 }}>
-                    Description – Optional
-                  </EuiText>
-                  <EuiText size="xs" color="subdued" style={{ marginBottom: 4 }}>
-                    Describe the purpose of the workload group.
-                  </EuiText>
-                  <EuiTextArea
-                    placeholder="Describe the workload group"
-                    value={description}
-                    onChange={(e) => {
-                      setDescription(e.target.value);
-                      setIsSaved(false);
-                    }}
-                  />
-                </>
-              </EuiFormRow>
-
               {/* Resiliency Mode */}
               <EuiFormRow>
                 <>
@@ -891,159 +851,193 @@ export const WLMDetails = ({
                   <EuiText size="s" style={{ marginTop: 8, marginBottom: 16 }}>
                     Define your rule using any combination of username, role, or index.
                   </EuiText>
-                  <div style={{ marginTop: 16 }}>
-                    <div>
+
+                  <EuiFlexGroup gutterSize="m">
+                    <EuiFlexItem>
                       <EuiText size="m" style={{ fontWeight: 600 }}>
-                        Username
+                        Description – Optional
                       </EuiText>
-                      <EuiTextArea
-                        placeholder="Enter username"
-                        value={rule.username}
+                      <EuiFieldText
+                        data-testid={`description-input-${idx}`}
+                        placeholder="Describe the rule"
+                        value={rule.description}
                         onChange={(e) => {
                           const updated = [...rules];
-                          updated[idx].username = e.target.value;
+                          updated[idx].description = e.target.value;
                           setRules(updated);
                           setIsSaved(false);
                         }}
-                        onBlur={(e) => {
-                          const originallyNonEmpty = !!existingRules[idx]?.username?.trim();
-                          const nowEmpty =
-                            (e.target.value ?? '')
-                              .split(',')
-                              .map((s) => s.trim())
-                              .filter(Boolean).length === 0;
-
-                          if (originallyNonEmpty && nowEmpty) {
-                            // revert to original and warn
-                            setRules((prev) => {
-                              const next = [...prev];
-                              next[idx] = {
-                                ...next[idx],
-                                username: existingRules[idx]?.username ?? '',
-                              };
-                              return next;
-                            });
-                            core.notifications.toasts.addWarning(
-                              'Username cannot be cleared once set.'
-                            );
-                          }
-                        }}
-                        disabled={!showSecurity}
                       />
-                      <EuiText size="xs" color="subdued" style={{ marginBottom: 4 }}>
-                        {!showSecurity
-                          ? 'Username rules require data source ≥ 3.3.'
-                          : 'You can use (,) to add multiple usernames.'}
-                      </EuiText>
-                    </div>
-
-                    <EuiSpacer size="s" />
-
-                    <EuiText size="m" style={{ fontWeight: 600 }}>
-                      Role
-                    </EuiText>
-                    <EuiTextArea
-                      placeholder="Enter role"
-                      value={rule.role}
-                      onChange={(e) => {
-                        const updated = [...rules];
-                        updated[idx].role = e.target.value;
-                        setRules(updated);
-                        setIsSaved(false);
-                      }}
-                      onBlur={(e) => {
-                        const originallyNonEmpty = !!existingRules[idx]?.role?.trim();
-                        const nowEmpty =
-                          (e.target.value ?? '')
-                            .split(',')
-                            .map((s) => s.trim())
-                            .filter(Boolean).length === 0;
-
-                        if (originallyNonEmpty && nowEmpty) {
-                          // revert to original and warn
-                          setRules((prev) => {
-                            const next = [...prev];
-                            next[idx] = { ...next[idx], role: existingRules[idx]?.role ?? '' };
-                            return next;
-                          });
-                          core.notifications.toasts.addWarning('Role cannot be cleared once set.');
-                        }
-                      }}
-                      disabled={!showSecurity}
-                    />
-                    <EuiText size="xs" color="subdued" style={{ marginBottom: 4 }}>
-                      {!showSecurity
-                        ? 'Role rules require data source ≥ 3.3.'
-                        : 'You can use (,) to add multiple roles.'}
-                    </EuiText>
-                  </div>
-
-                  <EuiSpacer size="s" />
-
-                  {/* Index */}
-                  <EuiFormRow isInvalid={Boolean(indexErrors[idx])} error={indexErrors[idx]}>
-                    <>
+                    </EuiFlexItem>
+                    <EuiFlexItem>
                       <EuiText size="m" style={{ fontWeight: 600 }}>
                         Index wildcard
                       </EuiText>
-                      <EuiSpacer size="s" />
-                      <EuiTextArea
-                        data-testid="indexInput"
-                        placeholder="Enter Index"
-                        value={rule.index}
-                        onChange={(e) => {
-                          const value = e.target.value;
-
-                          const updatedRules = [...rules];
-                          const updatedErrors = [...indexErrors];
-                          updatedRules[idx].index = value;
-
-                          let error: string | null = null;
-
-                          // split on commas, trim each segment
-                          const items = value.split(',').map((s) => s.trim());
-
-                          // 1) Any item too long?
-                          if (items.some((item) => item.length > 100)) {
-                            error = 'Index names must be 100 characters or fewer.';
-                          }
-                          // 2) Too many items?
-                          else if (items.length > 10) {
-                            error = 'You can specify at most 10 indexes per rule.';
-                          }
-
-                          updatedErrors[idx] = error;
-                          setRules(updatedRules);
-                          setIndexErrors(updatedErrors);
-                          setIsSaved(false);
-                        }}
-                        onBlur={(e) => {
-                          const originallyNonEmpty = !!existingRules[idx]?.index?.trim();
-                          const nowEmpty =
-                            (e.target.value ?? '')
-                              .split(',')
-                              .map((s) => s.trim())
-                              .filter(Boolean).length === 0;
-
-                          if (originallyNonEmpty && nowEmpty) {
-                            // revert to original and warn
-                            setRules((prev) => {
-                              const next = [...prev];
-                              next[idx] = { ...next[idx], index: existingRules[idx]?.index ?? '' };
-                              return next;
-                            });
-                            core.notifications.toasts.addWarning(
-                              'Index cannot be cleared once set.'
-                            );
-                          }
-                        }}
+                      <EuiFormRow
+                        fullWidth
                         isInvalid={Boolean(indexErrors[idx])}
-                      />
-                      <EuiText size="xs" color="subdued" style={{ marginBottom: 4 }}>
-                        You can use (,) to add multiple indexes.
+                        error={indexErrors[idx] || undefined}
+                        helpText="You can use (,) to add multiple indexes."
+                      >
+                        <EuiFieldText
+                          data-testid="indexInput"
+                          placeholder="Enter Index"
+                          value={rule.index}
+                          onChange={(e) => {
+                            const value = e.target.value;
+
+                            const updatedRules = [...rules];
+                            const updatedErrors = [...indexErrors];
+                            updatedRules[idx].index = value;
+
+                            let error: string | null = null;
+
+                            // split on commas, trim each segment
+                            const items = value.split(',').map((s) => s.trim());
+
+                            // 1) Any item too long?
+                            if (items.some((item) => item.length > 100)) {
+                              error = 'Index names must be 100 characters or fewer.';
+                            }
+                            // 2) Too many items?
+                            else if (items.length > 10) {
+                              error = 'You can specify at most 10 indexes per rule.';
+                            }
+
+                            updatedErrors[idx] = error;
+                            setRules(updatedRules);
+                            setIndexErrors(updatedErrors);
+                            setIsSaved(false);
+                          }}
+                          onBlur={(e) => {
+                            const originallyNonEmpty = !!existingRules[idx]?.index?.trim();
+                            const nowEmpty =
+                              (e.target.value ?? '')
+                                .split(',')
+                                .map((s) => s.trim())
+                                .filter(Boolean).length === 0;
+
+                            if (originallyNonEmpty && nowEmpty) {
+                              // revert to original and warn
+                              setRules((prev) => {
+                                const next = [...prev];
+                                next[idx] = {
+                                  ...next[idx],
+                                  index: existingRules[idx]?.index ?? '',
+                                };
+                                return next;
+                              });
+                              core.notifications.toasts.addWarning(
+                                'Index cannot be cleared once set.'
+                              );
+                            }
+                          }}
+                          isInvalid={Boolean(indexErrors[idx])}
+                        />
+                      </EuiFormRow>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+
+                  <EuiSpacer size="m" />
+
+                  <EuiFlexGroup gutterSize="m">
+                    <EuiFlexItem>
+                      <EuiText size="m" style={{ fontWeight: 600 }}>
+                        Username
                       </EuiText>
-                    </>
-                  </EuiFormRow>
+                      <EuiFormRow
+                        fullWidth
+                        helpText={
+                          !showSecurity
+                            ? 'Username rules require data source ≥ 3.3.'
+                            : 'You can use (,) to add multiple usernames.'
+                        }
+                      >
+                        <EuiFieldText
+                          placeholder="Enter username"
+                          value={rule.username}
+                          onChange={(e) => {
+                            const updated = [...rules];
+                            updated[idx].username = e.target.value;
+                            setRules(updated);
+                            setIsSaved(false);
+                          }}
+                          onBlur={(e) => {
+                            const originallyNonEmpty = !!existingRules[idx]?.username?.trim();
+                            const nowEmpty =
+                              (e.target.value ?? '')
+                                .split(',')
+                                .map((s) => s.trim())
+                                .filter(Boolean).length === 0;
+
+                            if (originallyNonEmpty && nowEmpty) {
+                              // revert to original and warn
+                              setRules((prev) => {
+                                const next = [...prev];
+                                next[idx] = {
+                                  ...next[idx],
+                                  username: existingRules[idx]?.username ?? '',
+                                };
+                                return next;
+                              });
+                              core.notifications.toasts.addWarning(
+                                'Username cannot be cleared once set.'
+                              );
+                            }
+                          }}
+                          disabled={!showSecurity}
+                        />
+                      </EuiFormRow>
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                      <EuiText size="m" style={{ fontWeight: 600 }}>
+                        Role
+                      </EuiText>
+                      <EuiFormRow
+                        fullWidth
+                        helpText={
+                          !showSecurity
+                            ? 'Role rules require data source ≥ 3.3.'
+                            : 'You can use (,) to add multiple roles.'
+                        }
+                      >
+                        <EuiFieldText
+                          placeholder="Enter role"
+                          value={rule.role}
+                          onChange={(e) => {
+                            const updated = [...rules];
+                            updated[idx].role = e.target.value;
+                            setRules(updated);
+                            setIsSaved(false);
+                          }}
+                          onBlur={(e) => {
+                            const originallyNonEmpty = !!existingRules[idx]?.role?.trim();
+                            const nowEmpty =
+                              (e.target.value ?? '')
+                                .split(',')
+                                .map((s) => s.trim())
+                                .filter(Boolean).length === 0;
+
+                            if (originallyNonEmpty && nowEmpty) {
+                              // revert to original and warn
+                              setRules((prev) => {
+                                const next = [...prev];
+                                next[idx] = {
+                                  ...next[idx],
+                                  role: existingRules[idx]?.role ?? '',
+                                };
+                                return next;
+                              });
+                              core.notifications.toasts.addWarning(
+                                'Role cannot be cleared once set.'
+                              );
+                            }
+                          }}
+                          disabled={!showSecurity}
+                        />
+                      </EuiFormRow>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
 
                   <EuiSpacer size="s" />
 
@@ -1064,7 +1058,10 @@ export const WLMDetails = ({
               ))}
               <EuiButton
                 onClick={() => {
-                  setRules([...rules, { index: '', indexId: '', role: '', username: '' }]);
+                  setRules([
+                    ...rules,
+                    { index: '', indexId: '', role: '', username: '', description: '' },
+                  ]);
                   setIndexErrors([...indexErrors, null]);
                   setIsSaved(false);
                 }}

--- a/public/pages/WorkloadManagement/auto_size_text_area.tsx
+++ b/public/pages/WorkloadManagement/auto_size_text_area.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useLayoutEffect, useRef } from 'react';
+import { EuiTextArea, EuiTextAreaProps } from '@elastic/eui';
+
+const MAX_HEIGHT_PX = 120;
+
+export const AutoSizeTextArea: React.FC<EuiTextAreaProps> = (props) => {
+  const ref = useRef<HTMLTextAreaElement | null>(null);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    const next = Math.min(el.scrollHeight, MAX_HEIGHT_PX);
+    el.style.height = `${next}px`;
+    el.style.overflowY = el.scrollHeight > MAX_HEIGHT_PX ? 'auto' : 'hidden';
+  }, [props.value]);
+
+  return (
+    <EuiTextArea
+      {...props}
+      inputRef={(node) => {
+        ref.current = node;
+        if (typeof props.inputRef === 'function') props.inputRef(node);
+      }}
+      rows={1}
+      resize="none"
+      style={{ minHeight: 40, ...(props.style || {}) }}
+    />
+  );
+};


### PR DESCRIPTION
### Bug fix
The previous WLM group `Description` field was semantically incorrect and nonfunctional. Workload group objects have no `description` attribute, so values typed into that field were never saved on the group. The dashboard worked around this by writing the string into the WLM rule description field. This PR makes `Description` properly display and save as a per-rule attribute instead of per-group.

### Other cosmetic changes
- Per-rule fields (Description, Username, Role, Index wildcard) collapsed from 4 stacked rows to a 2x2 grid (Description top-left, Index wildcard top-right, Username bottom-left, Role bottom-right). Auto-stacks to 4x1 on narrow viewports.
- Replaced multi-line text input with single-line input all four rule fields. This reduces the vertical page size drastically.

### Screenshots

Old Create Group Page
<img width="1582" height="1574" alt="Screenshot 2026-05-27 at 8 35 38 AM" src="https://github.com/user-attachments/assets/303d39f3-a429-4898-992d-ec3034965b33" />

New Create Group Page
<img width="1582" height="1265" alt="Screenshot 2026-05-27 at 8 36 24 AM" src="https://github.com/user-attachments/assets/688a9691-0b24-4067-8379-4fbc5f0ae4cc" />

Old Group Details Page
<img width="1578" height="1573" alt="Screenshot 2026-05-26 at 8 24 34 PM" src="https://github.com/user-attachments/assets/2b203916-d0f2-45b1-afec-eac7cec87da1" />

New Group Details Page
<img width="1576" height="1326" alt="Screenshot 2026-05-26 at 8 14 29 PM" src="https://github.com/user-attachments/assets/16d8dd85-3f4e-4709-ad3e-048a58a21eaf" />

### Issues Resolved
Resolves #525

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
