### PR TITLE
Pin get-ci-image-tag reusable workflow to a SHA with pinned nested actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   Get-CI-Image-Tag:
-    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@c2498b758c08fb7bc48476509a5fc1b8dd5f7493 # main
+    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@761e093b8c1349cc07f21c1d681d3b30bf9e1999 # main
     with:
       product: opensearch-dashboards
 


### PR DESCRIPTION
### Description

The `Get-CI-Image-Tag` check fails on every PR with:

```
The actions iarekylew00t/crane-installer@v1 and actions/checkout@v6 are not allowed in
opensearch-project/query-insights-dashboards because all actions must be pinned to a
full-length commit SHA.
```

This repo calls the reusable workflow `opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml`,
pinned to an older commit (`c2498b75`) whose internal steps used unpinned action tags
(`iarekylew00t/crane-installer@v1`, `actions/checkout@v6`). The org's SHA-pin policy is
enforced recursively, so those nested unpinned actions fail the check. This is pre-existing
and not caused by any PR.

Upstream already fixed this in `opensearch-build` commit `761e093b` ("Update build repo all
workflows to use SHA", #6253), which pins the nested actions.

### Fix

Bump the pinned reference for `get-ci-image-tag.yml` from `c2498b75` to `761e093b` — the
commit that SHA-pins the nested `crane-installer` and `checkout` actions.

### Check List
- [x] All tests pass.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
