### PR TITLE
Fix main CI failures: bump @babel/runtime to ^7.29.7 and remove unpinnable composite action from binary-install workflow

### DIFF
--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -23,13 +23,6 @@ jobs:
         with:
           path: plugin-source
 
-      - name: Check working directory and list files
-        run: |
-          echo "Current Directory: $(pwd)"
-          echo "Listing files:"
-          ls -la
-
-
       - name: Set env from opensearch_dashboards.json
         run: |
           opensearch_version=$(node -p "require('./opensearch_dashboards.json').opensearchDashboardsVersion")
@@ -39,12 +32,22 @@ jobs:
         working-directory: plugin-source
         shell: bash
 
-      - name: Run OpenSearch
-        uses: derek-ho/start-opensearch@e9060d3df24b30cdbfac62d749fec3367dade572 # v6
+      - name: Set up JDK
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
-          opensearch-version: ${{ env.OPENSEARCH_VERSION }}
-          security-enabled: false
-          jdk-version: 21
+          distribution: temurin
+          java-version: 21
+
+      - name: Download and Start OpenSearch
+        run: |
+          curl -SLO https://artifacts.opensearch.org/snapshots/core/opensearch/${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/opensearch-min-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT-linux-x64-latest.tar.gz
+          tar -xzf opensearch-*.tar.gz && mv opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT opensearch
+          rm -f opensearch-*.tar.gz
+          echo "cluster.routing.allocation.disk.threshold_enabled: false" >> ./opensearch/config/opensearch.yml
+          ./opensearch/bin/opensearch &
+          sleep 45
+          curl http://localhost:9200/_cat/plugins -v
+        shell: bash
 
       - name: Checkout OpenSearch-Dashboards
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
@@ -58,28 +61,18 @@ jobs:
         run: |
           mv plugin-source OpenSearch-Dashboards/plugins/query-insights-dashboards
 
-      - name: Get tool versions
-        id: tool-versions
-        run: |
-          echo "node_version=$(cat .node-version)" >> $GITHUB_OUTPUT
-          echo "yarn_version=$(jq -r '.engines.yarn' package.json)" >> $GITHUB_OUTPUT
-        working-directory: OpenSearch-Dashboards
-
       - name: Setup Node
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
-          node-version: ${{ steps.tool-versions.outputs.node_version }}
+          node-version-file: './OpenSearch-Dashboards/.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
 
-      - name: Setup Yarn
-        uses: Wandalen/wretry.action@e94c43bf2e865e7dbbd90b0c1061053f5888932a # master
-        with:
-          attempts: 3
-          command: |
-            npm uninstall -g yarn
-            npm i -g yarn@${{ steps.tool-versions.outputs.yarn_version }}
-            yarn cache clean
-            yarn add sha.js
-          current_path: OpenSearch-Dashboards
+      - name: Install Yarn
+        run: |
+          YARN_VERSION=$(node -p "require('./OpenSearch-Dashboards/package.json').engines.yarn")
+          echo "Installing yarn@$YARN_VERSION"
+          npm i -g yarn@$YARN_VERSION
+        shell: bash
 
       - name: Bootstrap OpenSearch Dashboards
         uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2
@@ -93,14 +86,11 @@ jobs:
         working-directory: OpenSearch-Dashboards/plugins/query-insights-dashboards
 
       - name: Download OpenSearch Dashboards binary
-        uses: peternied/download-file@6a5025a112bb8811a2eb5ee6dd3417acf6d928e4 # v2
-        with:
-          url: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.OPENSEARCH_VERSION }}/latest/linux/x64/tar/builds/opensearch-dashboards/dist/opensearch-dashboards-min-${{ env.OPENSEARCH_VERSION }}-linux-x64.tar.gz
-
-      - name: Extract binary
         run: |
-          tar -xzf opensearch-*.tar.gz
-          rm -f opensearch-*.tar.gz
+          curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.OPENSEARCH_VERSION }}/latest/linux/x64/tar/builds/opensearch-dashboards/dist/opensearch-dashboards-min-${{ env.OPENSEARCH_VERSION }}-linux-x64.tar.gz
+          tar -xzf opensearch-dashboards-*.tar.gz
+          rm -f opensearch-dashboards-*.tar.gz
+        shell: bash
 
       - name: Install plugin
         run: |
@@ -114,6 +104,6 @@ jobs:
 
       - name: Health check
         run: |
-          timeout 300 bash -c 'while [[ "$(curl -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} -k http://localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+          timeout 300 bash -c 'while [[ "$(curl -k http://localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
         working-directory: opensearch-dashboards-${{ env.OPENSEARCH_VERSION }}-linux-x64
         shell: bash

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@babel/helpers": "^7.22.9",
-    "@babel/runtime": "^7.26.10",
+    "@babel/runtime": "^7.29.7",
     "@babel/runtime-corejs3": "^7.22.9",
     "echarts": "^6.0.0",
     "echarts-for-react": "3.0.6",
@@ -56,7 +56,7 @@
     "serialize-javascript": "7.0.5",
     "glob-parent": "^6.0.0",
     "@babel/helpers": "^7.22.9",
-    "@babel/runtime": "^7.26.10",
+    "@babel/runtime": "^7.29.7",
     "@babel/runtime-corejs3": "^7.22.9",
     "pbkdf2": "3.1.5",
     "form-data": "4.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -240,10 +240,10 @@
   dependencies:
     core-js-pure "^3.48.0"
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.26.10", "@babel/runtime@^7.9.2":
-  version "7.29.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
-  integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.29.7", "@babel/runtime@^7.9.2":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
 
 "@babel/template@^7.28.6", "@babel/template@^7.3.3":
   version "7.28.6"


### PR DESCRIPTION
### Description

Fixes two pre-existing failures that block `main`'s required CI checks. Both are needed together — neither alone makes all required checks pass.

1. **`@babel/runtime` mismatch** (fixes `Run lint` + `Build`): OSD core bumped its requirement to `^7.29.7`, but this plugin pinned `^7.26.10`, so `osd bootstrap` failed the single-version check. Bumped to `^7.29.7` in `package.json` + `yarn.lock`.

2. **Unpinnable composite action** (fixes `Run binary installation`): the org's SHA-pin policy now rejects unpinned actions nested inside `derek-ho/start-opensearch`. Rewrote `verify-binary-installation.yml` to start OpenSearch via plain `run:` steps with first-party pinned actions (same approach as the `2.19` branch).

### Check List
- [x] All tests pass.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
