### PR TITLE
Fix flaky cypress tests on Windows

### DIFF
--- a/cypress/e2e/qi/1_top_queries.cy.js
+++ b/cypress/e2e/qi/1_top_queries.cy.js
@@ -269,8 +269,9 @@ describe('Query Insights — Dynamic Columns with Intercepted Top Queries (MIXED
     ];
     getHeaders().should('deep.equal', expected);
 
-    const queryOnlyCount = mixedRows.filter((r) => String(r.group_by).toUpperCase() === 'NONE')
-      .length;
+    const queryOnlyCount = mixedRows.filter(
+      (r) => String(r.group_by).toUpperCase() === 'NONE'
+    ).length;
     assertRowCountEquals(queryOnlyCount);
 
     expectSortedBy('Timestamp');
@@ -291,8 +292,9 @@ describe('Query Insights — Dynamic Columns with Intercepted Top Queries (MIXED
     ];
     getHeaders().should('deep.equal', expected);
 
-    const groupOnlyCount = mixedRows.filter((r) => String(r.group_by).toUpperCase() !== 'NONE')
-      .length;
+    const groupOnlyCount = mixedRows.filter(
+      (r) => String(r.group_by).toUpperCase() !== 'NONE'
+    ).length;
     assertRowCountEquals(groupOnlyCount);
 
     expectSortedBy('Query Count');
@@ -354,8 +356,11 @@ describe('Query Insights — Dynamic Columns (QUERY ONLY fixture)', () => {
       'WLM Group',
       'Total Shards',
     ];
-    getHeaders().should('deep.equal', expected);
+    // assertRowCountEquals uses .should('have.length', N) which retries until items
+    // has populated; once row count matches, columnsToShow has evaluated against the
+    // populated data and headers are stable for the deep-equal assertion.
     assertRowCountEquals(getRowsFromRaw(QUERY_ONLY).length);
+    getHeaders().should('deep.equal', expected);
   });
 });
 
@@ -379,8 +384,11 @@ describe('Query Insights — Dynamic Columns (GROUP ONLY fixture)', () => {
       'Average CPU Time',
       'Average Memory Usage',
     ];
-    getHeaders().should('deep.equal', expected);
+    // assertRowCountEquals uses .should('have.length', N) which retries until items
+    // has populated; once row count matches, columnsToShow has evaluated against the
+    // populated data and headers are stable for the deep-equal assertion.
     assertRowCountEquals(getRowsFromRaw(GROUP_ONLY).length);
+    getHeaders().should('deep.equal', expected);
   });
 
   it('renders dash in status column for group rows', () => {
@@ -397,7 +405,16 @@ describe('Query Insights — Stats & Visualizations Panel', () => {
     }).as('topQueries');
 
     cy.waitForQueryInsightsPlugin();
+    // The page fires three GETs (latency, cpu, memory) and only flips loading=false
+    // after all three resolve. Wait for all three plus the table to render so the
+    // visualizations panel is stable and React state has settled.
     cy.wait('@topQueries');
+    cy.wait('@topQueries');
+    cy.wait('@topQueries');
+    cy.get('.euiBasicTable', { timeout: 30000 })
+      .last()
+      .find('.euiTableRow')
+      .should('have.length.greaterThan', 0);
   });
 
   it('displays visualizations panel with Query/Group toggle', () => {
@@ -569,7 +586,19 @@ describe('Query Insights — DynamicSearchBar', () => {
     }).as('topQueries');
 
     cy.waitForQueryInsightsPlugin();
+    // The page fires three GETs (latency, cpu, memory) and only flips loading=false
+    // after all three resolve. The DynamicSearchBar is conditionally rendered on
+    // `!loading`, so wait for all three plus the table to render before any test
+    // interacts with the search input — otherwise the input may be detached/re-mounted
+    // between Cypress commands, surfacing as a misleading 'disabled element' error.
     cy.wait('@topQueries');
+    cy.wait('@topQueries');
+    cy.wait('@topQueries');
+    cy.get('.euiBasicTable', { timeout: 30000 })
+      .last()
+      .find('.euiTableRow')
+      .should('have.length.greaterThan', 0);
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`).should('be.visible');
   });
 
   it('renders the search bar with correct placeholder', () => {

--- a/cypress/e2e/qi/1_top_queries.cy.js
+++ b/cypress/e2e/qi/1_top_queries.cy.js
@@ -269,9 +269,8 @@ describe('Query Insights — Dynamic Columns with Intercepted Top Queries (MIXED
     ];
     getHeaders().should('deep.equal', expected);
 
-    const queryOnlyCount = mixedRows.filter(
-      (r) => String(r.group_by).toUpperCase() === 'NONE'
-    ).length;
+    const queryOnlyCount = mixedRows.filter((r) => String(r.group_by).toUpperCase() === 'NONE')
+      .length;
     assertRowCountEquals(queryOnlyCount);
 
     expectSortedBy('Timestamp');
@@ -292,9 +291,8 @@ describe('Query Insights — Dynamic Columns with Intercepted Top Queries (MIXED
     ];
     getHeaders().should('deep.equal', expected);
 
-    const groupOnlyCount = mixedRows.filter(
-      (r) => String(r.group_by).toUpperCase() !== 'NONE'
-    ).length;
+    const groupOnlyCount = mixedRows.filter((r) => String(r.group_by).toUpperCase() !== 'NONE')
+      .length;
     assertRowCountEquals(groupOnlyCount);
 
     expectSortedBy('Query Count');

--- a/cypress/e2e/qi/5_live_queries.cy.js
+++ b/cypress/e2e/qi/5_live_queries.cy.js
@@ -15,6 +15,21 @@ describe('Inflight Queries Dashboard', () => {
     cy.navigateToLiveQueries();
     cy.wait(1000);
     cy.wait('@getLiveQueries');
+
+    // Disable auto-refresh to keep the DOM stable across assertions. Without this,
+    // every refreshInterval (default 5s) the table re-renders, detaching row and
+    // pagination handles mid-test (root cause of the pagination 'detached from DOM'
+    // and WLM-disabled content-match failures).
+    cy.get('[data-test-subj="live-queries-autorefresh-toggle"]').then(($t) => {
+      if ($t.attr('aria-checked') === 'true') {
+        cy.wrap($t).click();
+      }
+    });
+    cy.get('[data-test-subj="live-queries-autorefresh-toggle"]').should(
+      'have.attr',
+      'aria-checked',
+      'false'
+    );
   });
 
   it('displays the correct page title', () => {
@@ -106,9 +121,9 @@ describe('Inflight Queries Dashboard', () => {
   });
 
   it('navigates to next page in table pagination', () => {
-    cy.wait('@getLiveQueries');
     cy.get('.euiPagination').should('be.visible');
-    cy.get('.euiPagination__item').contains('2').click();
+    cy.get('[data-test-subj="pagination-button-1"]').should('be.visible').click();
+    cy.get('[data-test-subj="pagination-button-1"]').should('have.attr', 'aria-current', 'true');
     cy.get('tbody tr').should('exist');
   });
 
@@ -134,6 +149,10 @@ describe('Inflight Queries Dashboard', () => {
     cy.get('[data-test-subj="live-queries-autorefresh-toggle"]').as('toggle');
     cy.get('[data-test-subj="live-queries-refresh-interval"]').as('dropdown');
 
+    // beforeEach already disabled auto-refresh; re-enable then toggle off so the
+    // observable transition to disabled is exercised.
+    cy.get('@toggle').click();
+    cy.get('@toggle').should('have.attr', 'aria-checked', 'true');
     cy.get('@toggle').click();
     cy.get('@toggle').should('have.attr', 'aria-checked', 'false');
     cy.get('@dropdown').should('be.disabled');
@@ -317,11 +336,11 @@ describe('Inflight Queries Dashboard', () => {
   });
 
   it('displays WLM group as text when WLM is disabled', () => {
-    cy.get('tbody tr')
-      .first()
-      .within(() => {
-        cy.get('td').contains('ANALYTICS_WORKLOAD_GROUP').should('not.have.attr', 'href');
-      });
+    // Use cy.contains(selector, text) which requeries on retry instead of latching
+    // onto a `tbody tr:first` handle that can go stale across React re-renders.
+    cy.contains('tbody td', 'ANALYTICS_WORKLOAD_GROUP', { timeout: 60000 })
+      .should('be.visible')
+      .and('not.have.attr', 'href');
   });
 });
 

--- a/cypress/e2e/qi/5_live_queries.cy.js
+++ b/cypress/e2e/qi/5_live_queries.cy.js
@@ -122,7 +122,12 @@ describe('Inflight Queries Dashboard', () => {
 
   it('navigates to next page in table pagination', () => {
     cy.get('.euiPagination').should('be.visible');
-    cy.get('[data-test-subj="pagination-button-1"]').should('be.visible').click();
+    // Break chain and force the click — the EuiPagination button can briefly
+    // re-render between visibility check and click on slow CI; aliasing then
+    // forcing avoids the 'page updated while this command was executing' race.
+    cy.get('[data-test-subj="pagination-button-1"]').as('nextPage');
+    cy.get('@nextPage').should('be.visible');
+    cy.get('@nextPage').click({ force: true });
     cy.get('[data-test-subj="pagination-button-1"]').should('have.attr', 'aria-current', 'true');
     cy.get('tbody tr').should('exist');
   });


### PR DESCRIPTION
## Summary

Fix race conditions in `cypress/e2e/qi/1_top_queries.cy.js` and `cypress/e2e/qi/5_live_queries.cy.js` exposed by slow Windows test agents (where the Amazon CI runner picks up a cached Cypress 9.5.4 binary instead of our declared 13.17.0). Same tests pass on Linux + Cypress 13 in this repo's GitHub Actions, but the OpenSearch-Dashboards integ-test pipeline runs the synced copy of these specs on Windows as part of release verification — the persistent Windows failures are tracked in [autocut #506](https://github.com/opensearch-project/query-insights-dashboards/issues/506) (builds [#8601](https://build.ci.opensearch.org/blue/organizations/jenkins/integ-test-opensearch-dashboards/detail/integ-test-opensearch-dashboards/8601/pipeline/) and [#8605](https://build.ci.opensearch.org/blue/organizations/jenkins/integ-test-opensearch-dashboards/detail/integ-test-opensearch-dashboards/8605/pipeline/)).

### `1_top_queries.cy.js`

- **QUERY ONLY / GROUP ONLY header tests:** reorder `assertRowCountEquals(...)` BEFORE `getHeaders().should('deep.equal', ...)`. `assertRowCountEquals` uses `.should('have.length', N)` which retries until React state populates `items`; once row count matches, `columnsToShow` has evaluated against the populated data, so the deep-equal header assertion reads stable headers. Without this reorder, headers were read while `items.length === 0` → `defaultColumns` (with `Query Count` + missing `Status`/`WLM Group`) was rendered → header count mismatch.
- **Stats & Visualizations and DynamicSearchBar `beforeEach`:** the page fires three sequential GETs (`/api/top_queries/latency`, `/cpu`, `/memory`) and only flips `loading=false` after all three resolve. Wait for all three `@topQueries` plus the table to render so React state is settled and the conditionally-rendered `DynamicSearchBar` is stable before tests interact with it. This addresses the `'shows empty state when Group mode is selected'` DOM-detach and the 8 DynamicSearchBar `cy.type` "disabled element" failures.

### `5_live_queries.cy.js`

- **`beforeEach`:** disable auto-refresh after the initial fetch so the inflight-queries table stops re-rendering every 5s. The auto-refresh `setInterval` was the root cause of the pagination "detached from DOM" error and the WLM-disabled "never did" content match.
- **Pagination test:** use the stable `[data-test-subj="pagination-button-1"]` selector instead of `.contains('2')`, and assert `aria-current="true"` to confirm the click took effect.
- **WLM-disabled-text test:** swap `cy.get('tbody tr').first().within(...)` for `cy.contains('tbody td', text)` which requeries the parent on every retry.
- **`'disables auto-refresh when toggled off'`:** since `beforeEach` now leaves auto-refresh off, this test re-enables it then toggles off so the observable transition to disabled is still exercised.

A companion PR with the equivalent change is open against opensearch-project/opensearch-dashboards-functional-test 3.7 to keep the cypress specs in sync.

## Test plan

- [ ] Existing GitHub Actions cypress workflows pass.
- [ ] Re-run integ-test-opensearch-dashboards on a Windows distribution build (after the FT 3.7 backport ships) and confirm queryInsightsDashboards passes.