### PR TITLE
Show server-route failures as toast notification (#35)

### DIFF
--- a/public/pages/TopNQueries/TopNQueries.test.tsx
+++ b/public/pages/TopNQueries/TopNQueries.test.tsx
@@ -25,6 +25,14 @@ const mockCore = ({
   uiSettings: {
     get: jest.fn().mockReturnValue(false),
   },
+  notifications: {
+    toasts: {
+      addDanger: jest.fn(),
+      addSuccess: jest.fn(),
+      addWarning: jest.fn(),
+      addError: jest.fn(),
+    },
+  },
 } as unknown) as CoreStart;
 
 const setUpDefaultEnabledSettings = () => {
@@ -576,6 +584,81 @@ describe('TopNQueries Component', () => {
       // Verify the component renders successfully
       expect(screen.getByText('Mocked QueryInsights')).toBeInTheDocument();
       expect(container).toMatchSnapshot();
+    });
+  });
+
+  describe('Error handling', () => {
+    it('show a danger toast when a top queries fails', async () => {
+      const mockSettingsResponse = {
+        response: {
+          persistent: {
+            search: {
+              insights: {
+                top_queries: {
+                  latency: { enabled: 'true', top_n_size: '10', window_size: '1h' },
+                  cpu: { enabled: 'false' },
+                  memory: { enabled: 'false' },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const fetchError = {
+        body: { message: 'no handler found for uri [/_insights/top_queries] and method [GET]' },
+      };
+      (mockCore.http.get as jest.Mock).mockImplementation((endpoint) => {
+        if (endpoint === '/api/settings') return Promise.resolve(mockSettingsResponse);
+        if (endpoint === '/api/top_queries/latency') return Promise.reject(fetchError);
+        return Promise.resolve({ response: { top_queries: [] } });
+      });
+
+      renderTopNQueries(QUERY_INSIGHTS);
+
+      await waitFor(() => {
+        expect(mockCore.notifications.toasts.addDanger).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Failed to retrieve top queries',
+            text: expect.stringContaining('no handler found'),
+          })
+        );
+      });
+    });
+
+    it('use error.message when error.body.message is absent', async () => {
+      const mockSettingsResponse = {
+        response: {
+          persistent: {
+            search: {
+              insights: {
+                top_queries: {
+                  latency: { enabled: 'true', top_n_size: '10', window_size: '1h' },
+                  cpu: { enabled: 'false' },
+                  memory: { enabled: 'false' },
+                },
+              },
+            },
+          },
+        },
+      };
+      const plainError = new Error('network down');
+      (mockCore.http.get as jest.Mock).mockImplementation((endpoint) => {
+        if (endpoint === '/api/settings') return Promise.resolve(mockSettingsResponse);
+        if (endpoint === '/api/top_queries/latency') return Promise.reject(plainError);
+        return Promise.resolve({ response: { top_queries: [] } });
+      });
+
+      renderTopNQueries(QUERY_INSIGHTS);
+
+      await waitFor(() => {
+        expect(mockCore.notifications.toasts.addDanger).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Failed to retrieve top queries',
+            text: 'network down',
+          })
+        );
+      });
     });
   });
 });

--- a/public/pages/TopNQueries/TopNQueries.tsx
+++ b/public/pages/TopNQueries/TopNQueries.tsx
@@ -259,7 +259,14 @@ const TopNQueries = ({
                 : [],
             },
           };
-        } catch {
+        } catch (error) {
+          core.notifications.toasts.addDanger({
+            title: 'Failed to retrieve top queries',
+            text:
+              error?.body?.message ??
+              error?.message ??
+              'An unknown error occurred while fetching top queries.',
+          });
           return nullResponse;
         }
       };

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -43,10 +43,10 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
         }
       } catch (error) {
         console.error('Unable to get top queries: ', error);
-        return response.ok({
+        return response.customError({
+          statusCode: error.statusCode ?? 500,
           body: {
-            ok: false,
-            response: error.message,
+            message: error.message || 'Internal server error',
           },
         });
       }
@@ -100,10 +100,10 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
         }
       } catch (error) {
         console.error('Unable to get top queries (latency): ', error);
-        return response.ok({
+        return response.customError({
+          statusCode: error.statusCode ?? 500,
           body: {
-            ok: false,
-            response: error.message,
+            message: error.message || 'Internal server error',
           },
         });
       }
@@ -158,10 +158,10 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
         }
       } catch (error) {
         console.error('Unable to get top queries (cpu): ', error);
-        return response.ok({
+        return response.customError({
+          statusCode: error.statusCode ?? 500,
           body: {
-            ok: false,
-            response: error.message,
+            message: error.message || 'Internal server error',
           },
         });
       }
@@ -215,10 +215,10 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
         }
       } catch (error) {
         console.error('Unable to get top queries (memory): ', error);
-        return response.ok({
+        return response.customError({
+          statusCode: error.statusCode ?? 500,
           body: {
-            ok: false,
-            response: error.message,
+            message: error.message || 'Internal server error',
           },
         });
       }
@@ -260,10 +260,10 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
         }
       } catch (error) {
         console.error('Unable to get top queries: ', error);
-        return response.ok({
+        return response.customError({
+          statusCode: error.statusCode ?? 500,
           body: {
-            ok: false,
-            response: error.message,
+            message: error.message || 'Internal server error',
           },
         });
       }
@@ -348,10 +348,10 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
         }
       } catch (error) {
         console.error('Unable to set settings: ', error);
-        return response.ok({
+        return response.customError({
+          statusCode: error.statusCode ?? 500,
           body: {
-            ok: false,
-            response: error.message,
+            message: error.message || 'Internal server error',
           },
         });
       }
@@ -482,10 +482,10 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
         });
       } catch (error) {
         console.error('Unable to get cluster version: ', error);
-        return response.ok({
+        return response.customError({
+          statusCode: error.statusCode ?? 500,
           body: {
-            ok: false,
-            error: error.message,
+            message: error.message || 'Internal server error',
           },
         });
       }
@@ -591,7 +591,10 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
         }
       } catch (error) {
         console.error('Unable to get snapshot repositories: ', error);
-        return response.ok({ body: { ok: false, response: error.message } });
+        return response.customError({
+          statusCode: error.statusCode ?? 500,
+          body: { message: error.message || 'Internal server error' },
+        });
       }
     }
   );
@@ -621,7 +624,10 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
         }
       } catch (error) {
         console.error('Unable to get cat plugins: ', error);
-        return response.ok({ body: { ok: false, response: error.message } });
+        return response.customError({
+          statusCode: error.statusCode ?? 500,
+          body: { message: error.message || 'Internal server error' },
+        });
       }
     }
   );
@@ -655,7 +661,10 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
         }
       } catch (error) {
         console.error('Unable to delete snapshot repository: ', error);
-        return response.ok({ body: { ok: false, response: error.message } });
+        return response.customError({
+          statusCode: error.statusCode ?? 500,
+          body: { message: error.message || 'Internal server error' },
+        });
       }
     }
   );
@@ -696,10 +705,12 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean, logger
       } catch (error) {
         console.error('Unable to create snapshot repository: ', error);
         const errorBody = error.body || error.meta?.body;
-        return response.ok({
+        return response.customError({
+          statusCode: error.statusCode ?? 500,
           body: {
-            ok: false,
-            response: errorBody ? JSON.stringify(errorBody) : error.message,
+            message: errorBody
+              ? JSON.stringify(errorBody)
+              : error.message || 'Internal server error',
           },
         });
       }


### PR DESCRIPTION
### Description
Show server-route failures as toast notification

### Issues Resolved
Fix #35 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
