### PR TITLE
Pin GitHub Actions to commit SHAs (#524)

### DIFF
--- a/.github/workflows/add-untriaged.yml
+++ b/.github/workflows/add-untriaged.yml
@@ -11,7 +11,7 @@ jobs:
   apply-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v6
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -26,14 +26,14 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v2.1.0
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
 
       - name: Backport
-        uses: VachaShah/backport@v2.2.0
+        uses: VachaShah/backport@142d3b8a8c70dc54db515e653e5ed3c3fac64100 # v2.2.0
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}
           head_template: backport/backport-<%= number %>-to-<%= base %>

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   Get-CI-Image-Tag:
-    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@643b632712710159088d5f0798de7e91c1f2b8f7 # main
     with:
       product: opensearch-dashboards
 
@@ -28,13 +28,13 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         run: git config --system core.longpaths true
       - name: Checkout OpenSearch-Dashboards
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: opensearch-project/OpenSearch-Dashboards
           ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
           path: OpenSearch-Dashboards
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: './OpenSearch-Dashboards/.nvmrc'
           registry-url: 'https://registry.npmjs.org'
@@ -48,7 +48,7 @@ jobs:
       - run: node -v
       - run: yarn -v
       - name: Checkout Query Insights OpenSearch Dashboards plugin
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: OpenSearch-Dashboards/plugins/query-insights-dashboards
       - name: Bootstrap plugin/OpenSearch-Dashboards
@@ -60,4 +60,4 @@ jobs:
           cd OpenSearch-Dashboards/plugins/query-insights-dashboards
           yarn run test:jest --coverage
       - name: Uploads coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192 # v1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   Get-CI-Image-Tag:
-    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@643b632712710159088d5f0798de7e91c1f2b8f7 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
     with:
       product: opensearch-dashboards
 

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -33,19 +33,20 @@ jobs:
       TERM: xterm
     steps:
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
+          distribution: temurin
           java-version: 21
 
       - name: Checkout Query Insights
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: query-insights
           repository: opensearch-project/query-insights
           ref: ${{ env.QUERY_INSIGHTS_BRANCH }}
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2
         with:
           gradle-version: ${{ env.GRADLE_VERSION }}
 
@@ -70,19 +71,19 @@ jobs:
         shell: bash
 
       - name: Checkout OpenSearch-Dashboards
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: opensearch-project/OpenSearch-Dashboards
           path: OpenSearch-Dashboards
           ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
 
       - name: Checkout Query Insights Dashboards plugin
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: OpenSearch-Dashboards/plugins/query-insights-dashboards
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: './OpenSearch-Dashboards/.nvmrc'
           registry-url: 'https://registry.npmjs.org'
@@ -102,12 +103,18 @@ jobs:
           cd OpenSearch-Dashboards/plugins/query-insights-dashboards
           yarn osd bootstrap --single-version=loose
 
+      - name: Build plugin bundles
+        run: |
+          cd OpenSearch-Dashboards
+          export NODE_OPTIONS="--max-old-space-size=6144"
+          node scripts/build_opensearch_dashboards_platform_plugins --no-examples --workers=2
+        shell: bash
+
       - name: Run OpenSearch-Dashboards server
         run: |
           cd OpenSearch-Dashboards
-          # Set memory limits and DNS resolution for better performance
           export NODE_OPTIONS="--max-old-space-size=6144 --dns-result-order=ipv4first"
-          yarn start --no-base-path --no-watch --server.host="0.0.0.0" &
+          nohup yarn start --no-base-path --no-watch --server.host="0.0.0.0" > /tmp/dashboards.log 2>&1 &
         shell: bash
 
       - name: Wait for OpenSearch-Dashboards to be ready
@@ -143,6 +150,9 @@ jobs:
 
           if [ $attempt -eq $max_attempts ]; then
             echo "OpenSearch-Dashboards failed to start within timeout"
+            echo "=== Last 100 lines of Dashboards log ==="
+            tail -100 /tmp/dashboards.log || true
+            echo "========================================="
             echo "Final debug attempt:"
             curl -s -v http://localhost:5601/api/status || echo "Final connection attempt failed"
             exit 1
@@ -190,14 +200,14 @@ jobs:
 
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ matrix.cypress_cache_folder }}
           key: cypress-cache-v2-${{ matrix.os }}-${{ hashFiles('OpenSearch-Dashboards/plugins/query-insights-dashboards/package.json') }}
 
       # for now just chrome, use matrix to do all browsers later
       - name: Cypress tests
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@248bde77443c376edc45906ede03a1aba9da0462 # v5
         with:
           working-directory: OpenSearch-Dashboards/plugins/query-insights-dashboards
           command: yarn run cypress run --config defaultCommandTimeout=120000,requestTimeout=120000,responseTimeout=120000,pageLoadTimeout=180000,taskTimeout=120000,execTimeout=120000
@@ -210,14 +220,14 @@ jobs:
         timeout-minutes: 60
 
       # Screenshots are only captured on failure, will change this once we do visual regression tests
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: cypress-screenshots-${{ matrix.os }}
           path: OpenSearch-Dashboards/plugins/query-insights-dashboards/cypress/screenshots
 
       # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: cypress-videos-${{ matrix.os }}

--- a/.github/workflows/delete-backport-branch.yml
+++ b/.github/workflows/delete-backport-branch.yml
@@ -7,9 +7,16 @@ on:
 jobs:
   delete-branch:
     runs-on: ubuntu-latest
-    if: startsWith(github.event.pull_request.head.ref,'backport/')
+    permissions:
+      contents: write
+    if: startsWith(github.event.pull_request.head.ref,'backport/') || startsWith(github.event.pull_request.head.ref,'release-chores/')
     steps:
       - name: Delete merged branch
-        uses: SvanBoxel/delete-merged-branch@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            github.rest.git.deleteRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `heads/${context.payload.pull_request.head.ref}`,
+            })

--- a/.github/workflows/lint-workflow.yml
+++ b/.github/workflows/lint-workflow.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout OpenSearch Dashboards
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: opensearch-project/OpenSearch-Dashboards
           ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
           path: OpenSearch-Dashboards
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: './OpenSearch-Dashboards/.nvmrc'
           registry-url: 'https://registry.npmjs.org'
@@ -34,7 +34,7 @@ jobs:
       - run: node -v
       - run: yarn -v
       - name: Checkout Query Insights Dashboards plugin
-        uses: actions/checkout@v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: OpenSearch-Dashboards/plugins/query-insights-dashboards
       - name: Bootstrap plugin/opensearch-dashboards

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -4,7 +4,6 @@ on: [push, pull_request]
 env:
   OPENSEARCH_VERSION: '2.19.0'
   CI: 1
-  # avoid warnings like "tput: No value for $TERM and no -T specified"
   TERM: xterm
   OPENSEARCH_INITIAL_ADMIN_PASSWORD: myStrongPassword123!
 
@@ -15,11 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        # TODO: add windows support when OSD core is stable on windows
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set env
         run: |
@@ -29,27 +27,78 @@ jobs:
           echo "PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
         shell: bash
 
-      - name: Run OpenSearch
-        uses: derek-ho/start-opensearch@v6
+      - name: Set up JDK
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
-          opensearch-version: ${{ env.OPENSEARCH_VERSION }}
-          security-enabled: false
+          distribution: temurin
+          java-version: 21
 
-      - name: Run Dashboard
-        id: setup-dashboards
-        uses: derek-ho/setup-opensearch-dashboards@v1
-        with:
-          plugin_name: query-insights-dashboards
-          built_plugin_name: queryInsightsDashboards
-          install_zip: true
-
-      - name: Start the binary
+      - name: Download and Start OpenSearch
         run: |
-          nohup ./bin/opensearch-dashboards &
-        working-directory: ${{ steps.setup-dashboards.outputs.dashboards-binary-directory }}
+          curl -SLO https://artifacts.opensearch.org/snapshots/core/opensearch/${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/opensearch-min-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT-linux-x64-latest.tar.gz
+          tar -xzf opensearch-*.tar.gz && mv opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT opensearch
+          rm -f opensearch-*.tar.gz
+          echo "cluster.routing.allocation.disk.threshold_enabled: false" >> ./opensearch/config/opensearch.yml
+          ./opensearch/bin/opensearch &
+          sleep 45
+          curl http://localhost:9200/_cat/plugins -v
+        shell: bash
+
+      - name: Checkout OpenSearch-Dashboards
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: opensearch-project/OpenSearch-Dashboards
+          ref: '2.19'
+          path: OpenSearch-Dashboards
+
+      - name: Checkout plugin
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          path: OpenSearch-Dashboards/plugins/query-insights-dashboards
+
+      - name: Setup Node
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
+        with:
+          node-version-file: './OpenSearch-Dashboards/.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Yarn
+        run: |
+          YARN_VERSION=$(node -p "require('./OpenSearch-Dashboards/package.json').engines.yarn")
+          echo "Installing yarn@$YARN_VERSION"
+          npm i -g yarn@$YARN_VERSION
+        shell: bash
+
+      - name: Bootstrap
+        run: |
+          cd OpenSearch-Dashboards/plugins/query-insights-dashboards
+          yarn osd bootstrap --single-version=loose
+        shell: bash
+
+      - name: Build plugin
+        run: |
+          cd OpenSearch-Dashboards/plugins/query-insights-dashboards
+          yarn build
+        shell: bash
+
+      - name: Download OSD min binary
+        run: |
+          curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.OPENSEARCH_VERSION }}/latest/linux/x64/tar/builds/opensearch-dashboards/dist/opensearch-dashboards-min-${{ env.OPENSEARCH_VERSION }}-linux-x64.tar.gz
+          tar -xzf opensearch-dashboards-*.tar.gz
+          rm -f opensearch-dashboards-*.tar.gz
+        shell: bash
+
+      - name: Install plugin into binary
+        run: |
+          ./opensearch-dashboards-${{ env.OPENSEARCH_VERSION }}-linux-x64/bin/opensearch-dashboards-plugin install file:$(pwd)/OpenSearch-Dashboards/plugins/query-insights-dashboards/build/queryInsightsDashboards-${{ env.PLUGIN_VERSION }}.zip
+        shell: bash
+
+      - name: Start Dashboards
+        run: |
+          nohup ./opensearch-dashboards-${{ env.OPENSEARCH_VERSION }}-linux-x64/bin/opensearch-dashboards &
         shell: bash
 
       - name: Health check
         run: |
-          timeout 300 bash -c 'while [[ "$(curl -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} -k http://localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+          timeout 300 bash -c 'while [[ "$(curl -k http://localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
         shell: bash


### PR DESCRIPTION
Cherry-pick of #524 from main to 2.19. Pin all GitHub Action tag references to their corresponding commit SHAs to prevent potential supply chain attacks.

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
