### PR TITLE
Bump js-yaml to 4.2.0 and qs to 6.15.2 to address CVE-2026-53550 and CVE-2026-8723

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,11 +62,11 @@
     "form-data": "4.0.6",
     "sha.js": "^2.4.12",
     "min-document": "^2.19.1",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.2.0",
     "yaml": "^2.8.3",
     "minimatch": "^3.1.3",
     "lodash": "^4.18.0",
-    "qs": "^6.14.1"
+    "qs": "^6.15.2"
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3460,9 +3460,9 @@ jest-worker@^27.5.1:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1, js-yaml@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
+  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
   dependencies:
     argparse "^2.0.1"
 
@@ -4129,9 +4129,9 @@ punycode@^2.1.1, punycode@^2.3.1:
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
 qs@^6.14.1, qs@~6.14.1:
-  version "6.15.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.1.tgz#bdb55aed06bfac257a90c44a446a73fba5575c8f"
-  integrity sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
+  integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
   dependencies:
     side-channel "^1.1.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3459,7 +3459,7 @@ jest-worker@^27.5.1:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1, js-yaml@^4.1.1:
+js-yaml@^3.13.1, js-yaml@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
   integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
@@ -4128,7 +4128,7 @@ punycode@^2.1.1, punycode@^2.3.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-qs@^6.14.1, qs@~6.14.1:
+qs@^6.15.2, qs@~6.14.1:
   version "6.15.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
   integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==


### PR DESCRIPTION
### Description

Bumps two transitive dev-dependencies flagged by Mend to their patched versions:

- `js-yaml` `4.1.1` -> `4.2.0` (fixes **CVE-2026-53550**, Medium, algorithmic DoS)
- `qs` `6.15.1` -> `6.15.2` (fixes **CVE-2026-8723**, Medium, null-pointer crash)

Both are dev/test-only transitive deps (via `@istanbuljs/load-nyc-config` and `@cypress/request`), not shipped runtime code.

The `resolutions` floors are also raised to `js-yaml: ^4.2.0` and `qs: ^6.15.2` so that any future lockfile regeneration cannot regress below the patched versions. (`qs: ^6.15.2` matches the root OpenSearch-Dashboards resolution.) These live only in the `resolutions` block, so they do not trigger the monorepo `single_version_dependencies` check.

### Issues Resolved

Addresses CVE-2026-53550 and CVE-2026-8723.

### Check List
- [x] All tests pass.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.