### PR TITLE
[fix] Handle undefined dataSource in MDS environment

### DIFF
--- a/public/components/DataSourcePicker.tsx
+++ b/public/components/DataSourcePicker.tsx
@@ -48,6 +48,7 @@ export const DataSourceMenu = React.memo(
     const dataSourceEnabled = !!depsStart.dataSource?.dataSourceEnabled;
 
     const wrapSetDataSourceWithUpdateUrl = (dataSources: DataSourceOption[]) => {
+      if (!dataSources || !dataSources[0]) return;
       window.history.replaceState({}, '', getDataSourceEnabledUrl(dataSources[0]).toString());
       setDataSource(dataSources[0]);
       onSelectedDataSource();
@@ -74,7 +75,7 @@ export const DataSourceMenu = React.memo(
     ) : null;
   },
   (prevProps, newProps) =>
-    prevProps.selectedDataSource.id === newProps.selectedDataSource.id &&
+    prevProps.selectedDataSource?.id === newProps.selectedDataSource?.id &&
     prevProps.dataSourcePickerReadOnly === newProps.dataSourcePickerReadOnly
 );
 

--- a/public/utils/datasource-utils.ts
+++ b/public/utils/datasource-utils.ts
@@ -28,7 +28,11 @@ import { getSavedObjectsClient, getRouteService } from '../service';
 
 export function getDataSourceEnabledUrl(dataSource: DataSourceOption) {
   const url = new URL(window.location.href);
-  url.searchParams.set('dataSource', JSON.stringify(dataSource));
+  if (dataSource && (dataSource.id || dataSource.label)) {
+    url.searchParams.set('dataSource', JSON.stringify(dataSource));
+  } else {
+    url.searchParams.delete('dataSource');
+  }
   return url;
 }
 
@@ -61,6 +65,9 @@ export function getDataSourceFromUrl(): DataSourceOption {
   const urlParams = new URLSearchParams(window.location.search);
   const dataSourceParam = (urlParams && urlParams.get('dataSource')) || '{}';
   // following block is needed if the dataSource param is set to non-JSON value, say 'undefined'
+  if (!dataSourceParam || dataSourceParam === 'undefined' || dataSourceParam === 'null') {
+    return {} as DataSourceOption;
+  }
   try {
     return JSON.parse(dataSourceParam);
   } catch (_e) {


### PR DESCRIPTION

### Description

When data_source.hideLocalCluster is true and no remote data sources are configured, the DataSourceSelectable fires onSelectedDataSources with undefined, causing:

1. The memo comparator in DataSourcePicker crashes with TypeError: Cannot read properties of undefined (reading 'id')
2. getDataSourceEnabledUrl writes ?dataSource=undefined to the URL
3. Subsequent API calls fail with 500 errors

Changes:
- Add optional chaining in DataSourcePicker memo comparator
- Guard wrapSetDataSourceWithUpdateUrl against undefined dataSources
- Guard getDataSourceEnabledUrl to remove param when dataSource is invalid
- Handle literal 'undefined'/'null' strings in getDataSourceFromUrl


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
