### PR TITLE
Use official opensearch-build start-opensearch action for OpenSearch startup in CI

### DIFF
--- a/.github/workflows/cypress-tests-wlm.yml
+++ b/.github/workflows/cypress-tests-wlm.yml
@@ -84,7 +84,7 @@ jobs:
           ls -lh "$GITHUB_WORKSPACE/wlm.zip"
 
       - name: Run OpenSearch with WLM and Security plugins
-        uses: opensearch-project/opensearch-build/.github/actions/start-opensearch@main
+        uses: opensearch-project/opensearch-build/.github/actions/start-opensearch@15d4a8960ca11210dc1a2aec01c85a3840405085 # main
         with:
           opensearch-version: ${{ steps.get-version.outputs.VERSION }}
           plugins: "file:$GITHUB_WORKSPACE/wlm.zip,file:$GITHUB_WORKSPACE/security.zip"

--- a/.github/workflows/cypress-tests-wlm.yml
+++ b/.github/workflows/cypress-tests-wlm.yml
@@ -84,30 +84,13 @@ jobs:
           ls -lh "$GITHUB_WORKSPACE/wlm.zip"
 
       - name: Run OpenSearch with WLM and Security plugins
-        run: |
-          set -e
-          VERSION=${{ steps.get-version.outputs.VERSION }}
-
-          # Download and extract the OpenSearch core snapshot
-          curl -SLO "https://artifacts.opensearch.org/snapshots/core/opensearch/${VERSION}-SNAPSHOT/opensearch-min-${VERSION}-SNAPSHOT-linux-x64-latest.tar.gz"
-          tar -xzf opensearch-*.tar.gz && mv "opensearch-${VERSION}-SNAPSHOT" opensearch
-          rm -f opensearch-*.tar.gz
-
-          # Install the WLM and Security plugins (--batch auto-accepts prompts)
-          chmod +x ./opensearch/bin/opensearch-plugin
-          ./opensearch/bin/opensearch-plugin install --batch "file:$GITHUB_WORKSPACE/wlm.zip"
-          ./opensearch/bin/opensearch-plugin install --batch "file:$GITHUB_WORKSPACE/security.zip"
-
-          # Run the security demo configuration (-y: assume yes, -i: init security, -t: test env for OpenSearch >= 2.12)
-          chmod +x ./opensearch/plugins/opensearch-security/tools/install_demo_configuration.sh
-          ./opensearch/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -t
-          echo "cluster.routing.allocation.disk.threshold_enabled: false" >> ./opensearch/config/opensearch.yml
-
-          # Start OpenSearch and wait for it to come up
-          ./opensearch/bin/opensearch &
-          sleep 30
-          curl https://localhost:9200/_cat/plugins -u "admin:${OPENSEARCH_INITIAL_ADMIN_PASSWORD}" -k -v --fail-with-body
-        shell: bash
+        uses: opensearch-project/opensearch-build/.github/actions/start-opensearch@main
+        with:
+          opensearch-version: ${{ steps.get-version.outputs.VERSION }}
+          plugins: "file:$GITHUB_WORKSPACE/wlm.zip,file:$GITHUB_WORKSPACE/security.zip"
+          security-enabled: true
+          admin-password: ${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}
+          jdk-version: 21
 
       - name: Enable WLM (with or without Security) and verify
         run: |

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -32,22 +32,12 @@ jobs:
         working-directory: plugin-source
         shell: bash
 
-      - name: Set up JDK
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+      - name: Run OpenSearch
+        uses: opensearch-project/opensearch-build/.github/actions/start-opensearch@main
         with:
-          distribution: temurin
-          java-version: 21
-
-      - name: Download and Start OpenSearch
-        run: |
-          curl -SLO https://artifacts.opensearch.org/snapshots/core/opensearch/${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/opensearch-min-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT-linux-x64-latest.tar.gz
-          tar -xzf opensearch-*.tar.gz && mv opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT opensearch
-          rm -f opensearch-*.tar.gz
-          echo "cluster.routing.allocation.disk.threshold_enabled: false" >> ./opensearch/config/opensearch.yml
-          ./opensearch/bin/opensearch &
-          sleep 45
-          curl http://localhost:9200/_cat/plugins -v
-        shell: bash
+          opensearch-version: ${{ env.OPENSEARCH_VERSION }}
+          security-enabled: false
+          jdk-version: 21
 
       - name: Checkout OpenSearch-Dashboards
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -33,7 +33,7 @@ jobs:
         shell: bash
 
       - name: Run OpenSearch
-        uses: opensearch-project/opensearch-build/.github/actions/start-opensearch@main
+        uses: opensearch-project/opensearch-build/.github/actions/start-opensearch@15d4a8960ca11210dc1a2aec01c85a3840405085 # main
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           security-enabled: false


### PR DESCRIPTION
### Description

Replace the inline OpenSearch startup shell in two CI workflows with the official `opensearch-project/opensearch-build/.github/actions/start-opensearch` action. Both workflows currently duplicate the same download, install, configure, and start sequence, which the action handles.

### Changes

- `cypress-tests-wlm.yml` uses the action with security enabled and the WLM plus Security plugins
- `verify-binary-installation.yml` uses the action with security disabled, replacing the inline script and the standalone JDK setup step that the action already covers

The action is pinned to a full-length commit SHA per the org policy for step-level actions.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
