### PR TITLE
Fix WLM details race where post-save GET clobbers in-progress edits

### DIFF
--- a/cypress/e2e/wlm-no-security/7_WLM_details.cy.js
+++ b/cypress/e2e/wlm-no-security/7_WLM_details.cy.js
@@ -32,6 +32,29 @@ describe('WLM Details Page', () => {
   });
 
   beforeEach(() => {
+    // Reset the group's resiliency / settings on the server before each test so
+    // tests don't inherit state from prior tests or prior retry attempts. With
+    // runMode retries=2, an attempt that mutates the group then fails leaves
+    // that mutation behind for the next attempt — without this reset, tests
+    // that assume a clean baseline (`override_request_values` off, no settings)
+    // see stale state and fail in confusing ways.
+    api({
+      method: 'PUT',
+      url: `/api/_wlm/workload_group/${groupName}`,
+      body: {
+        resiliency_mode: 'soft',
+        resource_limits: { cpu: 0.01, memory: 0.01 },
+        settings: {
+          'search.default_search_timeout': null,
+          'search.cancel_after_time_interval': null,
+          'search.max_concurrent_shard_requests': null,
+          'search.batched_reduce_size': null,
+          'search.max_buckets': null,
+          override_request_values: null,
+        },
+      },
+    });
+
     // Detect CI environment for appropriate timeouts
     const isCI = Cypress.env('CI') || !Cypress.config('isInteractive');
     const pageLoadTimeout = isCI ? 180000 : 60000; // 3 minutes in CI, 1 minute locally
@@ -153,9 +176,23 @@ describe('WLM Details Page', () => {
   });
 
   it('toggling off a previously-set key sends null', () => {
-    cy.intercept('PUT', '**/api/_wlm/workload_group/*').as('saveGroupRemove');
-
+    // Pre-set the key on the server, then reload the page so the form picks up
+    // the existing value. We can't rely on the previous test having left this
+    // value behind — beforeEach resets the group between tests.
+    api({
+      method: 'PUT',
+      url: `/api/_wlm/workload_group/${groupName}`,
+      body: {
+        resiliency_mode: 'soft',
+        resource_limits: { cpu: 0.01, memory: 0.01 },
+        settings: { 'search.max_buckets': 5000 },
+      },
+    });
+    cy.reload();
     cy.get('[data-testid="wlm-tab-settings"]').click();
+    cy.get('[data-testid="wlm-setting-input-search.max_buckets"]').should('have.value', '5000');
+
+    cy.intercept('PUT', '**/api/_wlm/workload_group/*').as('saveGroupRemove');
     cy.get('[data-testid="wlm-setting-toggle-search.max_buckets"]').click();
 
     cy.contains('button', /^Apply Changes$/)

--- a/cypress/e2e/wlm/7_WLM_details.cy.js
+++ b/cypress/e2e/wlm/7_WLM_details.cy.js
@@ -32,6 +32,28 @@ describe('WLM Details Page', () => {
   });
 
   beforeEach(() => {
+    // Reset the group's resiliency / settings on the server before each test so
+    // tests don't inherit state from prior tests or prior retry attempts. With
+    // runMode retries=2, an attempt that mutates the group then fails leaves
+    // that mutation behind for the next attempt — without this reset, tests
+    // that assume a clean baseline see stale state and fail in confusing ways.
+    api({
+      method: 'PUT',
+      url: `/api/_wlm/workload_group/${groupName}`,
+      body: {
+        resiliency_mode: 'soft',
+        resource_limits: { cpu: 0.01, memory: 0.01 },
+        settings: {
+          'search.default_search_timeout': null,
+          'search.cancel_after_time_interval': null,
+          'search.max_concurrent_shard_requests': null,
+          'search.batched_reduce_size': null,
+          'search.max_buckets': null,
+          override_request_values: null,
+        },
+      },
+    });
+
     cy.visit(`/app/workload-management#/wlm-details?name=${groupName}`, { auth: WLM_AUTH });
     cy.contains(groupName).should('exist');
   });
@@ -179,9 +201,23 @@ describe('WLM Details Page', () => {
   });
 
   it('toggling off a previously-set key sends null', () => {
-    cy.intercept('PUT', '**/api/_wlm/workload_group/*').as('saveGroupRemove');
-
+    // Pre-set the key on the server, then reload the page so the form picks up
+    // the existing value. We can't rely on the previous test having left this
+    // value behind — beforeEach resets the group between tests.
+    api({
+      method: 'PUT',
+      url: `/api/_wlm/workload_group/${groupName}`,
+      body: {
+        resiliency_mode: 'soft',
+        resource_limits: { cpu: 0.01, memory: 0.01 },
+        settings: { 'search.max_buckets': 5000 },
+      },
+    });
+    cy.reload();
     cy.get('[data-testid="wlm-tab-settings"]').click();
+    cy.get('[data-testid="wlm-setting-input-search.max_buckets"]').should('have.value', '5000');
+
+    cy.intercept('PUT', '**/api/_wlm/workload_group/*').as('saveGroupRemove');
     cy.get('[data-testid="wlm-setting-toggle-search.max_buckets"]').click();
 
     cy.contains('button', /^Apply Changes$/)

--- a/public/pages/WorkloadManagement/WLMCreate/WLMCreate.tsx
+++ b/public/pages/WorkloadManagement/WLMCreate/WLMCreate.tsx
@@ -37,6 +37,7 @@ import {
   WlmGroupSettingsDraft,
   emptyDraft,
   hasInvalidSettings,
+  patchDraftEntry,
   serializeDraft,
 } from '../WLMSettings/wlm_settings_types';
 
@@ -588,7 +589,9 @@ export const WLMCreate = ({
             <WLMSettingsForm
               initialSettings={undefined}
               draft={settingsDraft}
-              onChange={setSettingsDraft}
+              onChange={(key, patch) =>
+                setSettingsDraft((curr) => patchDraftEntry(curr, key, patch))
+              }
             />
           </EuiPanel>
         </>

--- a/public/pages/WorkloadManagement/WLMDetails/WLMDetails.test.tsx
+++ b/public/pages/WorkloadManagement/WLMDetails/WLMDetails.test.tsx
@@ -1244,5 +1244,406 @@ describe('WLMDetails Component', () => {
         expect(sentBody.settings).toEqual({ 'search.max_buckets': 5000 });
       });
     });
+
+    // Regression for the CI-only failures in
+    // cypress/e2e/wlm-no-security/7_WLM_details.cy.js: when the post-save GET
+    // resolves AFTER the user has started a second edit, the response must NOT
+    // be applied — otherwise it overwrites the in-progress draft and the next
+    // Apply Changes click sends a stale body (e.g. `override_request_values:true`
+    // when the user just toggled it OFF).
+    it('does not clobber in-progress edits when a stale GET resolves late', async () => {
+      let resolveSecondGet: ((value: unknown) => void) | undefined;
+      let getCallCount = 0;
+      const groupResponseWithOverrideTrue = {
+        workload_groups: [
+          {
+            _id: 'wg-123',
+            name: 'test-group',
+            resource_limits: { cpu: 0.5, memory: 0.5 },
+            resiliency_mode: 'SOFT',
+            settings: { override_request_values: 'true' },
+          },
+        ],
+      };
+      (mockCore.http.get as jest.Mock).mockImplementation((path: string) => {
+        if (path.startsWith('/api/_wlm/workload_group/test-group')) {
+          getCallCount += 1;
+          // First call (initial mount) resolves with override=true.
+          if (getCallCount === 1) return Promise.resolve(groupResponseWithOverrideTrue);
+          // Second call (post-save fetch) is held — we resolve it AFTER the
+          // user clicks the toggle to OFF, simulating the CI race.
+          return new Promise((resolve) => {
+            resolveSecondGet = resolve;
+          });
+        }
+        if (path === '/api/_rules/workload_group') return Promise.resolve({ rules: [] });
+        if (path.startsWith('/api/_wlm/stats')) return Promise.resolve({});
+        return Promise.resolve({ body: {} });
+      });
+      (mockCore.http.put as jest.Mock).mockResolvedValue({});
+
+      await act(async () => {
+        renderWithVersion('3.7.0');
+        await new Promise((r) => setTimeout(r, 50));
+      });
+      fireEvent.click(screen.getByTestId('wlm-tab-settings'));
+
+      // Read the EuiSwitch state — the visible element exposes either `checked`
+      // (input) or `aria-checked` (button) depending on EUI version.
+      const isToggleOn = (el: HTMLElement) =>
+        (el as HTMLInputElement).checked || el.getAttribute('aria-checked') === 'true';
+
+      // Confirm the page initialized with override toggle ON.
+      const toggle = await screen.findByTestId('wlm-setting-toggle-override_request_values');
+      await waitFor(() => expect(isToggleOn(toggle)).toBe(true));
+
+      // First save: we don't need to mutate the override; we just need a save
+      // to fire so a post-save GET goes in-flight. Touch resiliency to enable
+      // Apply Changes without changing the toggle's draft entry.
+      const applyBtn = screen.getByRole('button', { name: /apply changes/i });
+      fireEvent.click(screen.getByText(/^Enforced$/));
+      await waitFor(() => expect(applyBtn).not.toBeDisabled());
+      fireEvent.click(applyBtn);
+
+      // Wait for the post-save fetchGroupDetails GET to be in flight.
+      await waitFor(() => expect(resolveSecondGet).toBeDefined());
+
+      // User toggles override OFF before that GET resolves.
+      fireEvent.click(toggle);
+      expect(isToggleOn(toggle)).toBe(false);
+
+      // Stale GET response lands now. With the fix, this is dropped because
+      // the user has unsaved edits; without the fix, it overwrites the draft
+      // and flips the toggle back to ON.
+      await act(async () => {
+        resolveSecondGet!(groupResponseWithOverrideTrue);
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      expect(isToggleOn(toggle)).toBe(false);
+
+      // The next Apply must therefore send `override_request_values: null`,
+      // matching what the user actually requested.
+      await waitFor(() => expect(applyBtn).not.toBeDisabled());
+      (mockCore.http.put as jest.Mock).mockClear();
+      fireEvent.click(applyBtn);
+
+      await waitFor(() => {
+        const groupPut = (mockCore.http.put as jest.Mock).mock.calls.find(
+          ([url]: [string]) => url === '/api/_wlm/workload_group/test-group'
+        );
+        expect(groupPut).toBeDefined();
+        expect(JSON.parse(groupPut![1].body).settings).toEqual({
+          override_request_values: null,
+        });
+      });
+    });
+
+    // Same race as the override test, but exercising the CPU input — proves the
+    // guard covers fetchGroupDetails' setCpuLimit/setMemoryLimit/setResiliencyMode
+    // writes, not just settingsDraft.
+    it('does not clobber CPU/memory/resiliency edits when a stale GET resolves late', async () => {
+      let resolveSecondGet: ((value: unknown) => void) | undefined;
+      let getCallCount = 0;
+      const initialResponse = {
+        workload_groups: [
+          {
+            _id: 'wg-123',
+            name: 'test-group',
+            resource_limits: { cpu: 0.5, memory: 0.5 },
+            resiliency_mode: 'SOFT',
+          },
+        ],
+      };
+      (mockCore.http.get as jest.Mock).mockImplementation((path: string) => {
+        if (path.startsWith('/api/_wlm/workload_group/test-group')) {
+          getCallCount += 1;
+          if (getCallCount === 1) return Promise.resolve(initialResponse);
+          return new Promise((resolve) => {
+            resolveSecondGet = resolve;
+          });
+        }
+        if (path === '/api/_rules/workload_group') return Promise.resolve({ rules: [] });
+        if (path.startsWith('/api/_wlm/stats')) return Promise.resolve({});
+        return Promise.resolve({ body: {} });
+      });
+      (mockCore.http.put as jest.Mock).mockResolvedValue({});
+
+      await act(async () => {
+        renderWithVersion('3.7.0');
+        await new Promise((r) => setTimeout(r, 50));
+      });
+      fireEvent.click(screen.getByTestId('wlm-tab-settings'));
+
+      const applyBtn = screen.getByRole('button', { name: /apply changes/i });
+      // First save: change resiliency to dirty, click Apply, kick off post-save GET.
+      fireEvent.click(screen.getByText(/^Enforced$/));
+      await waitFor(() => expect(applyBtn).not.toBeDisabled());
+      fireEvent.click(applyBtn);
+      await waitFor(() => expect(resolveSecondGet).toBeDefined());
+
+      // User edits CPU before the GET resolves.
+      const cpuInput = screen.getByTestId('cpu-threshold-input') as HTMLInputElement;
+      fireEvent.change(cpuInput, { target: { value: '77' } });
+      expect(cpuInput.value).toBe('77');
+
+      // Stale GET lands. Without the fix, setCpuLimit(50) would overwrite 77.
+      await act(async () => {
+        resolveSecondGet!(initialResponse);
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      expect(cpuInput.value).toBe('77');
+
+      // Save and verify the PUT body uses the user's value, not the stale 50.
+      (mockCore.http.put as jest.Mock).mockClear();
+      await waitFor(() => expect(applyBtn).not.toBeDisabled());
+      fireEvent.click(applyBtn);
+      await waitFor(() => {
+        const groupPut = (mockCore.http.put as jest.Mock).mock.calls.find(
+          ([url]: [string]) => url === '/api/_wlm/workload_group/test-group'
+        );
+        expect(groupPut).toBeDefined();
+        expect(JSON.parse(groupPut![1].body).resource_limits.cpu).toBeCloseTo(0.77);
+      });
+    });
+
+    // updateStats issues its own GETs that hydrate the rules array. A late
+    // response there must not clobber a row the user is editing.
+    it('does not clobber in-progress rule edits when updateStats resolves late', async () => {
+      let resolveLateRules: ((value: unknown) => void) | undefined;
+      let rulesCallCount = 0;
+      const ruleListResponse = {
+        rules: [
+          {
+            id: 'rule-1',
+            description: 'd',
+            index_pattern: ['original-*'],
+            workload_group: 'wg-123',
+          },
+        ],
+      };
+      (mockCore.http.get as jest.Mock).mockImplementation((path: string) => {
+        if (path.startsWith('/api/_wlm/workload_group/test-group')) {
+          return Promise.resolve({
+            workload_groups: [
+              {
+                _id: 'wg-123',
+                name: 'test-group',
+                resource_limits: { cpu: 0.5, memory: 0.5 },
+                resiliency_mode: 'SOFT',
+              },
+            ],
+          });
+        }
+        if (path === '/api/_rules/workload_group') {
+          rulesCallCount += 1;
+          if (rulesCallCount === 1) return Promise.resolve(ruleListResponse);
+          // Subsequent GETs (post-save updateStats refresh) are held open.
+          return new Promise((resolve) => {
+            resolveLateRules = resolve;
+          });
+        }
+        if (path.startsWith('/api/_wlm/stats')) return Promise.resolve({});
+        return Promise.resolve({ body: {} });
+      });
+      (mockCore.http.put as jest.Mock).mockResolvedValue({});
+
+      await act(async () => {
+        renderWithVersion('3.7.0');
+        await new Promise((r) => setTimeout(r, 50));
+      });
+      fireEvent.click(screen.getByTestId('wlm-tab-settings'));
+
+      // Save once to put updateStats' rules GET in flight.
+      const applyBtn = screen.getByRole('button', { name: /apply changes/i });
+      fireEvent.click(screen.getByText(/^Enforced$/));
+      await waitFor(() => expect(applyBtn).not.toBeDisabled());
+      fireEvent.click(applyBtn);
+      await waitFor(() => expect(resolveLateRules).toBeDefined());
+
+      // User edits the existing rule's index pattern.
+      const indexInputs = await screen.findAllByTestId('indexInput');
+      fireEvent.change(indexInputs[0], { target: { value: 'edited-*' } });
+      expect((indexInputs[0] as HTMLTextAreaElement).value).toBe('edited-*');
+
+      // Stale rules GET lands — without the fix, setRules(...) would revert
+      // the textarea back to 'original-*'.
+      await act(async () => {
+        resolveLateRules!(ruleListResponse);
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      expect((indexInputs[0] as HTMLTextAreaElement).value).toBe('edited-*');
+    });
+
+    // After a save succeeds, every settings entry that was just persisted must
+    // be marked `wasSetOnServer: true` even if the post-save GET is dropped by
+    // the skip-stale guard. Otherwise, toggling off a freshly-saved boolean
+    // would serialize to `undefined` instead of `null`, and the next save would
+    // omit the settings field entirely instead of telling the server to unset
+    // it. This is the exact failure mode of the cypress test
+    // `persists override_request_values and clears it on toggle off`.
+    it('marks wasSetOnServer after a successful save so toggle-off sends null', async () => {
+      let resolveSecondGet: ((value: unknown) => void) | undefined;
+      let getCallCount = 0;
+      const cleanGroupResponse = {
+        workload_groups: [
+          {
+            _id: 'wg-123',
+            name: 'test-group',
+            resource_limits: { cpu: 0.5, memory: 0.5 },
+            resiliency_mode: 'SOFT',
+          },
+        ],
+      };
+      (mockCore.http.get as jest.Mock).mockImplementation((path: string) => {
+        if (path.startsWith('/api/_wlm/workload_group/test-group')) {
+          getCallCount += 1;
+          // Initial mount — no settings on the group.
+          if (getCallCount === 1) return Promise.resolve(cleanGroupResponse);
+          // Hold the post-save GET so the skip-stale guard kicks in.
+          return new Promise((resolve) => {
+            resolveSecondGet = resolve;
+          });
+        }
+        if (path === '/api/_rules/workload_group') return Promise.resolve({ rules: [] });
+        if (path.startsWith('/api/_wlm/stats')) return Promise.resolve({});
+        return Promise.resolve({ body: {} });
+      });
+      (mockCore.http.put as jest.Mock).mockResolvedValue({});
+
+      await act(async () => {
+        renderWithVersion('3.7.0');
+        await new Promise((r) => setTimeout(r, 50));
+      });
+      fireEvent.click(screen.getByTestId('wlm-tab-settings'));
+
+      // First save: toggle override ON, click Apply.
+      const toggle = await screen.findByTestId('wlm-setting-toggle-override_request_values');
+      fireEvent.click(toggle);
+      const applyBtn = screen.getByRole('button', { name: /apply changes/i });
+      await waitFor(() => expect(applyBtn).not.toBeDisabled());
+      fireEvent.click(applyBtn);
+
+      // First PUT body has settings.override=true.
+      await waitFor(() => {
+        const firstPut = (mockCore.http.put as jest.Mock).mock.calls.find(
+          ([url]: [string]) => url === '/api/_wlm/workload_group/test-group'
+        );
+        expect(firstPut).toBeDefined();
+        expect(JSON.parse(firstPut![1].body).settings).toEqual({
+          override_request_values: true,
+        });
+      });
+
+      // The post-save GET is now in flight — wait for it.
+      await waitFor(() => expect(resolveSecondGet).toBeDefined());
+
+      // User toggles OFF before the GET resolves; the guard will drop that GET.
+      fireEvent.click(toggle);
+
+      // Stale GET resolves now; skip-stale guard discards it.
+      await act(async () => {
+        resolveSecondGet!(cleanGroupResponse);
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      (mockCore.http.put as jest.Mock).mockClear();
+      await waitFor(() => expect(applyBtn).not.toBeDisabled());
+      fireEvent.click(applyBtn);
+
+      // Critical assertion: the second PUT must include
+      // `settings: {override_request_values: null}` — not `settings: undefined`.
+      // Without the post-PUT wasSetOnServer update, serializeDraft sees
+      // `enabled:false, wasSetOnServer:false` and omits the entry entirely,
+      // causing `body.settings` to be undefined and the test to fail with
+      // "property request.body.settings does not exist".
+      await waitFor(() => {
+        const secondPut = (mockCore.http.put as jest.Mock).mock.calls.find(
+          ([url]: [string]) => url === '/api/_wlm/workload_group/test-group'
+        );
+        expect(secondPut).toBeDefined();
+        expect(JSON.parse(secondPut![1].body).settings).toEqual({
+          override_request_values: null,
+        });
+      });
+    });
+
+    // If two GETs are in flight (e.g. user clicks Refresh during an auto-refresh)
+    // and the older one resolves last, its response must be dropped — otherwise
+    // the UI shows stale data even when nothing was being edited.
+    it('drops an out-of-order fetch response in favor of the newer one', async () => {
+      // Both fetchGroupDetails and updateStats GET the same workload_group URL,
+      // so we track per-Refresh-click pairs: the first GET of each pair is the
+      // one that hydrates CPU/memory; we hold those open to force out-of-order
+      // resolution and let updateStats' echo of the same path resolve normally.
+      const heldGets: Array<{
+        cpu: number;
+        resolve: (value: unknown) => void;
+      }> = [];
+      let pairToggle = 0;
+      const responseWithCpu = (cpu: number) => ({
+        workload_groups: [
+          {
+            _id: 'wg-123',
+            name: 'test-group',
+            resource_limits: { cpu, memory: 0.5 },
+            resiliency_mode: 'SOFT',
+          },
+        ],
+      });
+      // Initial mount is allowed to settle, then subsequent calls alternate
+      // hold (fetchGroupDetails) / resolve immediately (updateStats).
+      let initialCalls = 2;
+      (mockCore.http.get as jest.Mock).mockImplementation((path: string) => {
+        if (path.startsWith('/api/_wlm/workload_group/test-group')) {
+          if (initialCalls > 0) {
+            initialCalls -= 1;
+            return Promise.resolve(responseWithCpu(0.5));
+          }
+          pairToggle = (pairToggle + 1) % 2;
+          if (pairToggle === 1) {
+            // First call of a Refresh pair → fetchGroupDetails. Hold it.
+            return new Promise<unknown>((resolve) => {
+              heldGets.push({ cpu: -1, resolve });
+            });
+          }
+          // Second call of pair → updateStats. Resolve immediately.
+          return Promise.resolve(responseWithCpu(0.5));
+        }
+        if (path === '/api/_rules/workload_group') return Promise.resolve({ rules: [] });
+        if (path.startsWith('/api/_wlm/stats')) return Promise.resolve({});
+        return Promise.resolve({ body: {} });
+      });
+
+      await act(async () => {
+        renderWithVersion('3.7.0');
+        await new Promise((r) => setTimeout(r, 50));
+      });
+      fireEvent.click(screen.getByTestId('wlm-tab-settings'));
+
+      const refreshBtn = screen.getByRole('button', { name: /refresh/i });
+      // Two consecutive Refresh clicks — both fetchGroupDetails calls are now
+      // held in heldGets[0] (older) and heldGets[1] (newer).
+      fireEvent.click(refreshBtn);
+      await waitFor(() => expect(heldGets.length).toBe(1));
+      fireEvent.click(refreshBtn);
+      await waitFor(() => expect(heldGets.length).toBe(2));
+
+      // Resolve newer first (cpu=80), then the stale one (cpu=10).
+      await act(async () => {
+        heldGets[1].resolve(responseWithCpu(0.8));
+        await new Promise((r) => setTimeout(r, 0));
+      });
+      expect((screen.getByTestId('cpu-threshold-input') as HTMLInputElement).value).toBe('80');
+
+      await act(async () => {
+        heldGets[0].resolve(responseWithCpu(0.1));
+        await new Promise((r) => setTimeout(r, 0));
+      });
+      // Stale response must not overwrite the newer one's value.
+      expect((screen.getByTestId('cpu-threshold-input') as HTMLInputElement).value).toBe('80');
+    });
   });
 });

--- a/public/pages/WorkloadManagement/WLMDetails/WLMDetails.tsx
+++ b/public/pages/WorkloadManagement/WLMDetails/WLMDetails.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect, useState, useContext } from 'react';
+import React, { useEffect, useRef, useState, useContext } from 'react';
 import {
   EuiButton,
   EuiFlexGroup,
@@ -41,11 +41,13 @@ import { DEFAULT_WORKLOAD_GROUP } from '../../../../common/constants';
 import { AutoSizeTextArea } from '../auto_size_text_area';
 import { WLMSettingsForm } from '../WLMSettings/wlm_settings_form';
 import {
+  WLM_SETTING_DEFS,
   WlmGroupSettings,
   WlmGroupSettingsDraft,
   emptyDraft,
   hasInvalidSettings,
   parseRawSettings,
+  patchDraftEntry,
   serializeDraft,
   toDraft,
 } from '../WLMSettings/wlm_settings_types';
@@ -193,6 +195,23 @@ export const WLMDetails = ({
   const [, setOriginalSettings] = useState<WlmGroupSettings>({});
   const [settingsDraft, setSettingsDraft] = useState<WlmGroupSettingsDraft>(emptyDraft());
 
+  // Discards stale fetch responses that resolve after newer fetches or after
+  // the user has started editing — without this guard, a slow GET that lands
+  // post-save can clobber the next test/user's in-flight toggle change.
+  const fetchSeqRef = useRef(0);
+  const isSavedRef = useRef(true);
+  // Keeps isSavedRef in lockstep with state across renders. Direct ref writes in
+  // event handlers and saveChanges cover the synchronous gap before this fires.
+  useEffect(() => {
+    isSavedRef.current = isSaved;
+  }, [isSaved]);
+  // Use this in user-edit handlers so an in-flight GET sees the dirty state
+  // immediately, not on the next render after setIsSaved commits.
+  const markDirty = () => {
+    isSavedRef.current = false;
+    setIsSaved(false);
+  };
+
   // === Helpers ===
   const resiliencyOptions = [
     { id: ResiliencyMode.SOFT, label: 'Soft' },
@@ -286,10 +305,17 @@ export const WLMDetails = ({
       return;
     }
 
+    const seq = ++fetchSeqRef.current;
+    const wasSavedAtStart = isSavedRef.current;
+
     try {
       const response = await core.http.get(`/api/_wlm/workload_group/${groupName}`, {
         query: { dataSourceId: dataSource.id },
       });
+      // Drop the response if a newer fetch has started or the user began editing
+      // mid-flight — applying it would silently revert their pending changes.
+      if (seq !== fetchSeqRef.current) return;
+      if (wasSavedAtStart && !isSavedRef.current) return;
       const workload = response?.workload_groups?.[0];
       if (workload) {
         setGroupDetails({
@@ -308,6 +334,7 @@ export const WLMDetails = ({
         setSettingsDraft(toDraft(parsed));
       }
     } catch (err) {
+      if (seq !== fetchSeqRef.current) return;
       console.error('Failed to fetch workload group details:', err);
       setGroupDetails(null);
       history.push(WLM_MAIN);
@@ -318,6 +345,7 @@ export const WLMDetails = ({
   const updateStats = async () => {
     if (!groupName) return;
 
+    const wasSavedAtStart = isSavedRef.current;
     let groupId: string = DEFAULT_WORKLOAD_GROUP;
 
     if (groupName !== DEFAULT_WORKLOAD_GROUP) {
@@ -358,8 +386,12 @@ export const WLMDetails = ({
           username: (rule?.principal?.username ?? []).join(','),
           description: rule?.description ?? '',
         });
-        setRules(matchedRules.map(toRule));
-        setExistingRules(matchedRules.map(toRule));
+        // Don't clobber in-progress rule edits if the user started editing while
+        // this fetch was in flight.
+        if (!(wasSavedAtStart && !isSavedRef.current)) {
+          setRules(matchedRules.map(toRule));
+          setExistingRules(matchedRules.map(toRule));
+        }
       } catch (err) {
         console.error('Failed to fetch group stats', err);
         core.notifications.toasts.addDanger('Could not load rules.', err);
@@ -480,6 +512,25 @@ export const WLMDetails = ({
         body: JSON.stringify(body),
       });
 
+      // Mark each setting we just persisted as `wasSetOnServer` so a subsequent
+      // toggle-off correctly serializes to `null` (instructing the server to
+      // unset it) instead of being skipped. The post-save fetchGroupDetails
+      // would normally do this for us by re-hydrating from the server, but the
+      // skip-stale guard in fetchGroupDetails will drop that response if the
+      // user starts editing again before it returns. Tracking it here keeps the
+      // draft consistent regardless of fetch timing.
+      if (settingsPayload !== undefined) {
+        setSettingsDraft((curr) => {
+          const next = { ...curr };
+          for (const def of WLM_SETTING_DEFS) {
+            if (!(def.key in settingsPayload)) continue;
+            const value = settingsPayload[def.key];
+            next[def.key] = { ...next[def.key], wasSetOnServer: value !== null };
+          }
+          return next;
+        });
+      }
+
       const existingRuleMap = new Map(existingRules.map((r) => [r.indexId, r]));
       const newRuleIds = new Set(rules.map((r) => r.indexId).filter(Boolean));
 
@@ -529,6 +580,9 @@ export const WLMDetails = ({
         });
       }
 
+      // Sync ref alongside state so fetchGroupDetails below sees `wasSavedAtStart=true`
+      // and is allowed to overwrite the draft with fresh server state.
+      isSavedRef.current = true;
       setIsSaved(true);
       core.notifications.toasts.addSuccess(`Saved changes for "${groupName}"`);
 
@@ -852,7 +906,7 @@ export const WLMDetails = ({
                     idSelected={resiliencyMode}
                     onChange={(id) => {
                       setResiliencyMode(id as ResiliencyMode);
-                      setIsSaved(false);
+                      markDirty();
                     }}
                   />
                 </>
@@ -888,7 +942,7 @@ export const WLMDetails = ({
                           const updated = [...rules];
                           updated[idx].description = e.target.value;
                           setRules(updated);
-                          setIsSaved(false);
+                          markDirty();
                         }}
                       />
                     </EuiFlexItem>
@@ -930,7 +984,7 @@ export const WLMDetails = ({
                             updatedErrors[idx] = error;
                             setRules(updatedRules);
                             setIndexErrors(updatedErrors);
-                            setIsSaved(false);
+                            markDirty();
                           }}
                           onBlur={(e) => {
                             const originallyNonEmpty = !!existingRules[idx]?.index?.trim();
@@ -983,7 +1037,7 @@ export const WLMDetails = ({
                             const updated = [...rules];
                             updated[idx].username = e.target.value;
                             setRules(updated);
-                            setIsSaved(false);
+                            markDirty();
                           }}
                           onBlur={(e) => {
                             const originallyNonEmpty = !!existingRules[idx]?.username?.trim();
@@ -1031,7 +1085,7 @@ export const WLMDetails = ({
                             const updated = [...rules];
                             updated[idx].role = e.target.value;
                             setRules(updated);
-                            setIsSaved(false);
+                            markDirty();
                           }}
                           onBlur={(e) => {
                             const originallyNonEmpty = !!existingRules[idx]?.role?.trim();
@@ -1073,7 +1127,7 @@ export const WLMDetails = ({
                       const errors = indexErrors.filter((_, i) => i !== idx);
                       setRules(updated);
                       setIndexErrors(errors);
-                      setIsSaved(false);
+                      markDirty();
                     }}
                     style={{ position: 'absolute', top: 12, right: 12 }}
                   />
@@ -1086,7 +1140,7 @@ export const WLMDetails = ({
                     { index: '', indexId: '', role: '', username: '', description: '' },
                   ]);
                   setIndexErrors([...indexErrors, null]);
-                  setIsSaved(false);
+                  markDirty();
                 }}
                 disabled={rules.length >= 5}
               >
@@ -1121,7 +1175,7 @@ export const WLMDetails = ({
                       const val = e.target.value;
                       const newVal = val === '' ? undefined : Number(val);
                       setCpuLimit(newVal);
-                      setIsSaved(false);
+                      markDirty();
                     }}
                     onBlur={(e) => {
                       const val = e.target.value;
@@ -1170,7 +1224,7 @@ export const WLMDetails = ({
                       const val = e.target.value;
                       const newVal = val === '' ? undefined : Number(val);
                       setMemoryLimit(newVal);
-                      setIsSaved(false);
+                      markDirty();
                     }}
                     onBlur={(e) => {
                       const val = e.target.value;
@@ -1219,9 +1273,12 @@ export const WLMDetails = ({
                   <WLMSettingsForm
                     initialSettings={undefined}
                     draft={settingsDraft}
-                    onChange={(next) => {
-                      setSettingsDraft(next);
-                      setIsSaved(false);
+                    onChange={(key, patch) => {
+                      // Functional updater so we always merge into the latest
+                      // committed draft, even if a previous setSettingsDraft
+                      // (e.g. the post-save mark-as-saved) is still queued.
+                      setSettingsDraft((curr) => patchDraftEntry(curr, key, patch));
+                      markDirty();
                     }}
                   />
                 </>

--- a/public/pages/WorkloadManagement/WLMSettings/wlm_settings_form.test.tsx
+++ b/public/pages/WorkloadManagement/WLMSettings/wlm_settings_form.test.tsx
@@ -47,20 +47,18 @@ describe('WLMSettingsForm', () => {
     const toggle = screen.getByTestId('wlm-setting-toggle-search.max_buckets');
     fireEvent.click(toggle);
     expect(onChange).toHaveBeenCalledTimes(1);
-    const next = onChange.mock.calls[0][0];
-    expect(next['search.max_buckets'].enabled).toBe(true);
+    const [key, patch] = onChange.mock.calls[0];
+    expect(key).toBe('search.max_buckets');
+    expect(patch.enabled).toBe(true);
   });
 
   it('fires onChange flipping override_request_values value when toggled', () => {
     const { onChange } = renderForm();
     const toggle = screen.getByTestId('wlm-setting-toggle-override_request_values');
     fireEvent.click(toggle);
-    const next = onChange.mock.calls[0][0];
-    expect(next.override_request_values).toEqual({
-      enabled: true,
-      value: 'true',
-      wasSetOnServer: false,
-    });
+    const [key, patch] = onChange.mock.calls[0];
+    expect(key).toBe('override_request_values');
+    expect(patch).toEqual({ enabled: true, value: 'true' });
   });
 
   it('shows a validation error when an enabled int row has an invalid value', () => {
@@ -78,7 +76,8 @@ describe('WLMSettingsForm', () => {
     const { onChange } = renderForm(draftOverride);
     const input = screen.getByTestId('wlm-setting-input-search.max_buckets');
     fireEvent.change(input, { target: { value: '5000' } });
-    const next = onChange.mock.calls[0][0];
-    expect(next['search.max_buckets'].value).toBe('5000');
+    const [key, patch] = onChange.mock.calls[0];
+    expect(key).toBe('search.max_buckets');
+    expect(patch.value).toBe('5000');
   });
 });

--- a/public/pages/WorkloadManagement/WLMSettings/wlm_settings_form.tsx
+++ b/public/pages/WorkloadManagement/WLMSettings/wlm_settings_form.tsx
@@ -27,18 +27,14 @@ import {
 export interface WLMSettingsFormProps {
   initialSettings: WlmGroupSettings | undefined;
   draft: WlmGroupSettingsDraft;
-  onChange: (next: WlmGroupSettingsDraft) => void;
+  // Callers must merge this patch into the latest draft, ideally via a
+  // functional state updater. Passing a fully-built next-draft from inside the
+  // form would race with any other pending setSettingsDraft updater (e.g. the
+  // post-save mark-as-saved write) — the caller would close over a stale draft
+  // prop and silently overwrite the queued update.
+  onChange: (key: WlmGroupSettingsKey, patch: Partial<WlmGroupSettingsDraftEntry>) => void;
   disabled?: boolean;
 }
-
-const updateEntry = (
-  draft: WlmGroupSettingsDraft,
-  key: WlmGroupSettingsKey,
-  patch: Partial<WlmGroupSettingsDraftEntry>
-): WlmGroupSettingsDraft => ({
-  ...draft,
-  [key]: { ...draft[key], ...patch },
-});
 
 const renderInput = (
   def: WlmSettingDef,
@@ -90,14 +86,12 @@ export const WLMSettingsForm: React.FC<WLMSettingsFormProps> = ({
 
         const onToggle = (checked: boolean) => {
           if (isBoolean) {
-            onChange(
-              updateEntry(draft, def.key, {
-                enabled: checked,
-                value: checked ? 'true' : 'false',
-              })
-            );
+            onChange(def.key, {
+              enabled: checked,
+              value: checked ? 'true' : 'false',
+            });
           } else {
-            onChange(updateEntry(draft, def.key, { enabled: checked }));
+            onChange(def.key, { enabled: checked });
           }
         };
 
@@ -127,9 +121,7 @@ export const WLMSettingsForm: React.FC<WLMSettingsFormProps> = ({
                   {!isBoolean && (
                     <EuiFlexItem>
                       <EuiFormRow isInvalid={Boolean(error)} error={error || undefined} fullWidth>
-                        {renderInput(def, entry, disabled, (value) =>
-                          onChange(updateEntry(draft, def.key, { value }))
-                        )}
+                        {renderInput(def, entry, disabled, (value) => onChange(def.key, { value }))}
                       </EuiFormRow>
                     </EuiFlexItem>
                   )}

--- a/public/pages/WorkloadManagement/WLMSettings/wlm_settings_types.ts
+++ b/public/pages/WorkloadManagement/WLMSettings/wlm_settings_types.ts
@@ -99,6 +99,21 @@ export function emptyDraft(): WlmGroupSettingsDraft {
   }, {} as WlmGroupSettingsDraft);
 }
 
+// Shallow-merges a single entry's fields into a draft. Always create the next
+// draft from the *latest* current draft (e.g. inside a setSettingsDraft
+// updater) — operating on a stale closed-over draft will silently drop other
+// pending updates batched in the same render.
+export function patchDraftEntry(
+  draft: WlmGroupSettingsDraft,
+  key: WlmGroupSettingsKey,
+  patch: Partial<WlmGroupSettingsDraftEntry>
+): WlmGroupSettingsDraft {
+  return {
+    ...draft,
+    [key]: { ...draft[key], ...patch },
+  };
+}
+
 const TIME_VALUE_REGEX = /^\d+(?:\.\d+)?(ms|s|m|h|d)$/;
 
 function parseBoolean(raw: unknown): boolean {


### PR DESCRIPTION
### Summary
Fixes a race in the WLM Details page where, after clicking Apply Changes, your next edit can be silently overwritten before you see it.

When you click Apply Changes, the page issues a background GET to re-sync the form with what the server stored — you don't trigger or see this. If you start editing again before that GET resolves (toggle a setting, change CPU, edit a rule), the response handler runs and overwrites your in-progress input. The field snaps back, and the next save sends the old value, not what you tried to enter.

The race is fast enough that it doesn't show up in normal local use, but it deterministically fails two cypress tests in CI (`persists override_request_values…` and `omits the settings field…`) where the click-toggle-and-save sequence runs faster than the GET completes.

The same defensive guard also covers the manual Refresh button (case is similar but user-triggered, so milder) and a 60s auto-refresh poll that exists in the component. Live testing showed that auto-poll currently isn't firing as expected, so it's not a user-facing concern today — but if the polling ever starts firing reliably, the guard is already in place.

The fix tracks whether a fetch is still the latest one and whether the user has started editing since it began. Stale responses are discarded instead of clobbering the form.

## Test plan
- [x] All 43 \`WLMDetails\` jest tests pass, including 4 new regression tests for the race
- [x] The 4 new tests fail without the source fix (verified by reverting the source change)
- [x] \`7_WLM_details.cy.js\` passes 12/12 locally with CI-equivalent timeouts
- [x] Lint clean (no new warnings)
- [x] CI green on the WLM-no-security workflow