### PR TITLE
Replace start-opensearch composite action in WLM security cypress workflow to satisfy SHA-pin policy

### DIFF
--- a/.github/workflows/cypress-tests-wlm.yml
+++ b/.github/workflows/cypress-tests-wlm.yml
@@ -93,16 +93,14 @@ jobs:
           tar -xzf opensearch-*.tar.gz && mv "opensearch-${VERSION}-SNAPSHOT" opensearch
           rm -f opensearch-*.tar.gz
 
-          # Install the WLM and Security plugins
+          # Install the WLM and Security plugins (--batch auto-accepts prompts)
           chmod +x ./opensearch/bin/opensearch-plugin
-          yes | ./opensearch/bin/opensearch-plugin install "file:$GITHUB_WORKSPACE/wlm.zip"
-          yes | ./opensearch/bin/opensearch-plugin install "file:$GITHUB_WORKSPACE/security.zip"
+          ./opensearch/bin/opensearch-plugin install --batch "file:$GITHUB_WORKSPACE/wlm.zip"
+          ./opensearch/bin/opensearch-plugin install --batch "file:$GITHUB_WORKSPACE/security.zip"
 
-          # Run the security demo configuration (-t is required for OpenSearch >= 2.12)
-          export OPENSEARCH_INITIAL_ADMIN_PASSWORD="${OPENSEARCH_INITIAL_ADMIN_PASSWORD}"
+          # Run the security demo configuration (-y: assume yes, -i: init security, -t: test env for OpenSearch >= 2.12)
           chmod +x ./opensearch/plugins/opensearch-security/tools/install_demo_configuration.sh
-          yes | ./opensearch/plugins/opensearch-security/tools/install_demo_configuration.sh -t
-          echo "plugins.security.unsupported.restapi.allow_securityconfig_modification: true" >> ./opensearch/config/opensearch.yml
+          ./opensearch/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -t
           echo "cluster.routing.allocation.disk.threshold_enabled: false" >> ./opensearch/config/opensearch.yml
 
           # Start OpenSearch and wait for it to come up

--- a/.github/workflows/cypress-tests-wlm.yml
+++ b/.github/workflows/cypress-tests-wlm.yml
@@ -83,14 +83,33 @@ jobs:
           cp plugins/workload-management/build/distributions/workload-management-*.zip "$GITHUB_WORKSPACE/wlm.zip"
           ls -lh "$GITHUB_WORKSPACE/wlm.zip"
 
-      - name: Run Opensearch with A Single Plugin
-        uses: derek-ho/start-opensearch@47c6a62637ce79510d7f67ac150639a4510cf694 # v9
-        with:
-          opensearch-version: ${{ steps.get-version.outputs.VERSION }}
-          plugins: "file:$GITHUB_WORKSPACE/wlm.zip,file:$GITHUB_WORKSPACE/security.zip"
-          security-enabled: true
-          admin-password: ${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}
-          jdk-version: 21
+      - name: Run OpenSearch with WLM and Security plugins
+        run: |
+          set -e
+          VERSION=${{ steps.get-version.outputs.VERSION }}
+
+          # Download and extract the OpenSearch core snapshot
+          curl -SLO "https://artifacts.opensearch.org/snapshots/core/opensearch/${VERSION}-SNAPSHOT/opensearch-min-${VERSION}-SNAPSHOT-linux-x64-latest.tar.gz"
+          tar -xzf opensearch-*.tar.gz && mv "opensearch-${VERSION}-SNAPSHOT" opensearch
+          rm -f opensearch-*.tar.gz
+
+          # Install the WLM and Security plugins
+          chmod +x ./opensearch/bin/opensearch-plugin
+          yes | ./opensearch/bin/opensearch-plugin install "file:$GITHUB_WORKSPACE/wlm.zip"
+          yes | ./opensearch/bin/opensearch-plugin install "file:$GITHUB_WORKSPACE/security.zip"
+
+          # Run the security demo configuration (-t is required for OpenSearch >= 2.12)
+          export OPENSEARCH_INITIAL_ADMIN_PASSWORD="${OPENSEARCH_INITIAL_ADMIN_PASSWORD}"
+          chmod +x ./opensearch/plugins/opensearch-security/tools/install_demo_configuration.sh
+          yes | ./opensearch/plugins/opensearch-security/tools/install_demo_configuration.sh -t
+          echo "plugins.security.unsupported.restapi.allow_securityconfig_modification: true" >> ./opensearch/config/opensearch.yml
+          echo "cluster.routing.allocation.disk.threshold_enabled: false" >> ./opensearch/config/opensearch.yml
+
+          # Start OpenSearch and wait for it to come up
+          ./opensearch/bin/opensearch &
+          sleep 30
+          curl https://localhost:9200/_cat/plugins -u "admin:${OPENSEARCH_INITIAL_ADMIN_PASSWORD}" -k -v --fail-with-body
+        shell: bash
 
       - name: Enable WLM (with or without Security) and verify
         run: |


### PR DESCRIPTION
### Description

`Run Cypress E2E tests for WLM with security` fails because `cypress-tests-wlm.yml` uses `derek-ho/start-opensearch@v9`, whose internal actions are unpinned tags. The org's SHA-pin policy is enforced recursively, so this repo can't satisfy it while calling that composite action.

### Fix

Replace the `start-opensearch` step with plain `run:` steps that download OpenSearch, install the WLM + Security plugins (`--batch`), run the security demo config (`-y -i -t`), and start it. Same composite-action-free approach as `verify-binary-installation.yml`; all remaining `uses:` are first-party SHA-pinned actions.

### Check List
- [x] All tests pass.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
