### PR TITLE
fix: Auto-select data source and prevent crashes in MDS environment

### DIFF
--- a/public/components/DataSourcePicker.tsx
+++ b/public/components/DataSourcePicker.tsx
@@ -48,8 +48,11 @@ export const DataSourceMenu = React.memo(
     const dataSourceEnabled = !!depsStart.dataSource?.dataSourceEnabled;
 
     const wrapSetDataSourceWithUpdateUrl = (dataSources: DataSourceOption[]) => {
-      window.history.replaceState({}, '', getDataSourceEnabledUrl(dataSources[0]).toString());
-      setDataSource(dataSources[0]);
+      if (!dataSources || dataSources.length === 0 || !dataSources[0]) return;
+      const selected = dataSources[0];
+      if (!selected.id && !selected.label) return;
+      window.history.replaceState({}, '', getDataSourceEnabledUrl(selected).toString());
+      setDataSource(selected);
       onSelectedDataSource();
     };
 
@@ -65,7 +68,7 @@ export const DataSourceMenu = React.memo(
           activeOption:
             selectedDataSource?.id || selectedDataSource?.label
               ? [selectedDataSource]
-              : [{ id: '', label: 'Local cluster' }],
+              : undefined,
           onSelectedDataSources: wrapSetDataSourceWithUpdateUrl,
           fullWidth: true,
           dataSourceFilter,
@@ -74,8 +77,9 @@ export const DataSourceMenu = React.memo(
     ) : null;
   },
   (prevProps, newProps) =>
-    prevProps.selectedDataSource.id === newProps.selectedDataSource.id &&
-    prevProps.dataSourcePickerReadOnly === newProps.dataSourcePickerReadOnly
+    prevProps.selectedDataSource?.id === newProps.selectedDataSource?.id &&
+    prevProps.dataSourcePickerReadOnly === newProps.dataSourcePickerReadOnly &&
+    prevProps.selectedDataSource?.label === newProps.selectedDataSource?.label
 );
 
 // Use the same component for both Query Insights and WLM

--- a/public/pages/TopNQueries/TopNQueries.tsx
+++ b/public/pages/TopNQueries/TopNQueries.tsx
@@ -106,6 +106,17 @@ const TopNQueries = ({
   const [currStart, setStart] = useState(initialStart);
   const [currEnd, setEnd] = useState(initialEnd);
   const [showLiveQueries, setShowLiveQueries] = useState<boolean>(true);
+
+  // Clean up invalid dataSource URL params on mount
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    const dsParam = url.searchParams.get('dataSource');
+    if (dsParam === 'undefined' || dsParam === 'null') {
+      url.searchParams.delete('dataSource');
+      window.history.replaceState({}, '', url.toString());
+    }
+  }, []);
+
   const dataSourceFromUrl = getDataSourceFromUrl();
   const dataSourceId = dataSourceFromUrl.id;
 
@@ -180,6 +191,43 @@ const TopNQueries = ({
 
   const [queries, setQueries] = useState<SearchQueryRecord[]>([]);
 
+  // Determine if MDS is enabled (data source plugin available)
+  const dataSourceEnabled = !!depsStart.dataSource?.dataSourceEnabled;
+
+  // Check if we have a valid data source to query against
+  const hasValidDataSource = !dataSourceEnabled || !!dataSource?.id || !!dataSource?.label;
+
+  // Auto-select first available data source when MDS is enabled but none is selected
+  useEffect(() => {
+    if (!dataSourceEnabled || dataSource?.id) return;
+
+    const autoSelectDataSource = async () => {
+      try {
+        const savedObjectsClient = core.savedObjects.client;
+        const response = await savedObjectsClient.find<any>({
+          type: 'data-source',
+          perPage: 1,
+        });
+        if (response.savedObjects.length > 0) {
+          const firstDs = response.savedObjects[0];
+          const selected: DataSourceOption = {
+            id: firstDs.id,
+            label: firstDs.attributes?.title || firstDs.id,
+          };
+          wrappedSetDataSource(selected);
+          // Update URL with the selected data source
+          const url = new URL(window.location.href);
+          url.searchParams.set('dataSource', JSON.stringify(selected));
+          window.history.replaceState({}, '', url.toString());
+        }
+      } catch (error) {
+        console.error('Failed to auto-select data source:', error);
+      }
+    };
+
+    autoSelectDataSource();
+  }, [dataSourceEnabled, dataSource?.id]);
+
   useEffect(() => {
     let isComponentUnmounted = false;
 
@@ -235,6 +283,7 @@ const TopNQueries = ({
   const retrieveQueries = useCallback(
     async (start: string, end: string) => {
       if (loading) return;
+      if (dataSourceEnabled && !getDataSourceFromUrl().id) return; // No valid data source in MDS mode
       setLoading(true);
       const nullResponse = { response: { top_queries: [] } };
       const apiParams = {
@@ -310,7 +359,7 @@ const TopNQueries = ({
         setLoading(false);
       }
     },
-    [latencySettings, cpuSettings, memorySettings, core]
+    [latencySettings, cpuSettings, memorySettings, core, dataSourceEnabled]
   );
 
   const retrieveConfigInfo = useCallback(
@@ -329,6 +378,7 @@ const TopNQueries = ({
       newRemotePath: string = ''
     ) => {
       if (get) {
+        if (dataSourceEnabled && !getDataSourceFromUrl().id) return; // No valid data source in MDS mode
         try {
           // const resp = await core.http.get('/api/settings', {query: {dataSourceId: '738ffbd0-d8de-11ef-9d96-eff1abd421b8'}});
           const resp = await core.http.get('/api/settings', {
@@ -463,7 +513,7 @@ const TopNQueries = ({
         }
       }
     },
-    [core]
+    [core, dataSourceEnabled]
   );
 
   const onTimeChange = ({ start, end }: { start: string; end: string }) => {
@@ -484,7 +534,7 @@ const TopNQueries = ({
 
   useEffect(() => {
     retrieveQueries(currStart, currEnd);
-  }, [latencySettings, cpuSettings, memorySettings, currStart, currEnd, retrieveQueries]);
+  }, [latencySettings, cpuSettings, memorySettings, currStart, currEnd, retrieveQueries, dataSource?.id]);
 
   return (
     <DataSourceContext.Provider value={{ dataSource, setDataSource: wrappedSetDataSource }}>

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -66,10 +66,21 @@ export class QueryInsightsDashboardsPlugin
         // Get start services as specified in opensearch_dashboards.json
         const [coreStart, depsStart] = await core.getStartServices();
 
-        // Preserve data source from URL if navigating between apps
+        // Strip invalid dataSource param from URL immediately
         const urlParams = new URLSearchParams(window.location.search);
         const dataSourceParam = urlParams.get('dataSource');
-        if (dataSourceParam && !params.history.location.search.includes('dataSource')) {
+        if (dataSourceParam === 'undefined' || dataSourceParam === 'null') {
+          const cleanUrl = new URL(window.location.href);
+          cleanUrl.searchParams.delete('dataSource');
+          window.history.replaceState({}, '', cleanUrl.toString());
+        }
+
+        // Preserve data source from URL if navigating between apps
+        const isValidDataSourceParam =
+          dataSourceParam &&
+          dataSourceParam !== 'undefined' &&
+          dataSourceParam !== 'null';
+        if (isValidDataSourceParam && !params.history.location.search.includes('dataSource')) {
           const newUrl = `${params.history.location.pathname}?dataSource=${encodeURIComponent(
             dataSourceParam
           )}`;
@@ -110,7 +121,11 @@ export class QueryInsightsDashboardsPlugin
           // Preserve data source from URL if navigating between apps
           const urlParams = new URLSearchParams(window.location.search);
           const dataSourceParam = urlParams.get('dataSource');
-          if (dataSourceParam && !params.history.location.search.includes('dataSource')) {
+          const isValidDataSourceParam =
+            dataSourceParam &&
+            dataSourceParam !== 'undefined' &&
+            dataSourceParam !== 'null';
+          if (isValidDataSourceParam && !params.history.location.search.includes('dataSource')) {
             const newUrl = `${params.history.location.pathname}?dataSource=${encodeURIComponent(
               dataSourceParam
             )}`;
@@ -169,7 +184,11 @@ export class QueryInsightsDashboardsPlugin
         url: undefined,
         onClick: () => {
           const currentDataSource = new URLSearchParams(window.location.search).get('dataSource');
-          const targetUrl = currentDataSource
+          const isValidDataSource =
+            currentDataSource &&
+            currentDataSource !== 'undefined' &&
+            currentDataSource !== 'null';
+          const targetUrl = isValidDataSource
             ? `/app/workload-management?dataSource=${encodeURIComponent(
                 currentDataSource
               )}#/workloadManagement`
@@ -183,7 +202,11 @@ export class QueryInsightsDashboardsPlugin
       url: undefined,
       onClick: () => {
         const currentDataSource = new URLSearchParams(window.location.search).get('dataSource');
-        const targetUrl = currentDataSource
+        const isValidDataSource =
+          currentDataSource &&
+          currentDataSource !== 'undefined' &&
+          currentDataSource !== 'null';
+        const targetUrl = isValidDataSource
           ? `/app/query-insights-dashboards?dataSource=${encodeURIComponent(
               currentDataSource
             )}#/queryInsights`

--- a/public/utils/datasource-utils.ts
+++ b/public/utils/datasource-utils.ts
@@ -28,7 +28,16 @@ import { getSavedObjectsClient, getRouteService } from '../service';
 
 export function getDataSourceEnabledUrl(dataSource: DataSourceOption) {
   const url = new URL(window.location.href);
-  url.searchParams.set('dataSource', JSON.stringify(dataSource));
+  if (
+    dataSource &&
+    (dataSource.id || dataSource.label) &&
+    dataSource.id !== undefined &&
+    String(dataSource.id) !== 'undefined'
+  ) {
+    url.searchParams.set('dataSource', JSON.stringify(dataSource));
+  } else {
+    url.searchParams.delete('dataSource');
+  }
   return url;
 }
 
@@ -61,10 +70,21 @@ export function getDataSourceFromUrl(): DataSourceOption {
   const urlParams = new URLSearchParams(window.location.search);
   const dataSourceParam = (urlParams && urlParams.get('dataSource')) || '{}';
   // following block is needed if the dataSource param is set to non-JSON value, say 'undefined'
+  if (!dataSourceParam || dataSourceParam === 'undefined' || dataSourceParam === 'null') {
+    return {} as DataSourceOption;
+  }
   try {
-    return JSON.parse(dataSourceParam);
+    const parsed = JSON.parse(dataSourceParam);
+    // Guard against parsed objects with id set to undefined or the string "undefined"
+    if (
+      Object.keys(parsed).length > 0 &&
+      (parsed.id === undefined || parsed.id === 'undefined' || parsed.id === null)
+    ) {
+      return { ...parsed, id: '' } as DataSourceOption;
+    }
+    return parsed;
   } catch (_e) {
-    return JSON.parse('{}'); // Return an empty object or some default value if parsing fails
+    return {} as DataSourceOption;
   }
 }
 


### PR DESCRIPTION
### Description

When hideLocalCluster is true and no data source is selected, the plugin fires API calls to the non-existent local cluster causing 500 errors and a TypeError crash on undefined.id access. This commit:

- Auto-selects first available data source when MDS is enabled
- Guards retrieveQueries/retrieveConfigInfo against missing dataSourceId
- Prevents dataSource=undefined from polluting the URL
- Adds optional chaining in DataSourcePicker memo comparator
- Validates dataSource param before writing to URL in getDataSourceEnabledUrl
- Normalizes invalid dataSource values in getDataSourceFromUrl

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
