### PR TITLE
Detect security plugin presence and improve WLM rule error message

### DIFF
--- a/cypress/e2e/wlm-no-security/8_WLM_create.cy.js
+++ b/cypress/e2e/wlm-no-security/8_WLM_create.cy.js
@@ -92,8 +92,12 @@ describe('WLM Create Page', () => {
     cy.get('[data-testid="name-input"]').type(groupName);
     cy.contains('Soft').click();
     cy.get('[data-testid="indexInput"]').type(' , , , ');
-    cy.get('[placeholder="Enter username"]').type(' , , ');
-    cy.get('[placeholder="Enter role"]').type(' , ');
+    // Username/Role inputs are gated off when the OpenSearch Security plugin is
+    // not installed (the case for this no-security suite). Use { force: true } so
+    // we still exercise the "commas-only payload not sent" path that is the
+    // actual subject of this test.
+    cy.get('[placeholder="Enter username"]').type(' , , ', { force: true });
+    cy.get('[placeholder="Enter role"]').type(' , ', { force: true });
     cy.get('[data-testid="memory-threshold-input"]').clear().type('1');
     cy.get('button').contains('Create workload group').click();
     cy.wait('@createGroup');

--- a/public/pages/WorkloadManagement/WLMCreate/WLMCreate.test.tsx
+++ b/public/pages/WorkloadManagement/WLMCreate/WLMCreate.test.tsx
@@ -17,6 +17,18 @@ const mockAddDanger = jest.fn();
 
 const coreMock = {
   http: {
+    get: jest.fn().mockImplementation((path: string) => {
+      if (path === '/api/cat/plugins') {
+        return Promise.resolve({
+          ok: true,
+          response: [{ component: 'opensearch-security' }, { component: 'workload-management' }],
+        });
+      }
+      if (path === '/api/_plugins/_security/health') {
+        return Promise.resolve({ ok: true, available: true });
+      }
+      return Promise.resolve({});
+    }),
     put: jest.fn(),
     delete: jest.fn(),
   },
@@ -704,6 +716,149 @@ describe('WLMCreate – group settings', () => {
       expect(createCall).toBeDefined();
       const sentBody = JSON.parse(createCall[1].body);
       expect(sentBody.settings).toBeUndefined();
+    });
+  });
+});
+
+describe('WLMCreate – security plugin gating', () => {
+  const fillRequiredFields = async () => {
+    await userEvent.type(screen.getByTestId('name-input'), 'MyGroup');
+    fireEvent.change(screen.getByTestId('cpu-threshold-input'), { target: { value: '50' } });
+    await userEvent.click(screen.getByLabelText(/Soft/i));
+  };
+
+  // setSecurityProbe permanently replaces coreMock.http.get; restore the original
+  // reference afterward so subsequent describes don't pick up our impl.
+  const originalHttpGet = coreMock.http.get;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    (coreMock.http as any).get = originalHttpGet;
+  });
+
+  const setSecurityProbe = (impl: (path: string) => Promise<any>) => {
+    (coreMock.http as any).get = jest.fn(impl);
+  };
+
+  const renderWith = () =>
+    render(
+      <MemoryRouter>
+        <DataSourceContext.Provider
+          value={{ dataSource: mockDataSource, setDataSource: jest.fn() }}
+        >
+          <WLMCreate
+            core={coreMock as any}
+            depsStart={depsMock as any}
+            params={mockParams}
+            dataSourceManagement={mockDataSourceManagement}
+          />
+        </DataSourceContext.Provider>
+      </MemoryRouter>
+    );
+
+  it('disables Username and Role inputs and shows helper text when Security plugin is missing', async () => {
+    setSecurityProbe((path) => {
+      if (path === '/api/cat/plugins') {
+        return Promise.resolve({ ok: true, response: [{ component: 'workload-management' }] });
+      }
+      return Promise.resolve({});
+    });
+
+    renderWith();
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/username/i)).toBeDisabled();
+      expect(screen.getByPlaceholderText(/^enter role$/i)).toBeDisabled();
+    });
+    expect(screen.getAllByText(/Requires the OpenSearch Security plugin/i).length).toBeGreaterThan(
+      0
+    );
+  });
+
+  it('disables Username and Role inputs when Security plugin is installed but disabled', async () => {
+    setSecurityProbe((path) => {
+      if (path === '/api/cat/plugins') {
+        return Promise.resolve({
+          ok: true,
+          response: [{ component: 'opensearch-security' }],
+        });
+      }
+      if (path === '/api/_plugins/_security/health') {
+        return Promise.resolve({ ok: true, available: false });
+      }
+      return Promise.resolve({});
+    });
+
+    renderWith();
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/username/i)).toBeDisabled();
+    });
+  });
+
+  it('keeps Username and Role enabled when Security plugin is active', async () => {
+    setSecurityProbe((path) => {
+      if (path === '/api/cat/plugins') {
+        return Promise.resolve({
+          ok: true,
+          response: [{ component: 'opensearch-security' }],
+        });
+      }
+      if (path === '/api/_plugins/_security/health') {
+        return Promise.resolve({ ok: true, available: true });
+      }
+      return Promise.resolve({});
+    });
+
+    renderWith();
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/username/i)).not.toBeDisabled();
+      expect(screen.getByPlaceholderText(/^enter role$/i)).not.toBeDisabled();
+    });
+  });
+
+  it('does not disable Username/Role when the probe is inconclusive (status: unknown)', async () => {
+    setSecurityProbe(() => Promise.reject(new Error('network')));
+
+    renderWith();
+
+    // Stays enabled — better than over-blocking.
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/username/i)).not.toBeDisabled();
+    });
+  });
+
+  it('rewrites the cryptic principal save error from the rule PUT to point at the Security plugin', async () => {
+    // The cluster only emits the "principal is not a valid attribute" error from
+    // /_rules/workload_group, never from the workload_group create itself. Simulate
+    // that realistic flow: the group create succeeds, the rule PUT rejects.
+    setSecurityProbe(() => Promise.reject(new Error('network'))); // probe inconclusive → form stays open
+
+    coreMock.http.put.mockResolvedValueOnce({ _id: 'gid-realistic', name: 'gid-realistic' });
+    coreMock.http.put.mockRejectedValueOnce({
+      body: {
+        message:
+          '[x_content_parse_exception] principal is not a valid attribute within the workload_group feature.',
+      },
+    });
+    coreMock.http.delete.mockResolvedValue({ ok: true });
+
+    renderWith();
+    await fillRequiredFields();
+    // Type a username so the rule actually has a principal payload
+    await userEvent.type(screen.getByPlaceholderText(/username/i), 'alice');
+
+    fireEvent.click(screen.getByRole('button', { name: /create workload group/i }));
+
+    await waitFor(() => {
+      expect(mockAddDanger).toHaveBeenCalledWith({
+        title: 'Rule creation failed',
+        text: expect.stringMatching(/OpenSearch Security plugin/i),
+      });
     });
   });
 });

--- a/public/pages/WorkloadManagement/WLMCreate/WLMCreate.tsx
+++ b/public/pages/WorkloadManagement/WLMCreate/WLMCreate.tsx
@@ -30,6 +30,10 @@ import {
   resolveDataSourceVersion,
   isSecurityAttributesSupported,
   isWlmGroupSettingsSupported,
+  getSecurityPluginStatus,
+  describeRuleSaveError,
+  getSecurityFieldDisabledHelpText,
+  SecurityPluginStatus,
 } from '../../../utils/datasource-utils';
 import { AutoSizeTextArea } from '../auto_size_text_area';
 import { WLMSettingsForm } from '../WLMSettings/wlm_settings_form';
@@ -76,10 +80,21 @@ export const WLMCreate = ({
   const { dataSource, setDataSource } = useContext(DataSourceContext)!;
   const isMounted = useRef(true);
   const [dsVersion, setDsVersion] = useState<string | undefined>();
+  const [securityStatus, setSecurityStatus] = useState<SecurityPluginStatus>('unknown');
   const dataSourceEnabled = !!depsStart?.dataSource?.dataSourceEnabled;
-  const showSecurity = !dataSourceEnabled || isSecurityAttributesSupported(dsVersion);
+  const versionSupportsSecurity = !dataSourceEnabled || isSecurityAttributesSupported(dsVersion);
+  const securityPluginMissing = securityStatus === 'unavailable';
+  const showSecurity = versionSupportsSecurity && !securityPluginMissing;
   const showGroupSettings = !dataSourceEnabled || isWlmGroupSettingsSupported(dsVersion);
   const [settingsDraft, setSettingsDraft] = useState<WlmGroupSettingsDraft>(emptyDraft());
+  const securityDisabledHelpText = getSecurityFieldDisabledHelpText(
+    'username',
+    versionSupportsSecurity
+  );
+  const securityRoleDisabledHelpText = getSecurityFieldDisabledHelpText(
+    'role',
+    versionSupportsSecurity
+  );
 
   const isFormValid =
     name.trim() !== '' &&
@@ -114,6 +129,20 @@ export const WLMCreate = ({
     (async () => {
       const v = await resolveDataSourceVersion(core, dataSource);
       if (!cancelled) setDsVersion(v);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [core, dataSource?.id]);
+
+  useEffect(() => {
+    let cancelled = false;
+    // Reset to 'unknown' on dataSource change so a previous cluster's 'available'
+    // result doesn't carry over and leave the form fail-open while the new probe runs.
+    setSecurityStatus('unknown');
+    (async () => {
+      const status = await getSecurityPluginStatus(core.http, dataSource?.id);
+      if (!cancelled) setSecurityStatus(status);
     })();
     return () => {
       cancelled = true;
@@ -170,6 +199,9 @@ export const WLMCreate = ({
       const payloads = (rules ?? [])
         .map((rule) => {
           const indexPattern = splitCSV(rule.index);
+          // Always include what the user typed: dropping principal data based on a
+          // racing probe result would silently lose work. If the cluster ultimately
+          // rejects the principal, describeRuleSaveError humanizes the response.
           const usernames = splitCSV(rule.username);
           const roles = splitCSV(rule.role);
 
@@ -234,14 +266,13 @@ export const WLMCreate = ({
         } catch (cleanupErr: any) {
           core.notifications.toasts.addDanger({
             title: 'Rule creation failed; group rollback also failed',
-            text: cleanupErr?.body?.message || cleanupErr?.message || 'Check server logs.',
+            text: describeRuleSaveError(cleanupErr) || 'Check server logs.',
           });
         }
 
         core.notifications.toasts.addDanger({
           title: 'Rule creation failed',
-          text:
-            ruleErr?.body?.message || ruleErr?.message || 'Rolled back created rules and group.',
+          text: describeRuleSaveError(ruleErr) || 'Rolled back created rules and group.',
         });
         return;
       }
@@ -249,7 +280,7 @@ export const WLMCreate = ({
       console.error(err);
       core.notifications.toasts.addDanger({
         title: 'Failed to create workload group and rules',
-        text: err?.body?.message || err?.message || 'Something went wrong',
+        text: describeRuleSaveError(err) || 'Something went wrong',
       });
     } finally {
       if (isMounted.current) setLoading(false);
@@ -416,7 +447,7 @@ export const WLMCreate = ({
                   error={usernameErrors[idx] || undefined}
                   helpText={
                     !showSecurity
-                      ? 'Username rules require data source ≥ 3.3.'
+                      ? securityDisabledHelpText
                       : 'You can use (,) to add multiple usernames.'
                   }
                 >
@@ -437,7 +468,9 @@ export const WLMCreate = ({
                       setRules(updatedRules);
                       setUsernameErrors(updatedErrors);
                     }}
-                    disabled={!showSecurity}
+                    // Stay editable if the user has already typed something so they can clear
+                    // it after a probe flips to 'unavailable' mid-flight.
+                    disabled={!showSecurity && !rule.username}
                     isInvalid={Boolean(usernameErrors[idx])}
                   />
                 </EuiFormRow>
@@ -453,7 +486,7 @@ export const WLMCreate = ({
                   error={roleErrors[idx] || undefined}
                   helpText={
                     !showSecurity
-                      ? 'Role rules require data source ≥ 3.3.'
+                      ? securityRoleDisabledHelpText
                       : 'You can use (,) to add multiple roles.'
                   }
                 >
@@ -474,7 +507,7 @@ export const WLMCreate = ({
                       setRules(updatedRules);
                       setRoleErrors(updatedErrors);
                     }}
-                    disabled={!showSecurity}
+                    disabled={!showSecurity && !rule.role}
                     isInvalid={Boolean(roleErrors[idx])}
                   />
                 </EuiFormRow>

--- a/public/pages/WorkloadManagement/WLMDetails/WLMDetails.security.test.tsx
+++ b/public/pages/WorkloadManagement/WLMDetails/WLMDetails.security.test.tsx
@@ -1,0 +1,266 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom';
+import { CoreStart } from 'opensearch-dashboards/public';
+import { WLMDetails } from './WLMDetails';
+import { DataSourceContext } from '../WorkloadManagement';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({ push: jest.fn() }),
+}));
+
+jest.mock('../../../components/PageHeader', () => ({
+  PageHeader: () => <div data-testid="mock-page-header">Mocked PageHeader</div>,
+}));
+
+const MockDataSourceMenu = (_props: any) => <div>Mocked Data Source Menu</div>;
+
+const mockDataSourceManagement = {
+  ui: {
+    getDataSourceMenu: jest.fn(() => MockDataSourceMenu),
+  },
+} as any;
+
+const mockParams = {
+  setHeaderActionMenu: jest.fn(),
+} as any;
+
+const groupResponse = {
+  workload_groups: [
+    {
+      _id: 'wg-123',
+      name: 'test-group',
+      resource_limits: { cpu: 0.5, memory: 0.5 },
+      resiliency_mode: 'SOFT',
+    },
+  ],
+};
+
+// dataSourceEnabled=false bypasses the version gate, isolating the
+// security-plugin probe path under test.
+const noDsDeps = { dataSource: { dataSourceEnabled: false } } as any;
+const localDataSource = { id: '', name: '', label: '' } as any;
+
+const buildCore = (): CoreStart =>
+  (({
+    http: {
+      get: jest.fn(),
+      put: jest.fn(),
+      delete: jest.fn(),
+    },
+    notifications: {
+      toasts: {
+        addSuccess: jest.fn(),
+        addDanger: jest.fn(),
+        addWarning: jest.fn(),
+      },
+    },
+    chrome: {
+      setBreadcrumbs: jest.fn(),
+    },
+    application: {
+      navigateToApp: jest.fn(),
+      getUrlForApp: jest.fn(() => '/app/query-insights'),
+    },
+    savedObjects: {
+      client: {
+        get: jest.fn().mockResolvedValue({ attributes: { dataSourceVersion: '3.3.0' } }),
+      },
+    },
+  } as unknown) as CoreStart);
+
+const setRouting = (core: CoreStart, securityImpl: (path: string) => Promise<any> | undefined) => {
+  (core.http.get as jest.Mock).mockImplementation((path: string) => {
+    const overridden = securityImpl(path);
+    if (overridden) return overridden;
+    if (path.startsWith('/api/_wlm/workload_group/test-group')) {
+      return Promise.resolve(groupResponse);
+    }
+    if (path === '/api/_rules/workload_group') {
+      return Promise.resolve({
+        rules: [
+          {
+            id: 'r1',
+            description: 'd',
+            index_pattern: ['keep-*'],
+            workload_group: 'wg-123',
+          },
+        ],
+      });
+    }
+    if (path.startsWith('/api/_wlm/stats')) {
+      // Match the real stats shape ({ [nodeId]: { workload_groups: { ... } } })
+      // so updateStats() iterates cleanly without throwing.
+      return Promise.resolve({
+        'node-1': {
+          workload_groups: {
+            'wg-123': {
+              cpu: { current_usage: 0 },
+              memory: { current_usage: 0 },
+            },
+          },
+        },
+      });
+    }
+    return Promise.resolve({ body: {} });
+  });
+};
+
+const renderWith = (core: CoreStart, name = 'test-group') => {
+  render(
+    <MemoryRouter initialEntries={[`/wlm-details?name=${name}`]}>
+      <DataSourceContext.Provider value={{ dataSource: localDataSource, setDataSource: jest.fn() }}>
+        <WLMDetails
+          core={core}
+          depsStart={noDsDeps}
+          params={mockParams}
+          dataSourceManagement={mockDataSourceManagement}
+        />
+      </DataSourceContext.Provider>
+    </MemoryRouter>
+  );
+};
+
+describe('WLMDetails — security plugin gating', () => {
+  it('disables Username and Role inputs when Security plugin is not installed', async () => {
+    const core = buildCore();
+    setRouting(core, (path) => {
+      if (path === '/api/cat/plugins') {
+        return Promise.resolve({ ok: true, response: [{ component: 'workload-management' }] });
+      }
+      return undefined;
+    });
+
+    renderWith(core);
+    fireEvent.click(screen.getByTestId('wlm-tab-settings'));
+    await waitFor(() => expect(screen.getByText(/Workload group settings/i)).toBeInTheDocument());
+
+    await waitFor(() => {
+      const inputs = screen.getAllByPlaceholderText('Enter username');
+      expect(inputs[0]).toBeDisabled();
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryAllByText(/Requires the OpenSearch Security plugin/i).length
+      ).toBeGreaterThan(0);
+    });
+  });
+
+  it('disables Username/Role when Security plugin is installed but disabled', async () => {
+    const core = buildCore();
+    setRouting(core, (path) => {
+      if (path === '/api/cat/plugins') {
+        return Promise.resolve({
+          ok: true,
+          response: [{ component: 'opensearch-security' }],
+        });
+      }
+      if (path === '/api/_plugins/_security/health') {
+        return Promise.resolve({ ok: true, available: false });
+      }
+      return undefined;
+    });
+
+    renderWith(core);
+    fireEvent.click(screen.getByTestId('wlm-tab-settings'));
+    await waitFor(() => expect(screen.getByText(/Workload group settings/i)).toBeInTheDocument());
+
+    await waitFor(async () => {
+      const usernameInput = await screen.findByPlaceholderText('Enter username');
+      expect(usernameInput).toBeDisabled();
+    });
+  });
+
+  it('keeps Username/Role enabled when Security plugin is active', async () => {
+    const core = buildCore();
+    setRouting(core, (path) => {
+      if (path === '/api/cat/plugins') {
+        return Promise.resolve({
+          ok: true,
+          response: [{ component: 'opensearch-security' }],
+        });
+      }
+      if (path === '/api/_plugins/_security/health') {
+        return Promise.resolve({ ok: true, available: true });
+      }
+      return undefined;
+    });
+
+    renderWith(core);
+    fireEvent.click(screen.getByTestId('wlm-tab-settings'));
+    await waitFor(() => expect(screen.getByText(/Workload group settings/i)).toBeInTheDocument());
+
+    await waitFor(async () => {
+      const usernameInput = await screen.findByPlaceholderText('Enter username');
+      expect(usernameInput).not.toBeDisabled();
+    });
+  });
+
+  it('rewrites the cryptic principal save error from the rule PUT to point at the Security plugin', async () => {
+    // The cluster only emits the principal error from /_rules/workload_group, and only
+    // when the payload actually contains principal data. Simulate the realistic flow:
+    //   1. probe is inconclusive ('unknown') so the form does not over-block
+    //   2. user types a username on a rule
+    //   3. group settings PUT succeeds, rule PUT rejects with the cryptic message
+    const core = buildCore();
+    setRouting(core, (path) => {
+      if (path === '/api/cat/plugins') return Promise.reject(new Error('inconclusive'));
+      if (path === '/api/_plugins/_security/health') {
+        return Promise.reject(new Error('inconclusive'));
+      }
+      return undefined;
+    });
+
+    (core.http.put as jest.Mock)
+      .mockResolvedValueOnce({}) // group settings PUT succeeds
+      .mockRejectedValueOnce({
+        body: {
+          message:
+            '[x_content_parse_exception] principal is not a valid attribute within the workload_group feature.',
+        },
+      });
+
+    renderWith(core);
+    fireEvent.click(screen.getByTestId('wlm-tab-settings'));
+    await waitFor(() => expect(screen.getByText(/Workload group settings/i)).toBeInTheDocument());
+
+    // Probe is 'unknown' → fields stay enabled. Populate principal so the rule PUT
+    // payload actually carries one.
+    const usernameInput = await screen.findByPlaceholderText('Enter username');
+    await waitFor(() => expect(usernameInput).not.toBeDisabled());
+    fireEvent.change(usernameInput, { target: { value: 'alice' } });
+
+    const applyButton = await screen.findByRole('button', { name: /apply changes/i });
+    await waitFor(() => expect(applyButton).not.toBeDisabled());
+    fireEvent.click(applyButton);
+
+    await waitFor(() => {
+      expect(core.notifications.toasts.addDanger).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Failed to save changes',
+          text: expect.stringMatching(/OpenSearch Security plugin/i),
+        })
+      );
+    });
+
+    // The rule PUT body must include principal.username — proving the test exercises
+    // the documented intent rather than passing on an empty payload.
+    const ruleCalls = (core.http.put as jest.Mock).mock.calls.filter(
+      ([url]) => url === '/api/_rules/workload_group/r1'
+    );
+    expect(ruleCalls.length).toBeGreaterThan(0);
+    const body = JSON.parse(ruleCalls[0][1].body);
+    expect(body.principal).toEqual(expect.objectContaining({ username: ['alice'] }));
+  });
+});

--- a/public/pages/WorkloadManagement/WLMDetails/WLMDetails.tsx
+++ b/public/pages/WorkloadManagement/WLMDetails/WLMDetails.tsx
@@ -36,6 +36,10 @@ import {
   resolveDataSourceVersion,
   isSecurityAttributesSupported,
   isWlmGroupSettingsSupported,
+  getSecurityPluginStatus,
+  describeRuleSaveError,
+  getSecurityFieldDisabledHelpText,
+  SecurityPluginStatus,
 } from '../../../utils/datasource-utils';
 import { DEFAULT_WORKLOAD_GROUP } from '../../../../common/constants';
 import { AutoSizeTextArea } from '../auto_size_text_area';
@@ -189,11 +193,22 @@ export const WLMDetails = ({
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const { dataSource, setDataSource } = useContext(DataSourceContext)!;
   const [dsVersion, setDsVersion] = useState<string | undefined>();
+  const [securityStatus, setSecurityStatus] = useState<SecurityPluginStatus>('unknown');
   const dataSourceEnabled = !!depsStart?.dataSource?.dataSourceEnabled;
-  const showSecurity = !dataSourceEnabled || isSecurityAttributesSupported(dsVersion);
+  const versionSupportsSecurity = !dataSourceEnabled || isSecurityAttributesSupported(dsVersion);
+  const securityPluginMissing = securityStatus === 'unavailable';
+  const showSecurity = versionSupportsSecurity && !securityPluginMissing;
   const showGroupSettings = !dataSourceEnabled || isWlmGroupSettingsSupported(dsVersion);
   const [, setOriginalSettings] = useState<WlmGroupSettings>({});
   const [settingsDraft, setSettingsDraft] = useState<WlmGroupSettingsDraft>(emptyDraft());
+  const securityDisabledHelpText = getSecurityFieldDisabledHelpText(
+    'username',
+    versionSupportsSecurity
+  );
+  const securityRoleDisabledHelpText = getSecurityFieldDisabledHelpText(
+    'role',
+    versionSupportsSecurity
+  );
 
   // Discards stale fetch responses that resolve after newer fetches or after
   // the user has started editing — without this guard, a slow GET that lands
@@ -262,6 +277,25 @@ export const WLMDetails = ({
     };
   }, [core, dataSource?.id]);
 
+  useEffect(() => {
+    // No groupName means fetchGroupDetails will redirect away — skip the probe.
+    if (!groupName) return;
+    let cancelled = false;
+    // Reset to 'unknown' on dataSource change so a previous cluster's 'available'
+    // result doesn't carry over and leave the form fail-open while the new probe runs.
+    // Note: deps intentionally exclude `groupName` — navigating between groups on the
+    // same cluster should not flicker the security gate.
+    setSecurityStatus('unknown');
+    (async () => {
+      const status = await getSecurityPluginStatus(core.http, dataSource?.id);
+      if (!cancelled) setSecurityStatus(status);
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [core, dataSource?.id]);
+
   // Do the initial fetch when inputs change
   useEffect(() => {
     fetchGroupDetails();
@@ -275,10 +309,20 @@ export const WLMDetails = ({
     const interval = setInterval(() => {
       fetchGroupDetails();
       updateStats();
+      // Refresh the security plugin gate too so a long-lived form reflects cluster
+      // changes (admin enables/disables the plugin) instead of staying stale.
+      let cancelled = false;
+      (async () => {
+        const status = await getSecurityPluginStatus(core.http, dataSource?.id);
+        if (!cancelled) setSecurityStatus(status);
+      })();
+      return () => {
+        cancelled = true;
+      };
     }, 60000);
 
     return () => clearInterval(interval);
-  }, [isSaved, groupName, dataSource]);
+  }, [isSaved, groupName, dataSource, core]);
 
   // === Data Fetching ===
   const fetchDefaultGroupDetails = () => {
@@ -454,8 +498,12 @@ export const WLMDetails = ({
     }
   ): RulePayload | null => {
     const indexPattern = splitCSV(rule.index);
-    const usernames = showSecurity ? splitCSV(rule.username) : [];
-    const roles = showSecurity ? splitCSV(rule.role) : [];
+    // Always include any existing principal values: stripping them silently when the
+    // probe says 'unavailable' would discard data the user (or a previous edit) loaded
+    // from the cluster. If the cluster genuinely rejects the principal, the friendlier
+    // describeRuleSaveError surfaces that to the user.
+    const usernames = splitCSV(rule.username);
+    const roles = splitCSV(rule.role);
 
     const hasIndexes = indexPattern.length > 0;
     const hasUsernames = usernames.length > 0;
@@ -589,8 +637,11 @@ export const WLMDetails = ({
       await fetchGroupDetails();
       await updateStats();
     } catch (err) {
-      const errorMessage = err?.body?.message || err?.message || String(err);
-      core.notifications.toasts.addDanger(`Failed to save changes: ${errorMessage}`);
+      console.error(err);
+      core.notifications.toasts.addDanger({
+        title: 'Failed to save changes',
+        text: describeRuleSaveError(err) || 'Something went wrong',
+      });
     }
   };
 
@@ -603,9 +654,10 @@ export const WLMDetails = ({
       history.push(WLM_MAIN);
     } catch (err) {
       console.error('Failed to delete group:', err);
-      core.notifications.toasts.addDanger(
-        `Failed to delete group: ${err.body?.message || err.message}`
-      );
+      core.notifications.toasts.addDanger({
+        title: 'Failed to delete group',
+        text: describeRuleSaveError(err) || 'Something went wrong',
+      });
     }
   };
 
@@ -1026,7 +1078,7 @@ export const WLMDetails = ({
                         fullWidth
                         helpText={
                           !showSecurity
-                            ? 'Username rules require data source ≥ 3.3.'
+                            ? securityDisabledHelpText
                             : 'You can use (,) to add multiple usernames.'
                         }
                       >
@@ -1062,7 +1114,9 @@ export const WLMDetails = ({
                               );
                             }
                           }}
-                          disabled={!showSecurity}
+                          // Stay editable if the rule already has a username so the user
+                          // can clear it after the probe flips to 'unavailable'.
+                          disabled={!showSecurity && !rule.username}
                         />
                       </EuiFormRow>
                     </EuiFlexItem>
@@ -1074,7 +1128,7 @@ export const WLMDetails = ({
                         fullWidth
                         helpText={
                           !showSecurity
-                            ? 'Role rules require data source ≥ 3.3.'
+                            ? securityRoleDisabledHelpText
                             : 'You can use (,) to add multiple roles.'
                         }
                       >
@@ -1110,7 +1164,7 @@ export const WLMDetails = ({
                               );
                             }
                           }}
-                          disabled={!showSecurity}
+                          disabled={!showSecurity && !rule.role}
                         />
                       </EuiFormRow>
                     </EuiFlexItem>

--- a/public/utils/datasource-utils.test.ts
+++ b/public/utils/datasource-utils.test.ts
@@ -19,7 +19,9 @@
  */
 
 import {
+  describeRuleSaveError,
   getDataSourceFromUrl,
+  getSecurityPluginStatus,
   isDataSourceCompatible,
   isWLMDataSourceCompatible,
 } from './datasource-utils';
@@ -261,6 +263,122 @@ describe('Tests datasource utils', () => {
           references: [],
         } as any)
       ).toBe(false);
+    });
+  });
+
+  describe('getSecurityPluginStatus', () => {
+    const makeHttp = (impl: (path: string, opts?: any) => Promise<any>) => ({
+      get: jest.fn(impl),
+    });
+
+    it('returns "available" when security is listed in /_cat/plugins and health is reachable', async () => {
+      const http = makeHttp((path) => {
+        if (path === '/api/cat/plugins') {
+          return Promise.resolve({
+            ok: true,
+            response: [{ component: 'opensearch-security' }, { component: 'workload-management' }],
+          });
+        }
+        if (path === '/api/_plugins/_security/health') {
+          return Promise.resolve({ ok: true, available: true });
+        }
+        return Promise.resolve({});
+      });
+      await expect(getSecurityPluginStatus(http, 'ds-1')).resolves.toBe('available');
+      expect(http.get).toHaveBeenCalledWith(
+        '/api/cat/plugins',
+        expect.objectContaining({ query: { dataSourceId: 'ds-1' } })
+      );
+    });
+
+    it('returns "unavailable" when security is not listed in /_cat/plugins (skips health probe)', async () => {
+      const http = makeHttp((path) => {
+        if (path === '/api/cat/plugins') {
+          return Promise.resolve({ ok: true, response: [{ component: 'workload-management' }] });
+        }
+        return Promise.resolve({ ok: true, available: true });
+      });
+      await expect(getSecurityPluginStatus(http)).resolves.toBe('unavailable');
+      expect(http.get).toHaveBeenCalledTimes(1);
+      expect(http.get).toHaveBeenCalledWith(
+        '/api/cat/plugins',
+        expect.objectContaining({ query: { dataSourceId: '' } })
+      );
+    });
+
+    it('returns "unavailable" when security plugin is installed but health route reports unavailable (disabled)', async () => {
+      const http = makeHttp((path) => {
+        if (path === '/api/cat/plugins') {
+          return Promise.resolve({
+            ok: true,
+            response: [{ component: 'opensearch-security' }],
+          });
+        }
+        if (path === '/api/_plugins/_security/health') {
+          return Promise.resolve({ ok: true, available: false });
+        }
+        return Promise.resolve({});
+      });
+      await expect(getSecurityPluginStatus(http)).resolves.toBe('unavailable');
+    });
+
+    it('returns "available" when security plugin is listed but health probe is inconclusive', async () => {
+      const http = makeHttp((path) => {
+        if (path === '/api/cat/plugins') {
+          return Promise.resolve({
+            ok: true,
+            response: [{ component: 'opensearch-security' }],
+          });
+        }
+        return Promise.resolve({ ok: false, error: 'boom' });
+      });
+      await expect(getSecurityPluginStatus(http)).resolves.toBe('available');
+    });
+
+    it('returns "unknown" when /_cat/plugins fails completely', async () => {
+      const http = makeHttp((path) => {
+        if (path === '/api/cat/plugins') {
+          return Promise.reject(new Error('network down'));
+        }
+        return Promise.reject(new Error('network down'));
+      });
+      await expect(getSecurityPluginStatus(http)).resolves.toBe('unknown');
+    });
+  });
+
+  describe('describeRuleSaveError', () => {
+    it('rewrites the cryptic principal error to a security-plugin guidance message', () => {
+      expect(
+        describeRuleSaveError({
+          body: {
+            message:
+              '[x_content_parse_exception] principal is not a valid attribute within the workload_group feature.',
+          },
+        })
+      ).toMatch(/OpenSearch Security plugin/i);
+    });
+
+    it('passes through unrelated errors unchanged', () => {
+      expect(describeRuleSaveError(new Error('something else broke'))).toBe('something else broke');
+      expect(describeRuleSaveError({ body: { message: 'generic failure' } })).toBe(
+        'generic failure'
+      );
+    });
+
+    it('returns empty string for nullish or plain-object inputs (caller fallback wins)', () => {
+      // Empty string lets the call-site `|| 'Something went wrong'` produce a generic
+      // toast instead of leaking '[object Object]' to the user.
+      expect(describeRuleSaveError(undefined)).toBe('');
+      expect(describeRuleSaveError(null)).toBe('');
+      expect(describeRuleSaveError({})).toBe('');
+      expect(describeRuleSaveError({ body: { message: '' } })).toBe('');
+    });
+
+    it('falls through empty body.message to err.message', () => {
+      // Regression: ?? would short-circuit on '' and surface a blank toast tail.
+      expect(describeRuleSaveError({ body: { message: '' }, message: 'fallback' })).toBe(
+        'fallback'
+      );
     });
   });
 });

--- a/public/utils/datasource-utils.ts
+++ b/public/utils/datasource-utils.ts
@@ -144,3 +144,110 @@ export function isWlmGroupSettingsSupported(version?: string): boolean {
   const v = version && semver.valid(version) ? version : semver.coerce(version || '')?.version;
   return !!v && semver.gte(v, '3.7.0');
 }
+
+/**
+ * Result of probing the cluster for the opensearch-security plugin:
+ * - 'available': plugin is installed and active (or its auth is intercepting requests)
+ * - 'unavailable': plugin is not installed, or installed but disabled
+ * - 'unknown': probe failed for an unrelated reason (network, etc.) — let user proceed
+ */
+export type SecurityPluginStatus = 'available' | 'unavailable' | 'unknown';
+
+const SECURITY_PLUGIN_COMPONENT = 'opensearch-security';
+
+const SECURITY_PLUGIN_REQUIRED_HELP_TEXT =
+  'Requires the OpenSearch Security plugin to be installed and enabled on this cluster.';
+
+/**
+ * Helper text shown beneath a disabled Username or Role input. Picks the most
+ * relevant blocker (version gate first, then security plugin gate).
+ */
+export function getSecurityFieldDisabledHelpText(
+  field: 'username' | 'role',
+  versionSupportsSecurity: boolean
+): string {
+  if (!versionSupportsSecurity) {
+    return field === 'username'
+      ? 'Username rules require data source ≥ 3.3.'
+      : 'Role rules require data source ≥ 3.3.';
+  }
+  return SECURITY_PLUGIN_REQUIRED_HELP_TEXT;
+}
+
+/**
+ * Detect whether the opensearch-security plugin is installed AND active on the
+ * target cluster. Combines two probes:
+ *   1. /_cat/plugins — confirms the plugin is installed somewhere in the cluster.
+ *   2. /_plugins/_security/health — confirms the plugin is enabled and responding.
+ *
+ * Both probes must succeed for the plugin to be considered available. If either
+ * probe fails for an inconclusive reason we return 'unknown' so the UI does not
+ * over-block the user.
+ */
+export async function getSecurityPluginStatus(
+  http: { get: (path: string, options?: any) => Promise<any> },
+  dataSourceId?: string
+): Promise<SecurityPluginStatus> {
+  const query = { dataSourceId: dataSourceId ?? '' };
+
+  let pluginListed: boolean | undefined;
+  try {
+    const pluginsResp = await http.get('/api/cat/plugins', { query });
+    if (pluginsResp?.ok && Array.isArray(pluginsResp.response)) {
+      pluginListed = pluginsResp.response.some(
+        (p: { component?: string }) => p?.component === SECURITY_PLUGIN_COMPONENT
+      );
+    }
+  } catch (err) {
+    console.warn('Failed to list cluster plugins:', err);
+  }
+
+  if (pluginListed === false) {
+    return 'unavailable';
+  }
+
+  try {
+    const healthResp = await http.get('/api/_plugins/_security/health', { query });
+    if (healthResp?.ok) {
+      // Only trust 'unavailable' from health when we have a positive plugin signal
+      // from /_cat/plugins. Otherwise a transient cat/plugins blip + a 400/404 from
+      // some upstream proxy could cause a permanent false 'unavailable'.
+      if (healthResp.available) return 'available';
+      if (pluginListed === true) return 'unavailable';
+      return 'unknown';
+    }
+  } catch (err) {
+    console.warn('Failed to probe security plugin health:', err);
+  }
+
+  // _cat/plugins says it's installed but health probe was inconclusive — assume available.
+  if (pluginListed === true) {
+    return 'available';
+  }
+
+  return 'unknown';
+}
+
+/**
+ * Convert a save error into a clearer message when the cluster rejects
+ * principal-based rule attributes because the security plugin isn't active.
+ *
+ * The cluster surfaces this as:
+ *   "[x_content_parse_exception] principal is not a valid attribute within the workload_group feature."
+ * which is technically correct but unactionable. Detect that exact shape and replace it.
+ */
+export function describeRuleSaveError(err: unknown): string {
+  // Use || rather than ?? so empty body.message falls through to err.message and
+  // String(err) — otherwise an err = { body: { message: '' } } produces an empty
+  // toast tail like "Failed to save changes: ".
+  const raw =
+    (err as any)?.body?.message || (err as any)?.message || (err == null ? '' : String(err));
+  let message = typeof raw === 'string' ? raw : String(raw);
+  // String({}) is "[object Object]"; surface an empty string so callers' fallback
+  // ("Something went wrong" / "Check server logs.") wins instead of showing junk.
+  if (message === '[object Object]') message = '';
+  if (/principal is not a valid attribute/i.test(message)) {
+    return 'Workload group rules with username or role require the OpenSearch Security plugin to be installed and enabled on this cluster.';
+  }
+  return message;
+}

--- a/server/clusters/queryInsightsPlugin.ts
+++ b/server/clusters/queryInsightsPlugin.ts
@@ -251,4 +251,11 @@ export const QueryInsightsPlugin = function (Client, config, components) {
     },
     method: 'GET',
   });
+
+  queryInsights.getSecurityHealth = ca({
+    url: {
+      fmt: `/_plugins/_security/health`,
+    },
+    method: 'GET',
+  });
 };

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -632,6 +632,73 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
     }
   );
 
+  router.get(
+    {
+      path: '/api/_plugins/_security/health',
+      validate: {
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      // The /_plugins/_security/health response shape:
+      //   { message: string|null, mode: 'strict'|'disabled'|..., status: 'UP'|'DOWN' }
+      // The plugin is "available" only when we have positive evidence:
+      //   - explicit status UP, or
+      //   - status absent but mode is a non-disabled string
+      // Empty / non-object responses (proxy returns 200 with no JSON, etc.) are
+      // treated as unavailable to avoid masking misconfigurations.
+      const isHealthBodyAvailable = (body: any): boolean => {
+        if (!body || typeof body !== 'object') return false;
+        const mode = typeof body.mode === 'string' ? body.mode.toLowerCase() : undefined;
+        const status = typeof body.status === 'string' ? body.status.toUpperCase() : undefined;
+        if (mode === 'disabled') return false;
+        if (status === 'UP') return true;
+        if (status) return false;
+        return mode !== undefined;
+      };
+
+      try {
+        let res: any;
+        if (!dataSourceEnabled || !request.query?.dataSourceId) {
+          const client = context.queryInsights_plugin.queryInsightsClient.asScoped(request)
+            .callAsCurrentUser;
+          res = await client('queryInsights.getSecurityHealth');
+        } else {
+          const client = context.dataSource.opensearch.legacy.getClient(
+            request.query?.dataSourceId
+          );
+          res = await client.callAPI('queryInsights.getSecurityHealth', {});
+        }
+        return response.ok({
+          body: { ok: true, available: isHealthBodyAvailable(res), response: res },
+        });
+      } catch (error) {
+        // 401/403 indicates the Security plugin is intercepting the request, so it is active.
+        // 400/404 means OpenSearch has no handler registered for this URI — the plugin is
+        // not installed or disabled. 503 typically means the plugin is installed but
+        // hasn't initialized (e.g. strict mode without securityconfig loaded).
+        const statusCode = error?.statusCode ?? error?.status;
+        if (statusCode === 401 || statusCode === 403) {
+          return response.ok({ body: { ok: true, available: true } });
+        }
+        if (statusCode === 400 || statusCode === 404 || statusCode === 503) {
+          return response.ok({ body: { ok: true, available: false } });
+        }
+        // Some upstream errors carry the plugin's health body even on non-2xx; if so,
+        // classify based on body contents rather than only the status code.
+        const errorBody = error?.body ?? error?.meta?.body;
+        if (errorBody && typeof errorBody === 'object') {
+          return response.ok({
+            body: { ok: true, available: isHealthBodyAvailable(errorBody), response: errorBody },
+          });
+        }
+        return response.ok({ body: { ok: false, error: error?.message ?? String(error) } });
+      }
+    }
+  );
+
   router.delete(
     {
       path: '/api/snapshot/repository/{repository}',


### PR DESCRIPTION
### Description
Saving a WLM rule with a username or role on a cluster without the Security plugin currently fails with this cryptic error:

```
Failed to save changes: [x_content_parse_exception] principal is not a valid attribute within the workload_group feature.
```

This PR detects whether the OpenSearch Security plugin is installed and active. If it isn't, the **Username** and **Role** inputs are disabled with helper text *"Requires the OpenSearch Security plugin to be installed and enabled on this cluster."* If a save still surfaces the cryptic backend error (e.g. on a slow probe or stale state), it's rewritten to that same actionable wording.

All inactive states are covered: not installed, installed-but-disabled, plugin reachable but degraded, and probe failure (in which case the UI does not over-block).

### Screenshot
<img width="1454" height="1320" alt="Screenshot 2026-05-28 at 2 16 06 PM" src="https://github.com/user-attachments/assets/ec060d06-b86b-4cce-85ff-607a5f2702bc" />

### Issues Resolved
Closes #530

### Testing
- New `WLMDetails.security.test.tsx` covering each plugin state and the rewritten save error.
- Extended `datasource-utils.test.ts` and `WLMCreate.test.tsx` with the same coverage on the create path.
- All 470 unit tests pass; lint and typecheck clean.
- Manually verified on a local cluster with only the `workload-management` plugin installed.