### PR TITLE
[feat] Adds a reusable column visibility system allowing users to dynamically show/hide columns in both the Top N Queries and Live Queries tables 

### DIFF
--- a/cypress/e2e/qi/1_top_queries.cy.js
+++ b/cypress/e2e/qi/1_top_queries.cy.js
@@ -238,10 +238,7 @@ describe('Query Insights — Dynamic Columns with Intercepted Top Queries (MIXED
       'Avg CPU Time / CPU Time',
       'Avg Memory Usage / Memory Usage',
       'Indices',
-      'Search Type',
-      'Coordinator Node ID',
       'WLM Group',
-      'Total Shards',
     ];
     getHeaders().should('deep.equal', expected);
     assertRowCountEquals(totalRowCount);
@@ -262,10 +259,7 @@ describe('Query Insights — Dynamic Columns with Intercepted Top Queries (MIXED
       'CPU Time',
       'Memory Usage',
       'Indices',
-      'Search Type',
-      'Coordinator Node ID',
       'WLM Group',
-      'Total Shards',
     ];
     getHeaders().should('deep.equal', expected);
 
@@ -315,10 +309,7 @@ describe('Query Insights — Dynamic Columns with Intercepted Top Queries (MIXED
       'Avg CPU Time / CPU Time',
       'Avg Memory Usage / Memory Usage',
       'Indices',
-      'Search Type',
-      'Coordinator Node ID',
       'WLM Group',
-      'Total Shards',
     ];
     getHeaders().should('deep.equal', expected);
     assertRowCountEquals(totalRowCount);
@@ -351,10 +342,7 @@ describe('Query Insights — Dynamic Columns (QUERY ONLY fixture)', () => {
       'CPU Time',
       'Memory Usage',
       'Indices',
-      'Search Type',
-      'Coordinator Node ID',
       'WLM Group',
-      'Total Shards',
     ];
     getHeaders().should('deep.equal', expected);
     assertRowCountEquals(getRowsFromRaw(QUERY_ONLY).length);
@@ -385,7 +373,7 @@ describe('Query Insights — Dynamic Columns (GROUP ONLY fixture)', () => {
     assertRowCountEquals(getRowsFromRaw(GROUP_ONLY).length);
   });
 
-  it('renders dash in status column for group rows', () => {
+  it('renders no status badges in group-only view', () => {
     cy.get('.euiTableRow').each(($row) => {
       cy.wrap($row).find('.euiBadge').should('not.exist');
     });
@@ -623,11 +611,6 @@ describe('Query Insights — DynamicSearchBar', () => {
       .clear()
       .type('search_type = query_then_fetch');
     cy.get('.euiBasicTable').last().find('.euiTableRow').should('have.length.greaterThan', 0);
-    cy.get('.euiBasicTable')
-      .last()
-      .find('.euiTableRow')
-      .first()
-      .should('contain.text', 'query then fetch');
   });
 
   it('shows filter badges for active conditions', () => {
@@ -668,5 +651,126 @@ describe('Query Insights — DynamicSearchBar', () => {
   it('shows no items when filter matches nothing', () => {
     cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`).clear().type('id = nonexistent_xyz_123');
     cy.get('.euiBasicTable').last().contains('No items found').should('be.visible');
+  });
+});
+
+describe('Query Insights — Column Visibility', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/top_queries/**', (req) => {
+      req.reply({ statusCode: 200, body: makeTimestampedBody(MIXED) });
+    }).as('topQueries');
+
+    // Clear localStorage before visiting so column preferences start fresh
+    cy.clearLocalStorage('queryInsights_topn_visibleColumns');
+
+    cy.waitForQueryInsightsPlugin();
+    cy.wait('@topQueries');
+
+    // Ensure the table is rendered before interacting
+    cy.get('.euiBasicTable')
+      .last()
+      .find('.euiTableHeaderCell')
+      .should('have.length.greaterThan', 0);
+  });
+
+  it('displays the Columns button', () => {
+    cy.get('[data-test-subj="column-visibility-button"]').should('exist').and('be.visible');
+  });
+
+  it('opens popover with column checkboxes on click', () => {
+    cy.get('[data-test-subj="column-visibility-button"]').click();
+    cy.get('[data-test-subj="column-visibility-show-all"]').should('be.visible');
+    cy.get('[data-test-subj="column-visibility-hide-all"]').should('be.visible');
+    cy.get('[data-test-subj^="column-toggle-"]').should('have.length.greaterThan', 0);
+    // Close popover
+    cy.get('body').click(0, 0);
+  });
+
+  it('hides a column when unchecked', () => {
+    // Verify Indices column is visible initially
+    cy.get('.euiBasicTable').last().find('.euiTableHeaderCell').contains('Indices').should('exist');
+
+    // Open popover and toggle "Indices" column off
+    cy.get('[data-test-subj="column-visibility-button"]').click();
+    cy.wait(500);
+    cy.get('[data-test-subj="column-toggle-indices"]').click({ force: true });
+
+    // Close popover
+    cy.get('[data-test-subj="column-visibility-button"]').click();
+    cy.wait(300);
+
+    // Verify "Indices" header is gone
+    cy.get('.euiBasicTable')
+      .last()
+      .find('.euiTableHeaderCell')
+      .contains('Indices')
+      .should('not.exist');
+  });
+
+  it('shows a column when checked', () => {
+    // First hide Indices
+    cy.get('[data-test-subj="column-visibility-button"]').click();
+    cy.wait(500);
+    cy.get('[data-test-subj="column-toggle-indices"]').click({ force: true });
+    cy.get('[data-test-subj="column-visibility-button"]').click();
+    cy.wait(300);
+    cy.get('.euiBasicTable')
+      .last()
+      .find('.euiTableHeaderCell')
+      .contains('Indices')
+      .should('not.exist');
+
+    // Now show it again
+    cy.get('[data-test-subj="column-visibility-button"]').click();
+    cy.wait(500);
+    cy.get('[data-test-subj="column-toggle-indices"]').click({ force: true });
+    cy.get('[data-test-subj="column-visibility-button"]').click();
+    cy.wait(300);
+
+    // Verify "Indices" header is back
+    cy.get('.euiBasicTable').last().find('.euiTableHeaderCell').contains('Indices').should('exist');
+  });
+
+  it('ID column checkbox is disabled (pinned)', () => {
+    cy.get('[data-test-subj="column-visibility-button"]').click();
+    cy.wait(500);
+    cy.get('[data-test-subj="column-toggle-id"]').should('be.disabled');
+    cy.get('[data-test-subj="column-visibility-button"]').click();
+  });
+
+  it('Show all makes all columns visible', () => {
+    // First hide a column
+    cy.get('[data-test-subj="column-visibility-button"]').click();
+    cy.wait(500);
+    cy.get('[data-test-subj="column-toggle-type"]').click({ force: true });
+    cy.get('[data-test-subj="column-visibility-button"]').click();
+    cy.wait(300);
+    cy.get('.euiBasicTable')
+      .last()
+      .find('.euiTableHeaderCell')
+      .contains('Type')
+      .should('not.exist');
+
+    // Open popover and click Show all
+    cy.get('[data-test-subj="column-visibility-button"]').click();
+    cy.wait(500);
+    cy.get('[data-test-subj="column-visibility-show-all"]').click();
+    cy.get('[data-test-subj="column-visibility-button"]').click();
+    cy.wait(300);
+
+    // Verify Type column is back
+    cy.get('.euiBasicTable').last().find('.euiTableHeaderCell').contains('Type').should('exist');
+  });
+
+  it('Hide all keeps only pinned columns', () => {
+    cy.get('[data-test-subj="column-visibility-button"]').click();
+    cy.wait(500);
+    cy.get('[data-test-subj="column-visibility-hide-all"]').click();
+    cy.get('[data-test-subj="column-visibility-button"]').click();
+    cy.wait(300);
+
+    // Only "Id" should remain (pinned)
+    cy.get('.euiBasicTable').last().find('.euiTableHeaderCell').should('have.length', 1);
+    cy.get('.euiBasicTable').last().find('.euiTableHeaderCell').contains('Id').should('exist');
   });
 });

--- a/cypress/e2e/qi/1_top_queries.cy.js
+++ b/cypress/e2e/qi/1_top_queries.cy.js
@@ -684,18 +684,27 @@ describe('Query Insights — Column Visibility', () => {
     cy.get('body').click(0, 0);
   });
 
+  // Opens the popover and waits for its content to be rendered/visible,
+  // avoiding arbitrary fixed sleeps.
+  const openColumnPopover = () => {
+    cy.get('[data-test-subj="column-visibility-button"]').click();
+    cy.get('[data-test-subj="column-visibility-show-all"]').should('be.visible');
+  };
+
+  // Closes the popover and waits for its content to be removed from the DOM.
+  const closeColumnPopover = () => {
+    cy.get('[data-test-subj="column-visibility-button"]').click();
+    cy.get('[data-test-subj="column-visibility-show-all"]').should('not.exist');
+  };
+
   it('hides a column when unchecked', () => {
     // Verify Indices column is visible initially
     cy.get('.euiBasicTable').last().find('.euiTableHeaderCell').contains('Indices').should('exist');
 
     // Open popover and toggle "Indices" column off
-    cy.get('[data-test-subj="column-visibility-button"]').click();
-    cy.wait(500);
+    openColumnPopover();
     cy.get('[data-test-subj="column-toggle-indices"]').click({ force: true });
-
-    // Close popover
-    cy.get('[data-test-subj="column-visibility-button"]').click();
-    cy.wait(300);
+    closeColumnPopover();
 
     // Verify "Indices" header is gone
     cy.get('.euiBasicTable')
@@ -707,11 +716,9 @@ describe('Query Insights — Column Visibility', () => {
 
   it('shows a column when checked', () => {
     // First hide Indices
-    cy.get('[data-test-subj="column-visibility-button"]').click();
-    cy.wait(500);
+    openColumnPopover();
     cy.get('[data-test-subj="column-toggle-indices"]').click({ force: true });
-    cy.get('[data-test-subj="column-visibility-button"]').click();
-    cy.wait(300);
+    closeColumnPopover();
     cy.get('.euiBasicTable')
       .last()
       .find('.euiTableHeaderCell')
@@ -719,30 +726,25 @@ describe('Query Insights — Column Visibility', () => {
       .should('not.exist');
 
     // Now show it again
-    cy.get('[data-test-subj="column-visibility-button"]').click();
-    cy.wait(500);
+    openColumnPopover();
     cy.get('[data-test-subj="column-toggle-indices"]').click({ force: true });
-    cy.get('[data-test-subj="column-visibility-button"]').click();
-    cy.wait(300);
+    closeColumnPopover();
 
     // Verify "Indices" header is back
     cy.get('.euiBasicTable').last().find('.euiTableHeaderCell').contains('Indices').should('exist');
   });
 
   it('ID column checkbox is disabled (pinned)', () => {
-    cy.get('[data-test-subj="column-visibility-button"]').click();
-    cy.wait(500);
+    openColumnPopover();
     cy.get('[data-test-subj="column-toggle-id"]').should('be.disabled');
-    cy.get('[data-test-subj="column-visibility-button"]').click();
+    closeColumnPopover();
   });
 
   it('Show all makes all columns visible', () => {
     // First hide a column
-    cy.get('[data-test-subj="column-visibility-button"]').click();
-    cy.wait(500);
+    openColumnPopover();
     cy.get('[data-test-subj="column-toggle-type"]').click({ force: true });
-    cy.get('[data-test-subj="column-visibility-button"]').click();
-    cy.wait(300);
+    closeColumnPopover();
     cy.get('.euiBasicTable')
       .last()
       .find('.euiTableHeaderCell')
@@ -750,22 +752,18 @@ describe('Query Insights — Column Visibility', () => {
       .should('not.exist');
 
     // Open popover and click Show all
-    cy.get('[data-test-subj="column-visibility-button"]').click();
-    cy.wait(500);
+    openColumnPopover();
     cy.get('[data-test-subj="column-visibility-show-all"]').click();
-    cy.get('[data-test-subj="column-visibility-button"]').click();
-    cy.wait(300);
+    closeColumnPopover();
 
     // Verify Type column is back
     cy.get('.euiBasicTable').last().find('.euiTableHeaderCell').contains('Type').should('exist');
   });
 
   it('Hide all keeps only pinned columns', () => {
-    cy.get('[data-test-subj="column-visibility-button"]').click();
-    cy.wait(500);
+    openColumnPopover();
     cy.get('[data-test-subj="column-visibility-hide-all"]').click();
-    cy.get('[data-test-subj="column-visibility-button"]').click();
-    cy.wait(300);
+    closeColumnPopover();
 
     // Only "Id" should remain (pinned)
     cy.get('.euiBasicTable').last().find('.euiTableHeaderCell').should('have.length', 1);

--- a/cypress/e2e/qi/1_top_queries.cy.js
+++ b/cypress/e2e/qi/1_top_queries.cy.js
@@ -158,7 +158,6 @@ describe('Query Insights Dashboard', () => {
     cy.get('body').should('not.contain', 'No items found');
     // Click the Timestamp column header in main table to sort
     cy.get('.euiBasicTable').last().find('.euiTableHeaderCell').contains('Timestamp').click();
-    // eslint-disable-next-line jest/valid-expect-in-promise
     cy.get('.euiBasicTable')
       .last()
       .find('.euiTableRow')
@@ -167,7 +166,6 @@ describe('Query Insights Dashboard', () => {
       .then((firstRowAfterSort) => {
         const firstTimestamp = firstRowAfterSort.trim();
         cy.get('.euiBasicTable').last().find('.euiTableHeaderCell').contains('Timestamp').click();
-        // eslint-disable-next-line jest/valid-expect-in-promise
         cy.get('.euiBasicTable')
           .last()
           .find('.euiTableRow')

--- a/cypress/e2e/qi/5_live_queries.cy.js
+++ b/cypress/e2e/qi/5_live_queries.cy.js
@@ -147,7 +147,7 @@ describe('Inflight Queries Dashboard', () => {
   });
 
   it('manually refreshes data', () => {
-    cy.get('[data-test-subj="live-queries-refresh-button"]').click();
+    cy.get('[data-test-subj="live-queries-refresh-button"]').click({ force: true });
     cy.wait('@getLiveQueries');
   });
 

--- a/public/components/ColumnVisibilityPopover.test.tsx
+++ b/public/components/ColumnVisibilityPopover.test.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, fireEvent, screen, configure } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ColumnVisibilityPopover } from './ColumnVisibilityPopover';
+import { ColumnDef } from '../hooks/useColumnVisibility';
+
+// EUI uses data-test-subj instead of data-testid
+configure({ testIdAttribute: 'data-test-subj' });
+
+const mockColumns: ColumnDef[] = [
+  { id: 'id', label: 'ID', pinned: true },
+  { id: 'type', label: 'Type' },
+  { id: 'timestamp', label: 'Timestamp' },
+  { id: 'latency', label: 'Latency' },
+];
+
+const defaultProps = {
+  columns: mockColumns,
+  visibleColumnIds: new Set(['id', 'type', 'timestamp', 'latency']),
+  onToggleColumn: jest.fn(),
+  onShowAll: jest.fn(),
+  onHideAll: jest.fn(),
+};
+
+function openPopover() {
+  const button = screen.getByTestId('column-visibility-button');
+  fireEvent.click(button);
+}
+
+describe('ColumnVisibilityPopover', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('opens the popover on button click', () => {
+    render(<ColumnVisibilityPopover {...defaultProps} />);
+    expect(screen.queryByTestId('column-visibility-show-all')).toBeNull();
+    openPopover();
+    expect(screen.getByTestId('column-visibility-show-all')).toBeTruthy();
+  });
+
+  it('renders all columns as checkboxes', () => {
+    render(<ColumnVisibilityPopover {...defaultProps} />);
+    openPopover();
+    mockColumns.forEach((col) => {
+      // EUI puts data-test-subj directly on the input element
+      const checkbox = screen.getByTestId(`column-toggle-${col.id}`);
+      expect(checkbox).toBeTruthy();
+      expect(checkbox.tagName).toBe('INPUT');
+      expect(screen.getByLabelText(col.label)).toBeTruthy();
+    });
+  });
+
+  it('disables checkboxes for pinned columns', () => {
+    render(<ColumnVisibilityPopover {...defaultProps} />);
+    openPopover();
+    const pinnedCheckbox = screen.getByTestId('column-toggle-id') as HTMLInputElement;
+    expect(pinnedCheckbox.disabled).toBe(true);
+  });
+
+  it('calls onToggleColumn when a non-pinned checkbox is toggled', () => {
+    render(<ColumnVisibilityPopover {...defaultProps} />);
+    openPopover();
+    const typeCheckbox = screen.getByTestId('column-toggle-type');
+    fireEvent.click(typeCheckbox);
+    expect(defaultProps.onToggleColumn).toHaveBeenCalledWith('type');
+  });
+
+  it('calls onShowAll when "Show all" is clicked', () => {
+    render(<ColumnVisibilityPopover {...defaultProps} />);
+    openPopover();
+    fireEvent.click(screen.getByTestId('column-visibility-show-all'));
+    expect(defaultProps.onShowAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onHideAll when "Hide all" is clicked', () => {
+    render(<ColumnVisibilityPopover {...defaultProps} />);
+    openPopover();
+    fireEvent.click(screen.getByTestId('column-visibility-hide-all'));
+    expect(defaultProps.onHideAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('has proper accessibility attributes', () => {
+    render(<ColumnVisibilityPopover {...defaultProps} />);
+    const button = screen.getByTestId('column-visibility-button');
+    expect(button.getAttribute('aria-label')).toBe('Toggle column visibility');
+    openPopover();
+    mockColumns.forEach((col) => {
+      expect(screen.getByLabelText(col.label)).toBeTruthy();
+    });
+  });
+});

--- a/public/components/ColumnVisibilityPopover.tsx
+++ b/public/components/ColumnVisibilityPopover.tsx
@@ -44,34 +44,18 @@ export const ColumnVisibilityPopover: React.FC<ColumnVisibilityPopoverProps> = (
   }, []);
 
   const button = (
-    <button
+    <EuiButtonEmpty
       onClick={togglePopover}
       aria-label="Toggle column visibility"
       data-test-subj="column-visibility-button"
-      style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: 8,
-        padding: '0 12px',
-        height: 40,
-        cursor: 'pointer',
-        fontSize: 14,
-        color: '#017D73',
-        fontWeight: 400,
-        width: 'auto',
-        minWidth: 0,
-        textAlign: 'left',
-        border: '1px solid #D3DAE6',
-        borderRadius: 0,
-        background: 'transparent',
-        outline: 'none',
-        boxShadow: 'none',
-      }}
+      iconType="tableDensityExpanded"
+      iconSide="left"
+      size="s"
+      flush="both"
     >
-      <EuiIcon type="tableDensityExpanded" size="m" color="#017D73" />
       <span>Columns</span>
-      <EuiIcon type="arrowDown" size="s" color="#017D73" />
-    </button>
+      <EuiIcon type="arrowDown" size="s" style={{ marginLeft: 4 }} aria-hidden={true} />
+    </EuiButtonEmpty>
   );
 
   return (
@@ -115,8 +99,8 @@ export const ColumnVisibilityPopover: React.FC<ColumnVisibilityPopoverProps> = (
             const tooltipContent = isPinned
               ? 'This column cannot be hidden'
               : isUnavailable
-              ? 'Not applicable for aggregated data'
-              : '';
+                ? 'Not applicable for aggregated data'
+                : '';
 
             const checkbox = (
               <EuiCheckbox

--- a/public/components/ColumnVisibilityPopover.tsx
+++ b/public/components/ColumnVisibilityPopover.tsx
@@ -1,0 +1,148 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useCallback } from 'react';
+import {
+  EuiPopover,
+  EuiButtonEmpty,
+  EuiCheckbox,
+  EuiToolTip,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiIcon,
+} from '@elastic/eui';
+import { ColumnDef } from '../hooks/useColumnVisibility';
+
+export interface ColumnVisibilityPopoverProps {
+  columns: ColumnDef[];
+  visibleColumnIds: Set<string>;
+  onToggleColumn: (id: string) => void;
+  onShowAll: () => void;
+  onHideAll: () => void;
+  unavailableColumnIds?: Set<string>;
+}
+
+export const ColumnVisibilityPopover: React.FC<ColumnVisibilityPopoverProps> = ({
+  columns,
+  visibleColumnIds,
+  onToggleColumn,
+  onShowAll,
+  onHideAll,
+  unavailableColumnIds = new Set(),
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const togglePopover = useCallback(() => {
+    setIsOpen((prev) => !prev);
+  }, []);
+
+  const closePopover = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const button = (
+    <button
+      onClick={togglePopover}
+      aria-label="Toggle column visibility"
+      data-test-subj="column-visibility-button"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 8,
+        padding: '0 12px',
+        height: 40,
+        cursor: 'pointer',
+        fontSize: 14,
+        color: '#017D73',
+        fontWeight: 400,
+        width: 'auto',
+        minWidth: 0,
+        textAlign: 'left',
+        border: '1px solid #D3DAE6',
+        borderRadius: 0,
+        background: 'transparent',
+        outline: 'none',
+        boxShadow: 'none',
+      }}
+    >
+      <EuiIcon type="tableDensityExpanded" size="m" color="#017D73" />
+      <span>Columns</span>
+      <EuiIcon type="arrowDown" size="s" color="#017D73" />
+    </button>
+  );
+
+  return (
+    <EuiPopover
+      button={button}
+      isOpen={isOpen}
+      closePopover={closePopover}
+      anchorPosition="downLeft"
+      panelPaddingSize="s"
+      data-test-subj="column-visibility-popover"
+    >
+      <div style={{ width: 260 }}>
+        <EuiFlexGroup gutterSize="s" justifyContent="spaceBetween" alignItems="center">
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              size="xs"
+              onClick={onShowAll}
+              data-test-subj="column-visibility-show-all"
+            >
+              Show all
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              size="xs"
+              onClick={onHideAll}
+              data-test-subj="column-visibility-hide-all"
+            >
+              Hide all
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiHorizontalRule margin="xs" />
+        <div style={{ maxHeight: 300, overflowY: 'auto' }}>
+          {columns.map((col) => {
+            const isChecked = visibleColumnIds.has(col.id);
+            const isPinned = !!col.pinned;
+            const isUnavailable = unavailableColumnIds.has(col.id);
+            const isDisabled = isPinned || isUnavailable;
+
+            const tooltipContent = isPinned
+              ? 'This column cannot be hidden'
+              : isUnavailable
+              ? 'Not applicable for aggregated data'
+              : '';
+
+            const checkbox = (
+              <EuiCheckbox
+                id={`column-toggle-${col.id}`}
+                label={col.label}
+                checked={isPinned ? true : isUnavailable ? false : isChecked}
+                disabled={isDisabled}
+                onChange={() => onToggleColumn(col.id)}
+                data-test-subj={`column-toggle-${col.id}`}
+              />
+            );
+
+            return (
+              <div key={col.id} style={{ padding: '4px 0' }}>
+                {isDisabled ? (
+                  <EuiToolTip content={tooltipContent} position="right">
+                    {checkbox}
+                  </EuiToolTip>
+                ) : (
+                  checkbox
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </EuiPopover>
+  );
+};

--- a/public/hooks/useColumnVisibility.test.ts
+++ b/public/hooks/useColumnVisibility.test.ts
@@ -1,0 +1,338 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useColumnVisibility, ColumnDef } from './useColumnVisibility';
+
+const STORAGE_KEY = 'test_visible_columns';
+
+const baseColumns: ColumnDef[] = [
+  { id: 'id', label: 'ID', pinned: true },
+  { id: 'type', label: 'Type' },
+  { id: 'timestamp', label: 'Timestamp' },
+  { id: 'latency', label: 'Latency' },
+  { id: 'cpu', label: 'CPU Time' },
+];
+
+describe('useColumnVisibility', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('default state', () => {
+    it('all columns are visible when no localStorage value exists', () => {
+      const { result } = renderHook(() =>
+        useColumnVisibility({ storageKey: STORAGE_KEY, columns: baseColumns })
+      );
+
+      expect(result.current.visibleColumnIds.size).toBe(baseColumns.length);
+      baseColumns.forEach((col) => {
+        expect(result.current.isColumnVisible(col.id)).toBe(true);
+      });
+    });
+  });
+
+  describe('toggle on/off', () => {
+    it('toggling a column hides it', () => {
+      const { result } = renderHook(() =>
+        useColumnVisibility({ storageKey: STORAGE_KEY, columns: baseColumns })
+      );
+
+      act(() => {
+        result.current.toggleColumn('type');
+      });
+
+      expect(result.current.isColumnVisible('type')).toBe(false);
+    });
+
+    it('toggling a hidden column shows it again', () => {
+      const { result } = renderHook(() =>
+        useColumnVisibility({ storageKey: STORAGE_KEY, columns: baseColumns })
+      );
+
+      act(() => {
+        result.current.toggleColumn('type');
+      });
+      expect(result.current.isColumnVisible('type')).toBe(false);
+
+      act(() => {
+        result.current.toggleColumn('type');
+      });
+      expect(result.current.isColumnVisible('type')).toBe(true);
+    });
+  });
+
+  describe('pinned columns', () => {
+    it('attempting to toggle a pinned column is a no-op', () => {
+      const { result } = renderHook(() =>
+        useColumnVisibility({ storageKey: STORAGE_KEY, columns: baseColumns })
+      );
+
+      act(() => {
+        result.current.toggleColumn('id');
+      });
+
+      expect(result.current.isColumnVisible('id')).toBe(true);
+    });
+  });
+
+  describe('last-non-pinned-column guard', () => {
+    it('cannot hide the last visible non-pinned column', () => {
+      const { result } = renderHook(() =>
+        useColumnVisibility({ storageKey: STORAGE_KEY, columns: baseColumns })
+      );
+
+      // Hide all non-pinned columns except one
+      act(() => {
+        result.current.toggleColumn('type');
+      });
+      act(() => {
+        result.current.toggleColumn('timestamp');
+      });
+      act(() => {
+        result.current.toggleColumn('latency');
+      });
+      // Now only 'cpu' is the last non-pinned visible column
+      expect(result.current.isColumnVisible('cpu')).toBe(true);
+
+      // Trying to hide the last one should be a no-op
+      act(() => {
+        result.current.toggleColumn('cpu');
+      });
+      expect(result.current.isColumnVisible('cpu')).toBe(true);
+    });
+  });
+
+  describe('showAll', () => {
+    it('makes all columns visible', () => {
+      const { result } = renderHook(() =>
+        useColumnVisibility({ storageKey: STORAGE_KEY, columns: baseColumns })
+      );
+
+      // Hide some columns first
+      act(() => {
+        result.current.toggleColumn('type');
+      });
+      act(() => {
+        result.current.toggleColumn('latency');
+      });
+
+      act(() => {
+        result.current.showAll();
+      });
+
+      baseColumns.forEach((col) => {
+        expect(result.current.isColumnVisible(col.id)).toBe(true);
+      });
+    });
+  });
+
+  describe('hideAll', () => {
+    it('hides all non-pinned columns (pinned remain visible)', () => {
+      const { result } = renderHook(() =>
+        useColumnVisibility({ storageKey: STORAGE_KEY, columns: baseColumns })
+      );
+
+      act(() => {
+        result.current.hideAll();
+      });
+
+      // Pinned column remains visible
+      expect(result.current.isColumnVisible('id')).toBe(true);
+      // Non-pinned columns are hidden
+      expect(result.current.isColumnVisible('type')).toBe(false);
+      expect(result.current.isColumnVisible('timestamp')).toBe(false);
+      expect(result.current.isColumnVisible('latency')).toBe(false);
+      expect(result.current.isColumnVisible('cpu')).toBe(false);
+    });
+
+    it('keeps at least one column visible when there are no pinned columns', () => {
+      const noPinnedColumns: ColumnDef[] = [
+        { id: 'type', label: 'Type' },
+        { id: 'timestamp', label: 'Timestamp' },
+      ];
+
+      const { result } = renderHook(() =>
+        useColumnVisibility({ storageKey: STORAGE_KEY, columns: noPinnedColumns })
+      );
+
+      act(() => {
+        result.current.hideAll();
+      });
+
+      // At least one column should remain visible
+      const visibleCount = noPinnedColumns.filter((col) => result.current.isColumnVisible(col.id))
+        .length;
+      expect(visibleCount).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('localStorage persistence', () => {
+    it('persists state to localStorage on toggle', () => {
+      const { result } = renderHook(() =>
+        useColumnVisibility({ storageKey: STORAGE_KEY, columns: baseColumns })
+      );
+
+      act(() => {
+        result.current.toggleColumn('type');
+      });
+
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+      expect(stored).toBeInstanceOf(Array);
+      expect(stored).not.toContain('type');
+    });
+
+    it('persists state to localStorage on showAll', () => {
+      const { result } = renderHook(() =>
+        useColumnVisibility({ storageKey: STORAGE_KEY, columns: baseColumns })
+      );
+
+      act(() => {
+        result.current.toggleColumn('type');
+      });
+      act(() => {
+        result.current.showAll();
+      });
+
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+      expect(stored).toContain('type');
+      expect(stored).toContain('timestamp');
+      expect(stored).toContain('latency');
+      expect(stored).toContain('cpu');
+    });
+
+    it('persists state to localStorage on hideAll', () => {
+      const { result } = renderHook(() =>
+        useColumnVisibility({ storageKey: STORAGE_KEY, columns: baseColumns })
+      );
+
+      act(() => {
+        result.current.hideAll();
+      });
+
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+      // Non-pinned columns should not be in stored array (they're hidden)
+      expect(stored).not.toContain('type');
+      expect(stored).not.toContain('timestamp');
+    });
+
+    it('restores state from localStorage on mount', () => {
+      // Pre-seed localStorage with only some columns visible
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(['type', 'latency']));
+
+      const { result } = renderHook(() =>
+        useColumnVisibility({ storageKey: STORAGE_KEY, columns: baseColumns })
+      );
+
+      // Pinned column always visible
+      expect(result.current.isColumnVisible('id')).toBe(true);
+      // Stored visible columns
+      expect(result.current.isColumnVisible('type')).toBe(true);
+      expect(result.current.isColumnVisible('latency')).toBe(true);
+      // Not stored, so hidden
+      expect(result.current.isColumnVisible('timestamp')).toBe(false);
+      expect(result.current.isColumnVisible('cpu')).toBe(false);
+    });
+  });
+
+  describe('corrupted localStorage handling', () => {
+    it('falls back to all-visible defaults when stored JSON is invalid', () => {
+      localStorage.setItem(STORAGE_KEY, 'not-valid-json{{{');
+
+      const { result } = renderHook(() =>
+        useColumnVisibility({ storageKey: STORAGE_KEY, columns: baseColumns })
+      );
+
+      baseColumns.forEach((col) => {
+        expect(result.current.isColumnVisible(col.id)).toBe(true);
+      });
+    });
+
+    it('falls back to all-visible defaults when stored value is not an array of strings', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ foo: 'bar' }));
+
+      const { result } = renderHook(() =>
+        useColumnVisibility({ storageKey: STORAGE_KEY, columns: baseColumns })
+      );
+
+      baseColumns.forEach((col) => {
+        expect(result.current.isColumnVisible(col.id)).toBe(true);
+      });
+    });
+
+    it('falls back to all-visible defaults when stored array contains non-strings', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify([1, 2, 3]));
+
+      const { result } = renderHook(() =>
+        useColumnVisibility({ storageKey: STORAGE_KEY, columns: baseColumns })
+      );
+
+      baseColumns.forEach((col) => {
+        expect(result.current.isColumnVisible(col.id)).toBe(true);
+      });
+    });
+  });
+
+  describe('dynamic columns change', () => {
+    it('new columns that appear default to visible', () => {
+      const initialColumns: ColumnDef[] = [
+        { id: 'id', label: 'ID', pinned: true },
+        { id: 'type', label: 'Type' },
+      ];
+
+      const expandedColumns: ColumnDef[] = [
+        { id: 'id', label: 'ID', pinned: true },
+        { id: 'type', label: 'Type' },
+        { id: 'wlm_group', label: 'WLM Group' },
+      ];
+
+      const { result, rerender } = renderHook((props) => useColumnVisibility(props), {
+        initialProps: { storageKey: STORAGE_KEY, columns: initialColumns },
+      });
+
+      expect(result.current.isColumnVisible('id')).toBe(true);
+      expect(result.current.isColumnVisible('type')).toBe(true);
+
+      // Simulate columns changing (e.g., data source update)
+      rerender({ storageKey: STORAGE_KEY, columns: expandedColumns });
+
+      expect(result.current.isColumnVisible('wlm_group')).toBe(true);
+    });
+
+    it('columns that disappear are removed from the visible set', () => {
+      const initialColumns: ColumnDef[] = [
+        { id: 'id', label: 'ID', pinned: true },
+        { id: 'type', label: 'Type' },
+        { id: 'wlm_group', label: 'WLM Group' },
+      ];
+
+      const reducedColumns: ColumnDef[] = [
+        { id: 'id', label: 'ID', pinned: true },
+        { id: 'type', label: 'Type' },
+      ];
+
+      const { result, rerender } = renderHook((props) => useColumnVisibility(props), {
+        initialProps: { storageKey: STORAGE_KEY, columns: initialColumns },
+      });
+
+      expect(result.current.isColumnVisible('wlm_group')).toBe(true);
+
+      // Simulate columns changing (feature flag turned off)
+      rerender({ storageKey: STORAGE_KEY, columns: reducedColumns });
+
+      expect(result.current.visibleColumnIds.has('wlm_group')).toBe(false);
+    });
+  });
+
+  describe('columns pass-through', () => {
+    it('returns the columns array from options', () => {
+      const { result } = renderHook(() =>
+        useColumnVisibility({ storageKey: STORAGE_KEY, columns: baseColumns })
+      );
+
+      expect(result.current.columns).toBe(baseColumns);
+    });
+  });
+});

--- a/public/hooks/useColumnVisibility.test.ts
+++ b/public/hooks/useColumnVisibility.test.ts
@@ -163,8 +163,9 @@ describe('useColumnVisibility', () => {
       });
 
       // At least one column should remain visible
-      const visibleCount = noPinnedColumns.filter((col) => result.current.isColumnVisible(col.id))
-        .length;
+      const visibleCount = noPinnedColumns.filter((col) =>
+        result.current.isColumnVisible(col.id)
+      ).length;
       expect(visibleCount).toBeGreaterThanOrEqual(1);
     });
   });

--- a/public/hooks/useColumnVisibility.ts
+++ b/public/hooks/useColumnVisibility.ts
@@ -1,0 +1,249 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+
+export interface ColumnDef {
+  id: string;
+  label: string;
+  pinned?: boolean;
+  defaultVisible?: boolean;
+}
+
+export interface UseColumnVisibilityOptions {
+  storageKey: string;
+  columns: ColumnDef[];
+}
+
+export interface UseColumnVisibilityResult {
+  visibleColumnIds: Set<string>;
+  isColumnVisible: (id: string) => boolean;
+  toggleColumn: (id: string) => void;
+  showAll: () => void;
+  hideAll: () => void;
+  columns: ColumnDef[];
+}
+
+/**
+ * Reads stored column IDs from localStorage.
+ * Returns null if unavailable, corrupted, or not present.
+ */
+function readFromStorage(storageKey: string): string[] | null {
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (raw === null) return null;
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed) || !parsed.every((item) => typeof item === 'string')) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persists visible column IDs to localStorage.
+ * Silently ignores errors (e.g., quota exceeded, private browsing).
+ */
+function writeToStorage(storageKey: string, ids: string[]): void {
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(ids));
+  } catch {
+    // Fall back to in-memory only — no action needed
+  }
+}
+
+/**
+ * Computes the default visible set: columns with defaultVisible !== false.
+ */
+function getAllColumnIds(columns: ColumnDef[]): Set<string> {
+  return new Set(columns.filter((col) => col.defaultVisible !== false).map((col) => col.id));
+}
+
+/**
+ * A reusable hook for managing column visibility state with localStorage persistence.
+ *
+ * - Reads initial state from localStorage; defaults to all columns visible.
+ * - Pinned columns are always included in visibleColumnIds.
+ * - Guards against hiding all non-pinned columns (toggle is a no-op for the last one).
+ * - Reconciles state when the columns array changes (removes stale, adds new as visible).
+ * - Handles localStorage errors and corrupted JSON gracefully.
+ */
+export function useColumnVisibility(
+  options: UseColumnVisibilityOptions
+): UseColumnVisibilityResult {
+  const { storageKey, columns } = options;
+
+  // Track columns array identity for reconciliation
+  const prevColumnsRef = useRef<ColumnDef[]>(columns);
+
+  const [visibleColumnIds, setVisibleColumnIds] = useState<Set<string>>(() => {
+    const stored = readFromStorage(storageKey);
+    if (stored === null) {
+      return getAllColumnIds(columns);
+    }
+
+    // Build visible set from stored preferences, filtering to known column IDs
+    const knownIds = new Set(columns.map((col) => col.id));
+    const pinnedIds = new Set(columns.filter((col) => col.pinned).map((col) => col.id));
+    const visibleFromStorage = new Set<string>(stored.filter((id) => knownIds.has(id)));
+
+    // Always include pinned columns
+    for (const id of pinnedIds) {
+      visibleFromStorage.add(id);
+    }
+
+    return visibleFromStorage;
+  });
+
+  // Reconcile when columns array changes
+  const reconciledVisibleIds = useMemo(() => {
+    const currentIds = new Set(columns.map((col) => col.id));
+    const pinnedIds = new Set(columns.filter((col) => col.pinned).map((col) => col.id));
+    const prevIds = new Set(prevColumnsRef.current.map((col) => col.id));
+
+    // Find new columns (not in previous set)
+    const newColumnIds = [...currentIds].filter((id) => !prevIds.has(id));
+    // Find stale columns (in visible set but not in current columns)
+    const staleIds = [...visibleColumnIds].filter((id) => !currentIds.has(id));
+
+    if (newColumnIds.length === 0 && staleIds.length === 0) {
+      // Ensure pinned are always included
+      let needsUpdate = false;
+      for (const id of pinnedIds) {
+        if (!visibleColumnIds.has(id)) {
+          needsUpdate = true;
+          break;
+        }
+      }
+      if (!needsUpdate) return visibleColumnIds;
+    }
+
+    // Build reconciled set
+    const reconciled = new Set<string>();
+    for (const id of visibleColumnIds) {
+      if (currentIds.has(id)) {
+        reconciled.add(id);
+      }
+    }
+    // Add new columns as visible by default (respecting defaultVisible setting)
+    for (const id of newColumnIds) {
+      const col = columns.find((c) => c.id === id);
+      if (col && col.defaultVisible !== false) {
+        reconciled.add(id);
+      }
+    }
+    // Ensure pinned columns are always included
+    for (const id of pinnedIds) {
+      reconciled.add(id);
+    }
+
+    return reconciled;
+  }, [columns, visibleColumnIds]);
+
+  // Sync reconciled state back if it differs (via useEffect to avoid setting state during render)
+  useEffect(() => {
+    if (reconciledVisibleIds !== visibleColumnIds) {
+      setVisibleColumnIds(reconciledVisibleIds);
+      // Persist reconciled state
+      const idsToStore = [...reconciledVisibleIds].filter((id) => {
+        const col = columns.find((c) => c.id === id);
+        return col && !col.pinned;
+      });
+      writeToStorage(storageKey, idsToStore);
+    }
+  }, [reconciledVisibleIds, visibleColumnIds, columns, storageKey]);
+
+  // Update prevColumnsRef
+  useEffect(() => {
+    prevColumnsRef.current = columns;
+  }, [columns]);
+
+  const isColumnVisible = useCallback(
+    (id: string): boolean => {
+      return reconciledVisibleIds.has(id);
+    },
+    [reconciledVisibleIds]
+  );
+
+  const toggleColumn = useCallback(
+    (id: string) => {
+      const col = columns.find((c) => c.id === id);
+      // No-op for pinned columns
+      if (col?.pinned) return;
+
+      setVisibleColumnIds((prev) => {
+        const isCurrentlyVisible = prev.has(id);
+
+        if (isCurrentlyVisible) {
+          // Guard: don't hide if it's the last visible non-pinned column
+          const pinnedIds = new Set(columns.filter((c) => c.pinned).map((c) => c.id));
+          const currentColumnIds = new Set(columns.map((c) => c.id));
+          const nonPinnedVisible = [...prev].filter(
+            (visId) => !pinnedIds.has(visId) && currentColumnIds.has(visId)
+          );
+          if (nonPinnedVisible.length <= 1) {
+            return prev; // no-op
+          }
+        }
+
+        const next = new Set(prev);
+        if (isCurrentlyVisible) {
+          next.delete(id);
+        } else {
+          next.add(id);
+        }
+
+        // Persist (store only non-pinned visible IDs)
+        const idsToStore = [...next].filter((visId) => {
+          const colDef = columns.find((c) => c.id === visId);
+          return colDef && !colDef.pinned;
+        });
+        writeToStorage(storageKey, idsToStore);
+
+        return next;
+      });
+    },
+    [columns, storageKey]
+  );
+
+  const showAll = useCallback(() => {
+    const allIds = new Set(columns.map((col) => col.id));
+    setVisibleColumnIds(allIds);
+
+    // Persist (store only non-pinned)
+    const idsToStore = columns.filter((col) => !col.pinned).map((col) => col.id);
+    writeToStorage(storageKey, idsToStore);
+  }, [columns, storageKey]);
+
+  const hideAll = useCallback(() => {
+    // Keep only pinned columns visible
+    const pinnedIds = new Set(columns.filter((col) => col.pinned).map((col) => col.id));
+
+    // Guard: if there are no pinned columns, keep at least the first non-pinned column
+    if (pinnedIds.size === 0 && columns.length > 0) {
+      pinnedIds.add(columns[0].id);
+    }
+
+    setVisibleColumnIds(pinnedIds);
+
+    // Persist: store empty array for non-pinned (none visible)
+    const idsToStore = [...pinnedIds].filter((id) => {
+      const col = columns.find((c) => c.id === id);
+      return col && !col.pinned;
+    });
+    writeToStorage(storageKey, idsToStore);
+  }, [columns, storageKey]);
+
+  return {
+    visibleColumnIds: reconciledVisibleIds,
+    isColumnVisible,
+    toggleColumn,
+    showAll,
+    hideAll,
+    columns,
+  };
+}

--- a/public/pages/InflightQueries/InflightQueries.test.tsx
+++ b/public/pages/InflightQueries/InflightQueries.test.tsx
@@ -1664,40 +1664,23 @@ describe('InflightQueries - Column Visibility Integration', () => {
       expect(showAll).toBeInTheDocument();
     });
 
-    // Toggle a non-pinned column (e.g., "timestamp" or "index")
+    // "Timestamp" is a non-pinned column always present in the live-queries
+    // table, so its toggle must exist. Assert unconditionally.
     const timestampToggle = document.querySelector(
       '[data-test-subj="column-toggle-timestamp"]'
     ) as HTMLInputElement;
-    if (timestampToggle) {
-      fireEvent.click(timestampToggle);
+    expect(timestampToggle).toBeInTheDocument();
 
-      // Close the popover so aria-hidden is removed from the table
-      fireEvent.click(columnsButton);
+    fireEvent.click(timestampToggle);
 
-      await waitFor(() => {
-        const updatedTables = document.querySelectorAll('table');
-        const updatedMainTable = updatedTables[updatedTables.length - 1];
-        const updatedHeaders = updatedMainTable.querySelectorAll('th');
-        expect(updatedHeaders.length).toBeLessThan(initialColumnCount);
-      });
-    } else {
-      // Try another non-pinned column
-      const indexToggle = document.querySelector(
-        '[data-test-subj="column-toggle-index"]'
-      ) as HTMLInputElement;
-      if (indexToggle) {
-        fireEvent.click(indexToggle);
+    // Close the popover so aria-hidden is removed from the table
+    fireEvent.click(columnsButton);
 
-        // Close the popover
-        fireEvent.click(columnsButton);
-
-        await waitFor(() => {
-          const updatedTables = document.querySelectorAll('table');
-          const updatedMainTable = updatedTables[updatedTables.length - 1];
-          const updatedHeaders = updatedMainTable.querySelectorAll('th');
-          expect(updatedHeaders.length).toBeLessThan(initialColumnCount);
-        });
-      }
-    }
+    await waitFor(() => {
+      const updatedTables = document.querySelectorAll('table');
+      const updatedMainTable = updatedTables[updatedTables.length - 1];
+      const updatedHeaders = updatedMainTable.querySelectorAll('th');
+      expect(updatedHeaders.length).toBeLessThan(initialColumnCount);
+    });
   });
 });

--- a/public/pages/InflightQueries/InflightQueries.test.tsx
+++ b/public/pages/InflightQueries/InflightQueries.test.tsx
@@ -1551,3 +1551,168 @@ describe('InflightQueries - DynamicSearchBar filtering', () => {
     });
   });
 });
+
+describe('InflightQueries - Column Visibility Integration', () => {
+  it('renders the Columns button in the page', async () => {
+    const core = makeCore();
+    mockLiveQueries(mockStubLiveQueries);
+
+    render(
+      withDataSource(
+        <InflightQueries
+          core={core}
+          depsStart={
+            { data: { dataSources: { get: jest.fn().mockReturnValue(core.http) } } } as any
+          }
+          params={{} as any}
+          dataSourceManagement={undefined}
+        />
+      )
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(
+      () => {
+        const columnsButton = document.querySelector('[data-test-subj="column-visibility-button"]');
+        expect(columnsButton).toBeInTheDocument();
+        expect(columnsButton).toHaveTextContent('Columns');
+      },
+      { timeout: 5000 }
+    );
+  });
+
+  it('opens column visibility popover and shows column toggles', async () => {
+    const core = makeCore();
+    mockLiveQueries(mockStubLiveQueries);
+
+    render(
+      withDataSource(
+        <InflightQueries
+          core={core}
+          depsStart={
+            { data: { dataSources: { get: jest.fn().mockReturnValue(core.http) } } } as any
+          }
+          params={{} as any}
+          dataSourceManagement={undefined}
+        />
+      )
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const columnsButton = await waitFor(
+      () => {
+        const btn = document.querySelector('[data-test-subj="column-visibility-button"]');
+        expect(btn).toBeInTheDocument();
+        return btn as HTMLElement;
+      },
+      { timeout: 5000 }
+    );
+
+    fireEvent.click(columnsButton);
+
+    await waitFor(() => {
+      const showAllButton = document.querySelector('[data-test-subj="column-visibility-show-all"]');
+      expect(showAllButton).toBeInTheDocument();
+      // Should display column toggle checkboxes
+      const toggles = document.querySelectorAll('[data-test-subj^="column-toggle-"]');
+      expect(toggles.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('toggling a column off reduces the number of visible table columns', async () => {
+    const core = makeCore();
+    mockLiveQueries(mockStubLiveQueries);
+
+    render(
+      withDataSource(
+        <InflightQueries
+          core={core}
+          depsStart={
+            { data: { dataSources: { get: jest.fn().mockReturnValue(core.http) } } } as any
+          }
+          params={{} as any}
+          dataSourceManagement={undefined}
+        />
+      )
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Wait for table to render with data
+    await waitFor(
+      () => {
+        expect(screen.getByText('Active queries')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+
+    // Get initial column count using DOM queries to avoid aria-hidden issues
+    const tables = document.querySelectorAll('table');
+    const mainTable = tables[tables.length - 1];
+    const initialHeaders = mainTable.querySelectorAll('th');
+    const initialColumnCount = initialHeaders.length;
+
+    // Open the column visibility popover
+    const columnsButton = document.querySelector(
+      '[data-test-subj="column-visibility-button"]'
+    ) as HTMLElement;
+    expect(columnsButton).toBeInTheDocument();
+    fireEvent.click(columnsButton);
+
+    // Wait for popover
+    await waitFor(() => {
+      const showAll = document.querySelector('[data-test-subj="column-visibility-show-all"]');
+      expect(showAll).toBeInTheDocument();
+    });
+
+    // Toggle a non-pinned column (e.g., "timestamp" or "index")
+    const timestampToggle = document.querySelector(
+      '[data-test-subj="column-toggle-timestamp"]'
+    ) as HTMLInputElement;
+    if (timestampToggle) {
+      fireEvent.click(timestampToggle);
+
+      // Close the popover so aria-hidden is removed from the table
+      fireEvent.click(columnsButton);
+
+      await waitFor(() => {
+        const updatedTables = document.querySelectorAll('table');
+        const updatedMainTable = updatedTables[updatedTables.length - 1];
+        const updatedHeaders = updatedMainTable.querySelectorAll('th');
+        expect(updatedHeaders.length).toBeLessThan(initialColumnCount);
+      });
+    } else {
+      // Try another non-pinned column
+      const indexToggle = document.querySelector(
+        '[data-test-subj="column-toggle-index"]'
+      ) as HTMLInputElement;
+      if (indexToggle) {
+        fireEvent.click(indexToggle);
+
+        // Close the popover
+        fireEvent.click(columnsButton);
+
+        await waitFor(() => {
+          const updatedTables = document.querySelectorAll('table');
+          const updatedMainTable = updatedTables[updatedTables.length - 1];
+          const updatedHeaders = updatedMainTable.querySelectorAll('th');
+          expect(updatedHeaders.length).toBeLessThan(initialColumnCount);
+        });
+      }
+    }
+  });
+});

--- a/public/pages/InflightQueries/InflightQueries.tsx
+++ b/public/pages/InflightQueries/InflightQueries.tsx
@@ -825,7 +825,7 @@ export const InflightQueries = ({
                         <b>{metrics?.activeQueries ?? 0}</b>
                       </h2>
                     </EuiTitle>
-                    <EuiIcon type="visGauge" />
+                    <EuiIcon type="visGauge" aria-hidden={true} />
                   </EuiTextAlign>
                 </EuiFlexItem>
               </EuiPanel>
@@ -979,7 +979,7 @@ export const InflightQueries = ({
                 ) : (
                   <EuiTextAlign textAlign="center">
                     <EuiSpacer size="xl" />
-                    <EuiIcon type="visPie" size="xxl" color="subdued" />
+                    <EuiIcon type="visPie" size="xxl" color="subdued" aria-hidden={true} />
                     <EuiSpacer size="s" />
                     <EuiTitle size="s">
                       <h3>No Visualization Available</h3>
@@ -1045,7 +1045,7 @@ export const InflightQueries = ({
                 ) : (
                   <EuiTextAlign textAlign="center">
                     <EuiSpacer size="xl" />
-                    <EuiIcon type="visPie" size="xxl" color="subdued" />
+                    <EuiIcon type="visPie" size="xxl" color="subdued" aria-hidden={true} />
                     <EuiSpacer size="s" />
                     <EuiTitle size="s">
                       <h3>No Visualization Available</h3>
@@ -1235,7 +1235,7 @@ export const InflightQueries = ({
                               }}
                               color="primary"
                             >
-                              {displayName} <EuiIcon type="popout" size="s" />
+                              {displayName} <EuiIcon type="popout" size="s" aria-hidden={true} />
                             </EuiLink>
                           );
                         }

--- a/public/pages/InflightQueries/InflightQueries.tsx
+++ b/public/pages/InflightQueries/InflightQueries.tsx
@@ -62,6 +62,8 @@ import {
   evaluateExpression,
 } from '../../components/DynamicSearchBar';
 import { SearchQueryRecord } from '../../../types/types';
+import { useColumnVisibility, ColumnDef } from '../../hooks/useColumnVisibility';
+import { ColumnVisibilityPopover } from '../../components/ColumnVisibilityPopover';
 
 type LiveQueryRaw = NonNullable<LiveSearchQueryResponse['response']>['live_queries'][number];
 
@@ -549,6 +551,38 @@ export const InflightQueries = ({
     return map;
   }, [searchFields]);
 
+  // --- Column visibility ---
+  const columnDefs = useMemo<ColumnDef[]>(() => {
+    const defs: ColumnDef[] = [
+      { id: 'timestamp', label: 'Timestamp' },
+      { id: 'task_id', label: 'Task ID', pinned: true },
+      { id: 'index', label: 'Index' },
+      { id: 'coordinator_node', label: 'Coordinator Node' },
+      { id: 'time_elapsed', label: 'Time Elapsed' },
+      { id: 'cpu_usage', label: 'CPU Usage' },
+      { id: 'memory_usage', label: 'Memory Usage' },
+      { id: 'search_type', label: 'Search Type' },
+      { id: 'status', label: 'Status' },
+    ];
+    if (queryInsightWlmNavigationSupported) {
+      defs.push({ id: 'wlm_group', label: 'WLM Group' });
+    }
+    defs.push({ id: 'actions', label: 'Actions', pinned: true });
+    return defs;
+  }, [queryInsightWlmNavigationSupported]);
+
+  const {
+    visibleColumnIds,
+    isColumnVisible,
+    toggleColumn,
+    showAll,
+    hideAll,
+    columns: columnDefsForPopover,
+  } = useColumnVisibility({
+    storageKey: 'queryInsights_live_visibleColumns',
+    columns: columnDefs,
+  });
+
   // Filter live queries based on the dynamic search expression
   const filteredQueries = useMemo(() => {
     if (!searchQuery.trim()) return liveQueries;
@@ -713,6 +747,15 @@ export const InflightQueries = ({
             responsive={false}
             style={{ minHeight: 40 }}
           >
+            <EuiFlexItem grow={false}>
+              <ColumnVisibilityPopover
+                columns={columnDefsForPopover}
+                visibleColumnIds={visibleColumnIds}
+                onToggleColumn={toggleColumn}
+                onShowAll={showAll}
+                onHideAll={hideAll}
+              />
+            </EuiFlexItem>
             {taskDetailSupported && (
               <EuiFlexItem grow={false}>
                 <EuiSwitch
@@ -1096,112 +1139,148 @@ export const InflightQueries = ({
         )}
         <EuiInMemoryTable
           items={filteredQueries}
-          columns={[
-            { name: 'Timestamp', render: (item: any) => convertTime(item.timestamp) },
-            {
-              field: 'id',
-              name: 'Task ID',
-              render: taskDetailSupported
-                ? (id: string) => <EuiLink onClick={() => setSelectedTaskId(id)}>{id}</EuiLink>
-                : undefined,
-            },
-            { field: 'index', name: 'Index' },
-            { field: 'coordinator_node', name: 'Coordinator node' },
-            {
-              name: 'Time elapsed',
-              render: (item: any) => formatTime(item.measurements?.latency?.number / 1e9),
-            },
-            {
-              name: 'CPU usage',
-              render: (item: any) => formatTime(item.measurements?.cpu?.number / 1e9),
-            },
-            {
-              name: 'Memory usage',
-              render: (item: any) => formatMemory(item.measurements?.memory?.number),
-            },
-            { field: 'search_type', name: 'Search type' },
-
-            {
-              name: 'Status',
-              render: (item: any) =>
-                (item as any)._finished ? (
-                  <EuiBadge
-                    color={
-                      item.is_cancelled || (item as any)._status === 'Failed' ? 'danger' : 'success'
-                    }
-                  >
-                    {(item as any)._status || 'Completed'}
-                  </EuiBadge>
-                ) : item.is_cancelled === true ? (
-                  <EuiBadge color="danger">Cancelled</EuiBadge>
-                ) : (
-                  <EuiBadge color="primary">Running</EuiBadge>
-                ),
-            },
-
-            ...(queryInsightWlmNavigationSupported
-              ? [
-                  {
-                    name: 'WLM Group',
-                    render: (item: any) => {
-                      if (!item.wlm_group || item.wlm_group === 'N/A') {
-                        return 'N/A';
-                      }
-
-                      const displayName = wlmIdToNameMap[item.wlm_group] ?? item.wlm_group;
-
-                      if (wlmAvailable) {
-                        return (
-                          <EuiLink
-                            onClick={() => {
-                              const dsParam = `&dataSourceId=${dataSource?.id || ''}`;
-                              core.application.navigateToApp('workloadManagement', {
-                                path: `#/wlm-details?name=${encodeURIComponent(
-                                  displayName
-                                )}${dsParam}`,
-                              });
-                            }}
-                            color="primary"
-                          >
-                            {displayName} <EuiIcon type="popout" size="s" />
-                          </EuiLink>
-                        );
-                      }
-
-                      // Plugin not available → simple text
-                      return <span>{displayName}</span>;
+          columns={(() => {
+            const allColumns = [
+              ...(isColumnVisible('timestamp')
+                ? [{ name: 'Timestamp', render: (item: any) => convertTime(item.timestamp) }]
+                : []),
+              ...(isColumnVisible('task_id')
+                ? [
+                    {
+                      field: 'id',
+                      name: 'Task ID',
+                      render: taskDetailSupported
+                        ? (id: string) => (
+                            <EuiLink onClick={() => setSelectedTaskId(id)}>{id}</EuiLink>
+                          )
+                        : undefined,
                     },
-                  },
-                ]
-              : []),
+                  ]
+                : []),
+              ...(isColumnVisible('index') ? [{ field: 'index', name: 'Index' }] : []),
+              ...(isColumnVisible('coordinator_node')
+                ? [{ field: 'coordinator_node', name: 'Coordinator node' }]
+                : []),
+              ...(isColumnVisible('time_elapsed')
+                ? [
+                    {
+                      name: 'Time elapsed',
+                      render: (item: any) => formatTime(item.measurements?.latency?.number / 1e9),
+                    },
+                  ]
+                : []),
+              ...(isColumnVisible('cpu_usage')
+                ? [
+                    {
+                      name: 'CPU usage',
+                      render: (item: any) => formatTime(item.measurements?.cpu?.number / 1e9),
+                    },
+                  ]
+                : []),
+              ...(isColumnVisible('memory_usage')
+                ? [
+                    {
+                      name: 'Memory usage',
+                      render: (item: any) => formatMemory(item.measurements?.memory?.number),
+                    },
+                  ]
+                : []),
+              ...(isColumnVisible('search_type')
+                ? [{ field: 'search_type', name: 'Search type' }]
+                : []),
+              ...(isColumnVisible('status')
+                ? [
+                    {
+                      name: 'Status',
+                      render: (item: any) =>
+                        (item as any)._finished ? (
+                          <EuiBadge
+                            color={
+                              item.is_cancelled || (item as any)._status === 'Failed'
+                                ? 'danger'
+                                : 'success'
+                            }
+                          >
+                            {(item as any)._status || 'Completed'}
+                          </EuiBadge>
+                        ) : item.is_cancelled === true ? (
+                          <EuiBadge color="danger">Cancelled</EuiBadge>
+                        ) : (
+                          <EuiBadge color="primary">Running</EuiBadge>
+                        ),
+                    },
+                  ]
+                : []),
+              ...(queryInsightWlmNavigationSupported && isColumnVisible('wlm_group')
+                ? [
+                    {
+                      name: 'WLM Group',
+                      render: (item: any) => {
+                        if (!item.wlm_group || item.wlm_group === 'N/A') {
+                          return 'N/A';
+                        }
 
-            {
-              name: 'Actions',
-              actions: [
-                {
-                  name: 'Cancel',
-                  description: 'Cancel this query',
-                  icon: 'trash',
-                  color: 'danger',
-                  type: 'icon',
-                  available: (item) => item.is_cancelled !== true && !(item as any)._finished,
-                  onClick: async (item) => {
-                    try {
-                      const httpClient = dataSource?.id
-                        ? depsStart.data.dataSources.get(dataSource.id)
-                        : core.http;
+                        const displayName = wlmIdToNameMap[item.wlm_group] ?? item.wlm_group;
 
-                      await httpClient.post(API_ENDPOINTS.CANCEL_TASK(item.id));
-                      await new Promise((r) => setTimeout(r, 300));
-                      await fetchLiveQueries();
-                    } catch (err) {
-                      console.error('Failed to cancel task', err);
-                    }
-                  },
-                },
-              ],
-            },
-          ]}
+                        if (wlmAvailable) {
+                          return (
+                            <EuiLink
+                              onClick={() => {
+                                const dsParam = `&dataSourceId=${dataSource?.id || ''}`;
+                                core.application.navigateToApp('workloadManagement', {
+                                  path: `#/wlm-details?name=${encodeURIComponent(
+                                    displayName
+                                  )}${dsParam}`,
+                                });
+                              }}
+                              color="primary"
+                            >
+                              {displayName} <EuiIcon type="popout" size="s" />
+                            </EuiLink>
+                          );
+                        }
+
+                        // Plugin not available → simple text
+                        return <span>{displayName}</span>;
+                      },
+                    },
+                  ]
+                : []),
+              // Actions column always last
+              ...(isColumnVisible('actions')
+                ? [
+                    {
+                      name: 'Actions',
+                      actions: [
+                        {
+                          name: 'Cancel',
+                          description: 'Cancel this query',
+                          icon: 'trash',
+                          color: 'danger',
+                          type: 'icon',
+                          available: (item: any) =>
+                            item.is_cancelled !== true && !(item as any)._finished,
+                          onClick: async (item: any) => {
+                            try {
+                              const httpClient = dataSource?.id
+                                ? depsStart.data.dataSources.get(dataSource.id)
+                                : core.http;
+
+                              await httpClient.post(API_ENDPOINTS.CANCEL_TASK(item.id));
+                              await new Promise((r) => setTimeout(r, 300));
+                              await fetchLiveQueries();
+                            } catch (err) {
+                              console.error('Failed to cancel task', err);
+                            }
+                          },
+                        },
+                      ],
+                    },
+                  ]
+                : []),
+            ];
+            return allColumns;
+          })()}
           selection={selection}
           pagination={{
             pageIndex: pagination.pageIndex,

--- a/public/pages/InflightQueries/__snapshots__/InflightQueries.test.tsx.snap
+++ b/public/pages/InflightQueries/__snapshots__/InflightQueries.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`InflightQueries matches snapshot 1`] = `
                 <button
                   aria-label="Toggle column visibility"
                   data-test-subj="column-visibility-button"
-                  style="display: inline-flex; align-items: center; gap: 8px; padding: 0px 12px; height: 40px; cursor: pointer; font-size: 14px; color: rgb(1, 125, 115); font-weight: 400; width: auto; min-width: 0; text-align: left; border: 1px solid #d3dae6; border-radius: 0; background: transparent; outline: none; box-shadow: none;"
+                  style="display: inline-flex; align-items: center; gap: 8px; padding: 0px 12px; height: 40px; cursor: pointer; font-size: 14px; color: rgb(1, 125, 115); font-weight: 400; width: auto; min-width: 0; text-align: left; border: 1px solid rgb(211, 218, 230); border-radius: 0; background: transparent; outline: none; box-shadow: none;"
                 >
                   <svg
                     aria-hidden="true"

--- a/public/pages/InflightQueries/__snapshots__/InflightQueries.test.tsx.snap
+++ b/public/pages/InflightQueries/__snapshots__/InflightQueries.test.tsx.snap
@@ -73,43 +73,51 @@ exports[`InflightQueries matches snapshot 1`] = `
               >
                 <button
                   aria-label="Toggle column visibility"
+                  class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiButtonEmpty--flushBoth"
                   data-test-subj="column-visibility-button"
-                  style="display: inline-flex; align-items: center; gap: 8px; padding: 0px 12px; height: 40px; cursor: pointer; font-size: 14px; color: rgb(1, 125, 115); font-weight: 400; width: auto; min-width: 0; text-align: left; border: 1px solid rgb(211, 218, 230); border-radius: 0; background: transparent; outline: none; box-shadow: none;"
+                  type="button"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoaded"
-                    focusable="false"
-                    height="16"
-                    role="img"
-                    style="color: rgb(1, 125, 115);"
-                    viewBox="0 0 16 16"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
+                  <span
+                    class="euiButtonContent euiButtonEmpty__content"
                   >
-                    <path
-                      d="M16 3v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v1Zm-1 0V2a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v1h14Zm0 1H1v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4ZM4.5 7a.5.5 0 0 1 0 1H2.496a.5.5 0 1 1 0-1H4.5Zm9 0a.5.5 0 1 1 0 1h-6a.5.5 0 0 1 0-1h6Zm-9 4a.5.5 0 1 1 0 1H2.496a.5.5 0 1 1 0-1H4.5Zm9 0a.5.5 0 1 1 0 1h-6a.5.5 0 1 1 0-1h6Z"
-                    />
-                  </svg>
-                  <span>
-                    Columns
+                    <svg
+                      aria-hidden="true"
+                      class="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoaded euiButtonContent__icon"
+                      focusable="false"
+                      height="16"
+                      role="img"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M16 3v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v1Zm-1 0V2a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v1h14Zm0 1H1v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4ZM4.5 7a.5.5 0 0 1 0 1H2.496a.5.5 0 1 1 0-1H4.5Zm9 0a.5.5 0 1 1 0 1h-6a.5.5 0 0 1 0-1h6Zm-9 4a.5.5 0 1 1 0 1H2.496a.5.5 0 1 1 0-1H4.5Zm9 0a.5.5 0 1 1 0 1h-6a.5.5 0 1 1 0-1h6Z"
+                      />
+                    </svg>
+                    <span
+                      class="euiButtonEmpty__text"
+                    >
+                      <span>
+                        Columns
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--small euiIcon-isLoaded"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        style="margin-left: 4px;"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                          fill-rule="non-zero"
+                        />
+                      </svg>
+                    </span>
                   </span>
-                  <svg
-                    aria-hidden="true"
-                    class="euiIcon euiIcon--small euiIcon--customColor euiIcon-isLoaded"
-                    focusable="false"
-                    height="16"
-                    role="img"
-                    style="color: rgb(1, 125, 115);"
-                    viewBox="0 0 16 16"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                      fill-rule="non-zero"
-                    />
-                  </svg>
                 </button>
               </div>
             </div>

--- a/public/pages/InflightQueries/__snapshots__/InflightQueries.test.tsx.snap
+++ b/public/pages/InflightQueries/__snapshots__/InflightQueries.test.tsx.snap
@@ -65,6 +65,59 @@ exports[`InflightQueries matches snapshot 1`] = `
             class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <div
+              class="euiPopover euiPopover--anchorDownLeft"
+              data-test-subj="column-visibility-popover"
+            >
+              <div
+                class="euiPopover__anchor"
+              >
+                <button
+                  aria-label="Toggle column visibility"
+                  data-test-subj="column-visibility-button"
+                  style="display: inline-flex; align-items: center; gap: 8px; padding: 0px 12px; height: 40px; cursor: pointer; font-size: 14px; color: rgb(1, 125, 115); font-weight: 400; width: auto; min-width: 0; text-align: left; border: 1px solid #d3dae6; border-radius: 0; background: transparent; outline: none; box-shadow: none;"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoaded"
+                    focusable="false"
+                    height="16"
+                    role="img"
+                    style="color: rgb(1, 125, 115);"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M16 3v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v1Zm-1 0V2a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v1h14Zm0 1H1v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4ZM4.5 7a.5.5 0 0 1 0 1H2.496a.5.5 0 1 1 0-1H4.5Zm9 0a.5.5 0 1 1 0 1h-6a.5.5 0 0 1 0-1h6Zm-9 4a.5.5 0 1 1 0 1H2.496a.5.5 0 1 1 0-1H4.5Zm9 0a.5.5 0 1 1 0 1h-6a.5.5 0 1 1 0-1h6Z"
+                    />
+                  </svg>
+                  <span>
+                    Columns
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    class="euiIcon euiIcon--small euiIcon--customColor euiIcon-isLoaded"
+                    focusable="false"
+                    height="16"
+                    role="img"
+                    style="color: rgb(1, 125, 115);"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                      fill-rule="non-zero"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div
+            class="euiFlexItem euiFlexItem--flexGrowZero"
+          >
+            <div
               class="euiSwitch euiSwitch--primary"
             >
               <button

--- a/public/pages/QueryInsights/QueryInsights.test.tsx
+++ b/public/pages/QueryInsights/QueryInsights.test.tsx
@@ -241,6 +241,7 @@ describe('QueryInsights Component', () => {
         const headers = within(mainTable).getAllByRole('columnheader');
         const headerTexts = headers.map((h) => h.textContent?.trim());
         // sampleQueries has both NONE and SIMILARITY, so table shows mixed headers
+        // Note: Search Type, Coordinator Node ID, and Total Shards are hidden by default
         const expectedHeaders = [
           'Id',
           'Type',
@@ -251,10 +252,7 @@ describe('QueryInsights Component', () => {
           'Avg CPU Time / CPU Time',
           'Avg Memory Usage / Memory Usage',
           'Indices',
-          'Search Type',
-          'Coordinator Node ID',
           'WLM Group',
-          'Total Shards',
         ];
         expect(headerTexts).toEqual(expectedHeaders);
       },
@@ -306,10 +304,7 @@ describe('QueryInsights Component', () => {
           'CPU Time',
           'Memory Usage',
           'Indices',
-          'Search Type',
-          'Coordinator Node ID',
           'WLM Group',
-          'Total Shards',
         ];
         expect(headerTexts).toEqual(expectedHeaders);
       });
@@ -339,10 +334,7 @@ describe('QueryInsights Component', () => {
           'Avg CPU Time / CPU Time',
           'Avg Memory Usage / Memory Usage',
           'Indices',
-          'Search Type',
-          'Coordinator Node ID',
           'WLM Group',
-          'Total Shards',
         ];
         expect(headerTexts).toEqual(expectedHeaders);
       });
@@ -629,8 +621,6 @@ describe('QueryInsights Component', () => {
       const buttonTexts = buttons.map((b) => b.textContent?.trim());
       expect(buttonTexts).toContain('Type');
       expect(buttonTexts).toContain('Indices');
-      expect(buttonTexts).toContain('Search Type');
-      expect(buttonTexts).toContain('Coordinator Node ID');
       expect(buttonTexts).toContain('WLM Group');
     });
 
@@ -797,5 +787,123 @@ describe('QueryInsights Component', () => {
         expect(screen.queryByText('Failed')).not.toBeInTheDocument();
       });
     });
+  });
+});
+
+describe('QueryInsights - Column Visibility Integration', () => {
+  beforeAll(() => {
+    jest.spyOn(Date.prototype, 'toLocaleTimeString').mockImplementation(() => '12:00:00 AM');
+    jest.spyOn(Date.prototype, 'toDateString').mockImplementation(() => 'Mon Jan 13 2025');
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHttp.get.mockResolvedValue({ workload_groups: [] });
+  });
+
+  it('renders the Columns button in the page', async () => {
+    await act(async () => {
+      renderQueryInsights();
+    });
+
+    await waitFor(() => {
+      const columnsButton = document.querySelector('[data-test-subj="column-visibility-button"]');
+      expect(columnsButton).toBeInTheDocument();
+      expect(columnsButton).toHaveTextContent('Columns');
+    });
+  });
+
+  it('opens column visibility popover and shows column toggles', async () => {
+    await act(async () => {
+      renderQueryInsights();
+    });
+
+    const columnsButton = await waitFor(() => {
+      const btn = document.querySelector('[data-test-subj="column-visibility-button"]');
+      expect(btn).toBeInTheDocument();
+      return btn as HTMLElement;
+    });
+
+    fireEvent.click(columnsButton);
+
+    await waitFor(() => {
+      const showAllButton = document.querySelector('[data-test-subj="column-visibility-show-all"]');
+      expect(showAllButton).toBeInTheDocument();
+      // Should display at least one column toggle checkbox
+      const toggles = document.querySelectorAll('[data-test-subj^="column-toggle-"]');
+      expect(toggles.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('toggling a column off reduces the number of visible table columns', async () => {
+    await act(async () => {
+      renderQueryInsights();
+    });
+
+    // Wait for table to render (use container queries to avoid aria-hidden issues)
+    await waitFor(() => {
+      const tables = document.querySelectorAll('table');
+      expect(tables.length).toBeGreaterThan(0);
+    });
+
+    // Get initial column count from the main data table (last table)
+    const tables = document.querySelectorAll('table');
+    const mainTable = tables[tables.length - 1];
+    const initialHeaders = mainTable.querySelectorAll('th');
+    const initialColumnCount = initialHeaders.length;
+
+    // Open the column visibility popover
+    const columnsButton = document.querySelector(
+      '[data-test-subj="column-visibility-button"]'
+    ) as HTMLElement;
+    expect(columnsButton).toBeInTheDocument();
+    fireEvent.click(columnsButton);
+
+    // Wait for popover to open and find a non-pinned toggle
+    await waitFor(() => {
+      const showAll = document.querySelector('[data-test-subj="column-visibility-show-all"]');
+      expect(showAll).toBeInTheDocument();
+    });
+
+    // Toggle a non-pinned column (e.g., "type" or "timestamp")
+    const typeToggle = document.querySelector(
+      '[data-test-subj="column-toggle-type"]'
+    ) as HTMLInputElement;
+    if (typeToggle) {
+      fireEvent.click(typeToggle);
+
+      // Close the popover by clicking the button again so aria-hidden is removed
+      fireEvent.click(columnsButton);
+
+      // Verify column count decreased
+      await waitFor(() => {
+        const updatedTable = document.querySelectorAll('table');
+        const updatedMainTable = updatedTable[updatedTable.length - 1];
+        const updatedHeaders = updatedMainTable.querySelectorAll('th');
+        expect(updatedHeaders.length).toBeLessThan(initialColumnCount);
+      });
+    } else {
+      // If type toggle is not available, try timestamp
+      const timestampToggle = document.querySelector(
+        '[data-test-subj="column-toggle-timestamp"]'
+      ) as HTMLInputElement;
+      if (timestampToggle) {
+        fireEvent.click(timestampToggle);
+
+        // Close the popover
+        fireEvent.click(columnsButton);
+
+        await waitFor(() => {
+          const updatedTable = document.querySelectorAll('table');
+          const updatedMainTable = updatedTable[updatedTable.length - 1];
+          const updatedHeaders = updatedMainTable.querySelectorAll('th');
+          expect(updatedHeaders.length).toBeLessThan(initialColumnCount);
+        });
+      }
+    }
   });
 });

--- a/public/pages/QueryInsights/QueryInsights.test.tsx
+++ b/public/pages/QueryInsights/QueryInsights.test.tsx
@@ -869,41 +869,24 @@ describe('QueryInsights - Column Visibility Integration', () => {
       expect(showAll).toBeInTheDocument();
     });
 
-    // Toggle a non-pinned column (e.g., "type" or "timestamp")
+    // "Type" is a non-pinned column present in every default view, so its
+    // toggle must exist. Assert unconditionally rather than silently passing.
     const typeToggle = document.querySelector(
       '[data-test-subj="column-toggle-type"]'
     ) as HTMLInputElement;
-    if (typeToggle) {
-      fireEvent.click(typeToggle);
+    expect(typeToggle).toBeInTheDocument();
 
-      // Close the popover by clicking the button again so aria-hidden is removed
-      fireEvent.click(columnsButton);
+    fireEvent.click(typeToggle);
 
-      // Verify column count decreased
-      await waitFor(() => {
-        const updatedTable = document.querySelectorAll('table');
-        const updatedMainTable = updatedTable[updatedTable.length - 1];
-        const updatedHeaders = updatedMainTable.querySelectorAll('th');
-        expect(updatedHeaders.length).toBeLessThan(initialColumnCount);
-      });
-    } else {
-      // If type toggle is not available, try timestamp
-      const timestampToggle = document.querySelector(
-        '[data-test-subj="column-toggle-timestamp"]'
-      ) as HTMLInputElement;
-      if (timestampToggle) {
-        fireEvent.click(timestampToggle);
+    // Close the popover by clicking the button again so aria-hidden is removed
+    fireEvent.click(columnsButton);
 
-        // Close the popover
-        fireEvent.click(columnsButton);
-
-        await waitFor(() => {
-          const updatedTable = document.querySelectorAll('table');
-          const updatedMainTable = updatedTable[updatedTable.length - 1];
-          const updatedHeaders = updatedMainTable.querySelectorAll('th');
-          expect(updatedHeaders.length).toBeLessThan(initialColumnCount);
-        });
-      }
-    }
+    // Verify column count decreased
+    await waitFor(() => {
+      const updatedTable = document.querySelectorAll('table');
+      const updatedMainTable = updatedTable[updatedTable.length - 1];
+      const updatedHeaders = updatedMainTable.querySelectorAll('th');
+      expect(updatedHeaders.length).toBeLessThan(initialColumnCount);
+    });
   });
 });

--- a/public/pages/QueryInsights/QueryInsights.tsx
+++ b/public/pages/QueryInsights/QueryInsights.tsx
@@ -69,6 +69,8 @@ import {
   evaluateExpression,
 } from '../../components/DynamicSearchBar';
 import { DEFAULT_WORKLOAD_GROUP } from '../../../common/constants';
+import { useColumnVisibility, ColumnDef } from '../../hooks/useColumnVisibility';
+import { ColumnVisibilityPopover } from '../../components/ColumnVisibilityPopover';
 
 // --- constants for field names and defaults ---
 const TIMESTAMP_FIELD = 'timestamp';
@@ -167,6 +169,38 @@ const QueryInsights = ({
       history.replace(location.pathname);
     }
   }, [location.search, history, location.pathname]);
+
+  // --- Column visibility definitions ---
+  const columnDefs = useMemo<ColumnDef[]>(() => {
+    const defs: ColumnDef[] = [
+      { id: 'id', label: 'ID', pinned: true },
+      { id: 'type', label: 'Type' },
+      { id: 'query_count', label: 'Query Count' },
+      { id: 'timestamp', label: 'Timestamp' },
+      ...(statusSupported ? [{ id: 'status', label: 'Status' }] : []),
+      { id: 'latency', label: 'Latency' },
+      { id: 'cpu', label: 'CPU Time' },
+      { id: 'memory', label: 'Memory Usage' },
+      { id: 'indices', label: 'Indices' },
+      { id: 'search_type', label: 'Search Type', defaultVisible: false },
+      { id: 'node_id', label: 'Node ID', defaultVisible: false },
+      ...(queryInsightWlmNavigationSupported ? [{ id: 'wlm_group', label: 'WLM Group' }] : []),
+      { id: 'total_shards', label: 'Total Shards', defaultVisible: false },
+    ];
+    return defs;
+  }, [statusSupported, queryInsightWlmNavigationSupported]);
+
+  const {
+    visibleColumnIds,
+    isColumnVisible,
+    toggleColumn,
+    showAll,
+    hideAll,
+    columns: columnVisibilityColumns,
+  } = useColumnVisibility({
+    storageKey: 'queryInsights_topn_visibleColumns',
+    columns: columnDefs,
+  });
 
   const from = parseDateString(currStart);
   const to = parseDateString(currEnd);
@@ -421,8 +455,9 @@ const QueryInsights = ({
         : MEMORY_USAGE;
   }, [effectiveView]);
 
-  const baseColumns: Array<EuiBasicTableColumn<SearchQueryRecord>> = [
+  const baseColumns: Array<EuiBasicTableColumn<SearchQueryRecord> & { id?: string }> = [
     {
+      id: 'id',
       name: ID,
       render: (query: SearchQueryRecord) => (
         <span>
@@ -443,6 +478,7 @@ const QueryInsights = ({
       truncateText: true,
     },
     {
+      id: 'type',
       name: TYPE,
       render: (query: SearchQueryRecord) => (
         <span>
@@ -464,8 +500,9 @@ const QueryInsights = ({
     },
   ];
 
-  const querycountColumn: Array<EuiBasicTableColumn<SearchQueryRecord>> = [
+  const querycountColumn: Array<EuiBasicTableColumn<SearchQueryRecord> & { id?: string }> = [
     {
+      id: 'query_count',
       name: QUERY_COUNT,
       render: (q: SearchQueryRecord) =>
         `${
@@ -483,19 +520,20 @@ const QueryInsights = ({
     },
   ];
 
-  const timestampColumn: Array<EuiBasicTableColumn<SearchQueryRecord>> = [
+  const timestampColumn: Array<EuiBasicTableColumn<SearchQueryRecord> & { id?: string }> = [
     {
+      id: 'timestamp',
       name: TIMESTAMP,
       render: (q: SearchQueryRecord) => {
         const isQuery = q.group_by === 'NONE';
-        const linkContent = isQuery ? convertTime(q.timestamp) : '-';
+        if (!isQuery) return <EuiBadge color="hollow">Aggregated</EuiBadge>;
         const onClickHandler = () => {
           const route = `/query-details?from=${from}&to=${to}&id=${q.id}&verbose=true`;
           history.push(route);
         };
         return (
           <span>
-            <EuiLink onClick={onClickHandler}>{linkContent}</EuiLink>
+            <EuiLink onClick={onClickHandler}>{convertTime(q.timestamp)}</EuiLink>
           </span>
         );
       },
@@ -504,11 +542,12 @@ const QueryInsights = ({
     },
   ];
 
-  const statusColumn: Array<EuiBasicTableColumn<SearchQueryRecord>> = [
+  const statusColumn: Array<EuiBasicTableColumn<SearchQueryRecord> & { id?: string }> = [
     {
+      id: 'status',
       name: 'Status',
       render: (q: SearchQueryRecord) => {
-        if (q.group_by === 'SIMILARITY') return <span>-</span>;
+        if (q.group_by === 'SIMILARITY') return <EuiBadge color="hollow">Aggregated</EuiBadge>;
         return q.failed ? (
           <EuiBadge color="danger">Failed</EuiBadge>
         ) : (
@@ -521,30 +560,49 @@ const QueryInsights = ({
   ];
 
   // columns shown only for query-type records
-  const QueryTypeSpecificColumns: Array<EuiBasicTableColumn<SearchQueryRecord>> = [
+  const QueryTypeSpecificColumns: Array<
+    EuiBasicTableColumn<SearchQueryRecord> & { id?: string }
+  > = [
     {
+      id: 'indices',
       field: INDICES_FIELD as keyof SearchQueryRecord,
       name: INDICES,
       render: (indices: string[] = [], q: SearchQueryRecord) => (
-        <span>{q.group_by === 'SIMILARITY' ? '-' : Array.from(new Set(indices)).join(', ')}</span>
+        <span>
+          {q.group_by === 'SIMILARITY' ? (
+            <EuiBadge color="hollow">Aggregated</EuiBadge>
+          ) : (
+            Array.from(new Set(indices)).join(', ')
+          )}
+        </span>
       ),
       sortable: true,
       truncateText: true,
     },
     {
+      id: 'search_type',
       field: SEARCH_TYPE_FIELD as keyof SearchQueryRecord,
       name: SEARCH_TYPE,
       render: (st: string, q: SearchQueryRecord) => (
-        <span>{q.group_by === 'SIMILARITY' ? '-' : (st || '').replaceAll('_', ' ')}</span>
+        <span>
+          {q.group_by === 'SIMILARITY' ? (
+            <EuiBadge color="hollow">Aggregated</EuiBadge>
+          ) : (
+            (st || '').replaceAll('_', ' ')
+          )}
+        </span>
       ),
       sortable: true,
       truncateText: true,
     },
     {
+      id: 'node_id',
       field: NODE_ID_FIELD as keyof SearchQueryRecord,
       name: NODE_ID,
       render: (nid: string, q: SearchQueryRecord) => (
-        <span>{q.group_by === 'SIMILARITY' ? '-' : nid}</span>
+        <span>
+          {q.group_by === 'SIMILARITY' ? <EuiBadge color="hollow">Aggregated</EuiBadge> : nid}
+        </span>
       ),
       sortable: true,
       truncateText: true,
@@ -552,10 +610,12 @@ const QueryInsights = ({
     ...(queryInsightWlmNavigationSupported
       ? [
           {
+            id: 'wlm_group',
             field: WLM_GROUP_FIELD as keyof SearchQueryRecord,
             name: WLM_GROUP,
             render: (wlmGroupId: string, q: SearchQueryRecord) => {
-              if (q.group_by === 'SIMILARITY') return '-';
+              if (q.group_by === 'SIMILARITY')
+                return <EuiBadge color="hollow">Aggregated</EuiBadge>;
               const groupId = wlmGroupId || DEFAULT_WORKLOAD_GROUP;
               const displayName =
                 groupId === DEFAULT_WORKLOAD_GROUP
@@ -590,10 +650,13 @@ const QueryInsights = ({
         ]
       : []),
     {
+      id: 'total_shards',
       field: TOTAL_SHARDS_FIELD as keyof SearchQueryRecord,
       name: TOTAL_SHARDS,
       render: (ts: number, q: SearchQueryRecord) => (
-        <span>{q.group_by === 'SIMILARITY' ? '-' : ts}</span>
+        <span>
+          {q.group_by === 'SIMILARITY' ? <EuiBadge color="hollow">Aggregated</EuiBadge> : ts}
+        </span>
       ),
       sortable: true,
       truncateText: true,
@@ -601,9 +664,10 @@ const QueryInsights = ({
   ];
 
   // metric columns (latency, cpu, memory)
-  const metricColumns: Array<EuiBasicTableColumn<SearchQueryRecord>> = useMemo(
+  const metricColumns: Array<EuiBasicTableColumn<SearchQueryRecord> & { id?: string }> = useMemo(
     () => [
       {
+        id: 'latency',
         field: LATENCY_FIELD as keyof SearchQueryRecord,
         name: latencyHeader,
         render: (_: any, q: SearchQueryRecord) =>
@@ -619,6 +683,7 @@ const QueryInsights = ({
         truncateText: true,
       },
       {
+        id: 'cpu',
         field: CPU_FIELD as keyof SearchQueryRecord,
         name: cpuHeader,
         render: (_: any, q: SearchQueryRecord) =>
@@ -634,6 +699,7 @@ const QueryInsights = ({
         truncateText: true,
       },
       {
+        id: 'memory',
         field: MEMORY_FIELD as keyof SearchQueryRecord,
         name: memHeader,
         render: (_: any, q: SearchQueryRecord) =>
@@ -696,7 +762,8 @@ const QueryInsights = ({
 
   /**
    * Decide which column set to show
-   * based on selected filters and presence of query/group rows
+   * based on selected filters and presence of query/group rows,
+   * then filter through column visibility preferences.
    */
   const columnsToShow = useMemo(() => {
     // Check if any non-type filter conditions exist in the expression
@@ -706,21 +773,72 @@ const QueryInsights = ({
     const hasFreeText = !!parsedExpression.freeText;
     const nonGroupActive = hasNonTypeFilter || hasFreeText;
 
+    let selectedColumns: Array<EuiBasicTableColumn<SearchQueryRecord> & { id?: string }>;
+
     if (selectedGroupBy.length === 1) {
-      return selectedGroupBy[0] === 'SIMILARITY' ? groupTypeColumns : queryTypeColumns;
+      selectedColumns = selectedGroupBy[0] === 'SIMILARITY' ? groupTypeColumns : queryTypeColumns;
+    } else if (nonGroupActive && (selectedGroupBy.length === 0 || selectedGroupBy.length === 2)) {
+      selectedColumns = queryTypeColumns;
+    } else {
+      const hasAnyQuery = items.some((q: SearchQueryRecord) => q.group_by === 'NONE');
+      const hasAnyGroup = items.some((q: SearchQueryRecord) => q.group_by === 'SIMILARITY');
+
+      if (items.length === 0) {
+        selectedColumns = defaultColumns;
+      } else if (hasAnyQuery && hasAnyGroup) {
+        selectedColumns = defaultColumns;
+      } else if (hasAnyGroup) {
+        selectedColumns = groupTypeColumns;
+      } else {
+        selectedColumns = queryTypeColumns;
+      }
     }
 
-    if (nonGroupActive && (selectedGroupBy.length === 0 || selectedGroupBy.length === 2)) {
-      return queryTypeColumns;
+    // Filter columns through visibility preferences, preserving original definition order
+    return selectedColumns.filter((col) => {
+      if (!col.id) return true; // columns without an id are always shown
+      return isColumnVisible(col.id);
+    });
+  }, [
+    items,
+    selectedGroupBy,
+    parsedExpression,
+    defaultColumns,
+    groupTypeColumns,
+    queryTypeColumns,
+    isColumnVisible,
+  ]);
+
+  // Columns available in the current view (for the popover — only show toggles for columns in the active set)
+  const activeColumnIdsForPopover = useMemo(() => {
+    const hasNonTypeFilter = parsedExpression.conditions.some(
+      (c) => c.field.toLowerCase() !== 'type' && c.field.toLowerCase() !== 'group_by'
+    );
+    const hasFreeText = !!parsedExpression.freeText;
+    const nonGroupActive = hasNonTypeFilter || hasFreeText;
+
+    let selectedColumns: Array<EuiBasicTableColumn<SearchQueryRecord> & { id?: string }>;
+
+    if (selectedGroupBy.length === 1) {
+      selectedColumns = selectedGroupBy[0] === 'SIMILARITY' ? groupTypeColumns : queryTypeColumns;
+    } else if (nonGroupActive && (selectedGroupBy.length === 0 || selectedGroupBy.length === 2)) {
+      selectedColumns = queryTypeColumns;
+    } else {
+      const hasAnyQuery = items.some((q: SearchQueryRecord) => q.group_by === 'NONE');
+      const hasAnyGroup = items.some((q: SearchQueryRecord) => q.group_by === 'SIMILARITY');
+
+      if (items.length === 0) {
+        selectedColumns = defaultColumns;
+      } else if (hasAnyQuery && hasAnyGroup) {
+        selectedColumns = defaultColumns;
+      } else if (hasAnyGroup) {
+        selectedColumns = groupTypeColumns;
+      } else {
+        selectedColumns = queryTypeColumns;
+      }
     }
 
-    const hasAnyQuery = items.some((q: SearchQueryRecord) => q.group_by === 'NONE');
-    const hasAnyGroup = items.some((q: SearchQueryRecord) => q.group_by === 'SIMILARITY');
-
-    if (items.length === 0) return defaultColumns;
-    if (hasAnyQuery && hasAnyGroup) return defaultColumns;
-    if (hasAnyGroup) return groupTypeColumns;
-    return queryTypeColumns;
+    return new Set(selectedColumns.map((col) => col.id).filter(Boolean));
   }, [
     items,
     selectedGroupBy,
@@ -1021,6 +1139,22 @@ const QueryInsights = ({
                 queries={queries}
                 value={searchQuery}
                 onChange={onSearchChange}
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <ColumnVisibilityPopover
+                columns={columnVisibilityColumns}
+                visibleColumnIds={visibleColumnIds}
+                onToggleColumn={toggleColumn}
+                onShowAll={showAll}
+                onHideAll={hideAll}
+                unavailableColumnIds={
+                  new Set(
+                    columnVisibilityColumns
+                      .filter((col) => !activeColumnIdsForPopover.has(col.id))
+                      .map((col) => col.id)
+                  )
+                }
               />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>

--- a/public/pages/QueryInsights/QueryInsights.tsx
+++ b/public/pages/QueryInsights/QueryInsights.tsx
@@ -123,8 +123,9 @@ const QueryInsights = ({
   const [wlmIdToNameMap, setWlmIdToNameMap] = useState<Record<string, string>>({});
   const [wlmAvailable, setWlmAvailable] = useState<boolean>(false);
   const [statusSupported, setStatusSupported] = useState<boolean>(false);
-  const [queryInsightWlmNavigationSupported, setQueryInsightWlmNavigationSupported] =
-    useState<boolean>(false);
+  const [queryInsightWlmNavigationSupported, setQueryInsightWlmNavigationSupported] = useState<
+    boolean
+  >(false);
   // Initialize search query based on URL parameters
   const urlParams = new URLSearchParams(location.search);
   const wlmGroupIdFromUrl = urlParams.get('wlmGroupId');
@@ -435,24 +436,24 @@ const QueryInsights = ({
     return effectiveView === 'mixed'
       ? `Avg ${LATENCY} / ${LATENCY}`
       : effectiveView === 'group'
-        ? `Average ${LATENCY}`
-        : `${LATENCY}`;
+      ? `Average ${LATENCY}`
+      : `${LATENCY}`;
   }, [effectiveView]);
 
   const cpuHeader = useMemo(() => {
     return effectiveView === 'mixed'
       ? `Avg ${CPU_TIME} / ${CPU_TIME}`
       : effectiveView === 'group'
-        ? `Average ${CPU_TIME}`
-        : `${CPU_TIME}`;
+      ? `Average ${CPU_TIME}`
+      : `${CPU_TIME}`;
   }, [effectiveView]);
 
   const memHeader = useMemo(() => {
     return effectiveView === 'mixed'
       ? `Avg ${MEMORY_USAGE} / ${MEMORY_USAGE}`
       : effectiveView === 'group'
-        ? `Average ${MEMORY_USAGE}`
-        : MEMORY_USAGE;
+      ? `Average ${MEMORY_USAGE}`
+      : MEMORY_USAGE;
   }, [effectiveView]);
 
   const baseColumns: Array<EuiBasicTableColumn<SearchQueryRecord> & { id?: string }> = [
@@ -621,8 +622,8 @@ const QueryInsights = ({
                 groupId === DEFAULT_WORKLOAD_GROUP
                   ? DEFAULT_WORKLOAD_GROUP
                   : wlmAvailable
-                    ? wlmIdToNameMap[groupId] || '-'
-                    : '-';
+                  ? wlmIdToNameMap[groupId] || '-'
+                  : '-';
 
               if (wlmAvailable && displayName !== '-') {
                 return (
@@ -737,10 +738,11 @@ const QueryInsights = ({
       QueryTypeSpecificColumns,
     ]
   );
-  const groupTypeColumns = useMemo(
-    () => [...baseColumns, ...querycountColumn, ...metricColumns],
-    [baseColumns, querycountColumn, metricColumns]
-  );
+  const groupTypeColumns = useMemo(() => [...baseColumns, ...querycountColumn, ...metricColumns], [
+    baseColumns,
+    querycountColumn,
+    metricColumns,
+  ]);
 
   const queryTypeColumns = useMemo(
     () => [
@@ -1083,8 +1085,8 @@ const QueryInsights = ({
           performanceMetric === 'latency'
             ? 'Latency (ms)'
             : performanceMetric === 'cpu'
-              ? 'CPU Time (ms)'
-              : 'Memory (MB)',
+            ? 'CPU Time (ms)'
+            : 'Memory (MB)',
       },
       series: [
         {
@@ -1331,10 +1333,10 @@ const QueryInsights = ({
                               {chartGroupBy === 'node'
                                 ? 'Queries by Node'
                                 : chartGroupBy === 'index'
-                                  ? 'Queries by Index'
-                                  : chartGroupBy === 'username'
-                                    ? 'Queries by Username'
-                                    : 'Queries by WLM Group'}
+                                ? 'Queries by Index'
+                                : chartGroupBy === 'username'
+                                ? 'Queries by Username'
+                                : 'Queries by WLM Group'}
                             </h3>
                           </EuiTitle>
                         </EuiFlexItem>
@@ -1374,10 +1376,10 @@ const QueryInsights = ({
                                     chartGroupBy === 'node'
                                       ? 'Node'
                                       : chartGroupBy === 'index'
-                                        ? 'Index'
-                                        : chartGroupBy === 'username'
-                                          ? 'Username'
-                                          : 'WLM Group';
+                                      ? 'Index'
+                                      : chartGroupBy === 'username'
+                                      ? 'Username'
+                                      : 'WLM Group';
                                   return `${label}: ${pieParams.name}<br/>Query Count: ${pieParams.value}<br/>Percentage: ${pieParams.percent}%`;
                                 },
                               },
@@ -1419,12 +1421,12 @@ const QueryInsights = ({
                                   chartGroupBy === 'node'
                                     ? 'Node'
                                     : chartGroupBy === 'index'
-                                      ? 'Index'
-                                      : chartGroupBy === 'username'
-                                        ? 'Username'
-                                        : 'WLM Group',
+                                    ? 'Index'
+                                    : chartGroupBy === 'username'
+                                    ? 'Username'
+                                    : 'WLM Group',
                                 sortable: true,
-                                render: (name: string, item: (typeof chartData)[0]) => (
+                                render: (name: string, item: typeof chartData[0]) => (
                                   <EuiFlexGroup
                                     gutterSize="s"
                                     alignItems="center"
@@ -1448,7 +1450,7 @@ const QueryInsights = ({
                                 name: 'Percentage',
                                 render: (p: string) => `${p}%`,
                                 align: 'right',
-                                sortable: (item: (typeof chartData)[0]) =>
+                                sortable: (item: typeof chartData[0]) =>
                                   parseFloat(item.percentage),
                               },
                             ]}

--- a/public/pages/QueryInsights/QueryInsights.tsx
+++ b/public/pages/QueryInsights/QueryInsights.tsx
@@ -763,11 +763,11 @@ const QueryInsights = ({
   );
 
   /**
-   * Decide which column set to show
-   * based on selected filters and presence of query/group rows,
-   * then filter through column visibility preferences.
+   * Decide which column set to show for the current view, based on selected
+   * filters and the presence of query/group rows. This is the superset of
+   * columns before any visibility preferences are applied.
    */
-  const columnsToShow = useMemo(() => {
+  const viewColumns = useMemo(() => {
     // Check if any non-type filter conditions exist in the expression
     const hasNonTypeFilter = parsedExpression.conditions.some(
       (c) => c.field.toLowerCase() !== 'type' && c.field.toLowerCase() !== 'group_by'
@@ -775,32 +775,20 @@ const QueryInsights = ({
     const hasFreeText = !!parsedExpression.freeText;
     const nonGroupActive = hasNonTypeFilter || hasFreeText;
 
-    let selectedColumns: Array<EuiBasicTableColumn<SearchQueryRecord> & { id?: string }>;
-
     if (selectedGroupBy.length === 1) {
-      selectedColumns = selectedGroupBy[0] === 'SIMILARITY' ? groupTypeColumns : queryTypeColumns;
-    } else if (nonGroupActive && (selectedGroupBy.length === 0 || selectedGroupBy.length === 2)) {
-      selectedColumns = queryTypeColumns;
-    } else {
-      const hasAnyQuery = items.some((q: SearchQueryRecord) => q.group_by === 'NONE');
-      const hasAnyGroup = items.some((q: SearchQueryRecord) => q.group_by === 'SIMILARITY');
-
-      if (items.length === 0) {
-        selectedColumns = defaultColumns;
-      } else if (hasAnyQuery && hasAnyGroup) {
-        selectedColumns = defaultColumns;
-      } else if (hasAnyGroup) {
-        selectedColumns = groupTypeColumns;
-      } else {
-        selectedColumns = queryTypeColumns;
-      }
+      return selectedGroupBy[0] === 'SIMILARITY' ? groupTypeColumns : queryTypeColumns;
+    }
+    if (nonGroupActive && (selectedGroupBy.length === 0 || selectedGroupBy.length === 2)) {
+      return queryTypeColumns;
     }
 
-    // Filter columns through visibility preferences, preserving original definition order
-    return selectedColumns.filter((col) => {
-      if (!col.id) return true; // columns without an id are always shown
-      return isColumnVisible(col.id);
-    });
+    const hasAnyQuery = items.some((q: SearchQueryRecord) => q.group_by === 'NONE');
+    const hasAnyGroup = items.some((q: SearchQueryRecord) => q.group_by === 'SIMILARITY');
+
+    if (items.length === 0) return defaultColumns;
+    if (hasAnyQuery && hasAnyGroup) return defaultColumns;
+    if (hasAnyGroup) return groupTypeColumns;
+    return queryTypeColumns;
   }, [
     items,
     selectedGroupBy,
@@ -808,47 +796,26 @@ const QueryInsights = ({
     defaultColumns,
     groupTypeColumns,
     queryTypeColumns,
-    isColumnVisible,
   ]);
 
-  // Columns available in the current view (for the popover — only show toggles for columns in the active set)
+  /**
+   * Filter the view's columns through visibility preferences (preserving the
+   * original definition order) and strip the internal `id` marker so it does
+   * not leak onto the rendered table cells as an invalid duplicate DOM id.
+   */
+  const columnsToShow = useMemo(() => {
+    return viewColumns
+      .filter((col) => (col.id ? isColumnVisible(col.id) : true))
+      .map((col) => {
+        const { id: _id, ...rest } = col;
+        return rest;
+      });
+  }, [viewColumns, isColumnVisible]);
+
+  // Column ids available in the current view (the popover only shows toggles for these)
   const activeColumnIdsForPopover = useMemo(() => {
-    const hasNonTypeFilter = parsedExpression.conditions.some(
-      (c) => c.field.toLowerCase() !== 'type' && c.field.toLowerCase() !== 'group_by'
-    );
-    const hasFreeText = !!parsedExpression.freeText;
-    const nonGroupActive = hasNonTypeFilter || hasFreeText;
-
-    let selectedColumns: Array<EuiBasicTableColumn<SearchQueryRecord> & { id?: string }>;
-
-    if (selectedGroupBy.length === 1) {
-      selectedColumns = selectedGroupBy[0] === 'SIMILARITY' ? groupTypeColumns : queryTypeColumns;
-    } else if (nonGroupActive && (selectedGroupBy.length === 0 || selectedGroupBy.length === 2)) {
-      selectedColumns = queryTypeColumns;
-    } else {
-      const hasAnyQuery = items.some((q: SearchQueryRecord) => q.group_by === 'NONE');
-      const hasAnyGroup = items.some((q: SearchQueryRecord) => q.group_by === 'SIMILARITY');
-
-      if (items.length === 0) {
-        selectedColumns = defaultColumns;
-      } else if (hasAnyQuery && hasAnyGroup) {
-        selectedColumns = defaultColumns;
-      } else if (hasAnyGroup) {
-        selectedColumns = groupTypeColumns;
-      } else {
-        selectedColumns = queryTypeColumns;
-      }
-    }
-
-    return new Set(selectedColumns.map((col) => col.id).filter(Boolean));
-  }, [
-    items,
-    selectedGroupBy,
-    parsedExpression,
-    defaultColumns,
-    groupTypeColumns,
-    queryTypeColumns,
-  ]);
+    return new Set(viewColumns.map((col) => col.id).filter(Boolean));
+  }, [viewColumns]);
 
   const onSearchChange = (text: string) => {
     setSearchQuery(text);

--- a/public/pages/QueryInsights/QueryInsights.tsx
+++ b/public/pages/QueryInsights/QueryInsights.tsx
@@ -123,9 +123,8 @@ const QueryInsights = ({
   const [wlmIdToNameMap, setWlmIdToNameMap] = useState<Record<string, string>>({});
   const [wlmAvailable, setWlmAvailable] = useState<boolean>(false);
   const [statusSupported, setStatusSupported] = useState<boolean>(false);
-  const [queryInsightWlmNavigationSupported, setQueryInsightWlmNavigationSupported] = useState<
-    boolean
-  >(false);
+  const [queryInsightWlmNavigationSupported, setQueryInsightWlmNavigationSupported] =
+    useState<boolean>(false);
   // Initialize search query based on URL parameters
   const urlParams = new URLSearchParams(location.search);
   const wlmGroupIdFromUrl = urlParams.get('wlmGroupId');
@@ -436,24 +435,24 @@ const QueryInsights = ({
     return effectiveView === 'mixed'
       ? `Avg ${LATENCY} / ${LATENCY}`
       : effectiveView === 'group'
-      ? `Average ${LATENCY}`
-      : `${LATENCY}`;
+        ? `Average ${LATENCY}`
+        : `${LATENCY}`;
   }, [effectiveView]);
 
   const cpuHeader = useMemo(() => {
     return effectiveView === 'mixed'
       ? `Avg ${CPU_TIME} / ${CPU_TIME}`
       : effectiveView === 'group'
-      ? `Average ${CPU_TIME}`
-      : `${CPU_TIME}`;
+        ? `Average ${CPU_TIME}`
+        : `${CPU_TIME}`;
   }, [effectiveView]);
 
   const memHeader = useMemo(() => {
     return effectiveView === 'mixed'
       ? `Avg ${MEMORY_USAGE} / ${MEMORY_USAGE}`
       : effectiveView === 'group'
-      ? `Average ${MEMORY_USAGE}`
-      : MEMORY_USAGE;
+        ? `Average ${MEMORY_USAGE}`
+        : MEMORY_USAGE;
   }, [effectiveView]);
 
   const baseColumns: Array<EuiBasicTableColumn<SearchQueryRecord> & { id?: string }> = [
@@ -561,108 +560,107 @@ const QueryInsights = ({
   ];
 
   // columns shown only for query-type records
-  const QueryTypeSpecificColumns: Array<
-    EuiBasicTableColumn<SearchQueryRecord> & { id?: string }
-  > = [
-    {
-      id: 'indices',
-      field: INDICES_FIELD as keyof SearchQueryRecord,
-      name: INDICES,
-      render: (indices: string[] = [], q: SearchQueryRecord) => (
-        <span>
-          {q.group_by === 'SIMILARITY' ? (
-            <EuiBadge color="hollow">Aggregated</EuiBadge>
-          ) : (
-            Array.from(new Set(indices)).join(', ')
-          )}
-        </span>
-      ),
-      sortable: true,
-      truncateText: true,
-    },
-    {
-      id: 'search_type',
-      field: SEARCH_TYPE_FIELD as keyof SearchQueryRecord,
-      name: SEARCH_TYPE,
-      render: (st: string, q: SearchQueryRecord) => (
-        <span>
-          {q.group_by === 'SIMILARITY' ? (
-            <EuiBadge color="hollow">Aggregated</EuiBadge>
-          ) : (
-            (st || '').replaceAll('_', ' ')
-          )}
-        </span>
-      ),
-      sortable: true,
-      truncateText: true,
-    },
-    {
-      id: 'node_id',
-      field: NODE_ID_FIELD as keyof SearchQueryRecord,
-      name: NODE_ID,
-      render: (nid: string, q: SearchQueryRecord) => (
-        <span>
-          {q.group_by === 'SIMILARITY' ? <EuiBadge color="hollow">Aggregated</EuiBadge> : nid}
-        </span>
-      ),
-      sortable: true,
-      truncateText: true,
-    },
-    ...(queryInsightWlmNavigationSupported
-      ? [
-          {
-            id: 'wlm_group',
-            field: WLM_GROUP_FIELD as keyof SearchQueryRecord,
-            name: WLM_GROUP,
-            render: (wlmGroupId: string, q: SearchQueryRecord) => {
-              if (q.group_by === 'SIMILARITY')
-                return <EuiBadge color="hollow">Aggregated</EuiBadge>;
-              const groupId = wlmGroupId || DEFAULT_WORKLOAD_GROUP;
-              const displayName =
-                groupId === DEFAULT_WORKLOAD_GROUP
-                  ? DEFAULT_WORKLOAD_GROUP
-                  : wlmAvailable
-                  ? wlmIdToNameMap[groupId] || '-'
-                  : '-';
+  const QueryTypeSpecificColumns: Array<EuiBasicTableColumn<SearchQueryRecord> & { id?: string }> =
+    [
+      {
+        id: 'indices',
+        field: INDICES_FIELD as keyof SearchQueryRecord,
+        name: INDICES,
+        render: (indices: string[] = [], q: SearchQueryRecord) => (
+          <span>
+            {q.group_by === 'SIMILARITY' ? (
+              <EuiBadge color="hollow">Aggregated</EuiBadge>
+            ) : (
+              Array.from(new Set(indices)).join(', ')
+            )}
+          </span>
+        ),
+        sortable: true,
+        truncateText: true,
+      },
+      {
+        id: 'search_type',
+        field: SEARCH_TYPE_FIELD as keyof SearchQueryRecord,
+        name: SEARCH_TYPE,
+        render: (st: string, q: SearchQueryRecord) => (
+          <span>
+            {q.group_by === 'SIMILARITY' ? (
+              <EuiBadge color="hollow">Aggregated</EuiBadge>
+            ) : (
+              (st || '').replaceAll('_', ' ')
+            )}
+          </span>
+        ),
+        sortable: true,
+        truncateText: true,
+      },
+      {
+        id: 'node_id',
+        field: NODE_ID_FIELD as keyof SearchQueryRecord,
+        name: NODE_ID,
+        render: (nid: string, q: SearchQueryRecord) => (
+          <span>
+            {q.group_by === 'SIMILARITY' ? <EuiBadge color="hollow">Aggregated</EuiBadge> : nid}
+          </span>
+        ),
+        sortable: true,
+        truncateText: true,
+      },
+      ...(queryInsightWlmNavigationSupported
+        ? [
+            {
+              id: 'wlm_group',
+              field: WLM_GROUP_FIELD as keyof SearchQueryRecord,
+              name: WLM_GROUP,
+              render: (wlmGroupId: string, q: SearchQueryRecord) => {
+                if (q.group_by === 'SIMILARITY')
+                  return <EuiBadge color="hollow">Aggregated</EuiBadge>;
+                const groupId = wlmGroupId || DEFAULT_WORKLOAD_GROUP;
+                const displayName =
+                  groupId === DEFAULT_WORKLOAD_GROUP
+                    ? DEFAULT_WORKLOAD_GROUP
+                    : wlmAvailable
+                      ? wlmIdToNameMap[groupId] || '-'
+                      : '-';
 
-              if (wlmAvailable && displayName !== '-') {
-                return (
-                  <EuiLink
-                    onClick={() => {
-                      const dsParam = dataSource?.id
-                        ? `&dataSource=${encodeURIComponent(JSON.stringify(dataSource))}`
-                        : '';
-                      core.application.navigateToApp('workloadManagement', {
-                        path: `#/wlm-details?name=${encodeURIComponent(displayName)}${dsParam}`,
-                      });
-                    }}
-                    color="primary"
-                  >
-                    {displayName} <EuiIcon type="popout" size="s" />
-                  </EuiLink>
-                );
-              }
+                if (wlmAvailable && displayName !== '-') {
+                  return (
+                    <EuiLink
+                      onClick={() => {
+                        const dsParam = dataSource?.id
+                          ? `&dataSource=${encodeURIComponent(JSON.stringify(dataSource))}`
+                          : '';
+                        core.application.navigateToApp('workloadManagement', {
+                          path: `#/wlm-details?name=${encodeURIComponent(displayName)}${dsParam}`,
+                        });
+                      }}
+                      color="primary"
+                    >
+                      {displayName} <EuiIcon type="popout" size="s" aria-hidden={true} />
+                    </EuiLink>
+                  );
+                }
 
-              return <span>{displayName}</span>;
+                return <span>{displayName}</span>;
+              },
+              sortable: true,
+              truncateText: true,
             },
-            sortable: true,
-            truncateText: true,
-          },
-        ]
-      : []),
-    {
-      id: 'total_shards',
-      field: TOTAL_SHARDS_FIELD as keyof SearchQueryRecord,
-      name: TOTAL_SHARDS,
-      render: (ts: number, q: SearchQueryRecord) => (
-        <span>
-          {q.group_by === 'SIMILARITY' ? <EuiBadge color="hollow">Aggregated</EuiBadge> : ts}
-        </span>
-      ),
-      sortable: true,
-      truncateText: true,
-    },
-  ];
+          ]
+        : []),
+      {
+        id: 'total_shards',
+        field: TOTAL_SHARDS_FIELD as keyof SearchQueryRecord,
+        name: TOTAL_SHARDS,
+        render: (ts: number, q: SearchQueryRecord) => (
+          <span>
+            {q.group_by === 'SIMILARITY' ? <EuiBadge color="hollow">Aggregated</EuiBadge> : ts}
+          </span>
+        ),
+        sortable: true,
+        truncateText: true,
+      },
+    ];
 
   // metric columns (latency, cpu, memory)
   const metricColumns: Array<EuiBasicTableColumn<SearchQueryRecord> & { id?: string }> = useMemo(
@@ -738,11 +736,10 @@ const QueryInsights = ({
       QueryTypeSpecificColumns,
     ]
   );
-  const groupTypeColumns = useMemo(() => [...baseColumns, ...querycountColumn, ...metricColumns], [
-    baseColumns,
-    querycountColumn,
-    metricColumns,
-  ]);
+  const groupTypeColumns = useMemo(
+    () => [...baseColumns, ...querycountColumn, ...metricColumns],
+    [baseColumns, querycountColumn, metricColumns]
+  );
 
   const queryTypeColumns = useMemo(
     () => [
@@ -1052,8 +1049,8 @@ const QueryInsights = ({
           performanceMetric === 'latency'
             ? 'Latency (ms)'
             : performanceMetric === 'cpu'
-            ? 'CPU Time (ms)'
-            : 'Memory (MB)',
+              ? 'CPU Time (ms)'
+              : 'Memory (MB)',
       },
       series: [
         {
@@ -1176,7 +1173,7 @@ const QueryInsights = ({
                     <EuiSpacer size="xxl" />
                     <EuiFlexGroup direction="column" alignItems="center" justifyContent="center">
                       <EuiFlexItem grow={false}>
-                        <EuiIcon type="visLine" size="xxl" color="subdued" />
+                        <EuiIcon type="visLine" size="xxl" color="subdued" aria-hidden={true} />
                       </EuiFlexItem>
                       <EuiFlexItem grow={false}>
                         <EuiTitle size="s">
@@ -1300,10 +1297,10 @@ const QueryInsights = ({
                               {chartGroupBy === 'node'
                                 ? 'Queries by Node'
                                 : chartGroupBy === 'index'
-                                ? 'Queries by Index'
-                                : chartGroupBy === 'username'
-                                ? 'Queries by Username'
-                                : 'Queries by WLM Group'}
+                                  ? 'Queries by Index'
+                                  : chartGroupBy === 'username'
+                                    ? 'Queries by Username'
+                                    : 'Queries by WLM Group'}
                             </h3>
                           </EuiTitle>
                         </EuiFlexItem>
@@ -1343,10 +1340,10 @@ const QueryInsights = ({
                                     chartGroupBy === 'node'
                                       ? 'Node'
                                       : chartGroupBy === 'index'
-                                      ? 'Index'
-                                      : chartGroupBy === 'username'
-                                      ? 'Username'
-                                      : 'WLM Group';
+                                        ? 'Index'
+                                        : chartGroupBy === 'username'
+                                          ? 'Username'
+                                          : 'WLM Group';
                                   return `${label}: ${pieParams.name}<br/>Query Count: ${pieParams.value}<br/>Percentage: ${pieParams.percent}%`;
                                 },
                               },
@@ -1388,19 +1385,19 @@ const QueryInsights = ({
                                   chartGroupBy === 'node'
                                     ? 'Node'
                                     : chartGroupBy === 'index'
-                                    ? 'Index'
-                                    : chartGroupBy === 'username'
-                                    ? 'Username'
-                                    : 'WLM Group',
+                                      ? 'Index'
+                                      : chartGroupBy === 'username'
+                                        ? 'Username'
+                                        : 'WLM Group',
                                 sortable: true,
-                                render: (name: string, item: typeof chartData[0]) => (
+                                render: (name: string, item: (typeof chartData)[0]) => (
                                   <EuiFlexGroup
                                     gutterSize="s"
                                     alignItems="center"
                                     responsive={false}
                                   >
                                     <EuiFlexItem grow={false}>
-                                      <EuiIcon type="dot" color={item.color} />
+                                      <EuiIcon type="dot" color={item.color} aria-hidden={true} />
                                     </EuiFlexItem>
                                     <EuiFlexItem>{name}</EuiFlexItem>
                                   </EuiFlexGroup>
@@ -1417,7 +1414,7 @@ const QueryInsights = ({
                                 name: 'Percentage',
                                 render: (p: string) => `${p}%`,
                                 align: 'right',
-                                sortable: (item: typeof chartData[0]) =>
+                                sortable: (item: (typeof chartData)[0]) =>
                                   parseFloat(item.percentage),
                               },
                             ]}
@@ -1597,7 +1594,7 @@ const QueryInsights = ({
                   <EuiSpacer size="xxl" />
                   <EuiFlexGroup direction="column" alignItems="center" justifyContent="center">
                     <EuiFlexItem grow={false}>
-                      <EuiIcon type="visLine" size="xxl" color="subdued" />
+                      <EuiIcon type="visLine" size="xxl" color="subdued" aria-hidden={true} />
                     </EuiFlexItem>
                     <EuiFlexItem grow={false}>
                       <EuiTitle size="s">

--- a/public/pages/QueryInsights/__snapshots__/QueryInsights.test.tsx.snap
+++ b/public/pages/QueryInsights/__snapshots__/QueryInsights.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
           <button
             aria-label="Toggle column visibility"
             data-test-subj="column-visibility-button"
-            style="display: inline-flex; align-items: center; gap: 8px; padding: 0px 12px; height: 40px; cursor: pointer; font-size: 14px; color: rgb(1, 125, 115); font-weight: 400; width: auto; min-width: 0; text-align: left; border: 1px solid #d3dae6; border-radius: 0; background: transparent; outline: none; box-shadow: none;"
+            style="display: inline-flex; align-items: center; gap: 8px; padding: 0px 12px; height: 40px; cursor: pointer; font-size: 14px; color: rgb(1, 125, 115); font-weight: 400; width: auto; min-width: 0; text-align: left; border: 1px solid rgb(211, 218, 230); border-radius: 0; background: transparent; outline: none; box-shadow: none;"
           >
             <svg
               aria-hidden="true"

--- a/public/pages/QueryInsights/__snapshots__/QueryInsights.test.tsx.snap
+++ b/public/pages/QueryInsights/__snapshots__/QueryInsights.test.tsx.snap
@@ -65,43 +65,51 @@ exports[`QueryInsights Component renders the table with the correct columns and 
         >
           <button
             aria-label="Toggle column visibility"
+            class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small euiButtonEmpty--flushBoth"
             data-test-subj="column-visibility-button"
-            style="display: inline-flex; align-items: center; gap: 8px; padding: 0px 12px; height: 40px; cursor: pointer; font-size: 14px; color: rgb(1, 125, 115); font-weight: 400; width: auto; min-width: 0; text-align: left; border: 1px solid rgb(211, 218, 230); border-radius: 0; background: transparent; outline: none; box-shadow: none;"
+            type="button"
           >
-            <svg
-              aria-hidden="true"
-              class="euiIcon euiIcon--medium euiIcon--customColor"
-              focusable="false"
-              height="16"
-              role="img"
-              style="color: rgb(1, 125, 115);"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
+            <span
+              class="euiButtonContent euiButtonEmpty__content"
             >
-              <path
-                d="M16 3v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v1Zm-1 0V2a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v1h14Zm0 1H1v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4ZM4.5 7a.5.5 0 0 1 0 1H2.496a.5.5 0 1 1 0-1H4.5Zm9 0a.5.5 0 1 1 0 1h-6a.5.5 0 0 1 0-1h6Zm-9 4a.5.5 0 1 1 0 1H2.496a.5.5 0 1 1 0-1H4.5Zm9 0a.5.5 0 1 1 0 1h-6a.5.5 0 1 1 0-1h6Z"
-              />
-            </svg>
-            <span>
-              Columns
+              <svg
+                aria-hidden="true"
+                class="euiIcon euiIcon--medium euiIcon--inherit euiButtonContent__icon"
+                focusable="false"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16 3v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v1Zm-1 0V2a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v1h14Zm0 1H1v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4ZM4.5 7a.5.5 0 0 1 0 1H2.496a.5.5 0 1 1 0-1H4.5Zm9 0a.5.5 0 1 1 0 1h-6a.5.5 0 0 1 0-1h6Zm-9 4a.5.5 0 1 1 0 1H2.496a.5.5 0 1 1 0-1H4.5Zm9 0a.5.5 0 1 1 0 1h-6a.5.5 0 1 1 0-1h6Z"
+                />
+              </svg>
+              <span
+                class="euiButtonEmpty__text"
+              >
+                <span>
+                  Columns
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="euiIcon euiIcon--small"
+                  focusable="false"
+                  height="16"
+                  role="img"
+                  style="margin-left: 4px;"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                    fill-rule="non-zero"
+                  />
+                </svg>
+              </span>
             </span>
-            <svg
-              aria-hidden="true"
-              class="euiIcon euiIcon--small euiIcon--customColor"
-              focusable="false"
-              height="16"
-              role="img"
-              style="color: rgb(1, 125, 115);"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                fill-rule="non-zero"
-              />
-            </svg>
           </button>
         </div>
       </div>
@@ -1512,7 +1520,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
           >
             <td
               class="euiTableRowCell"
-              id="id"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1536,7 +1543,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="type"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1560,7 +1566,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="query_count"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1575,7 +1580,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="timestamp"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1599,7 +1603,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="latency"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1614,7 +1617,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="cpu"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1629,7 +1631,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="memory"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1644,7 +1645,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="indices"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1667,7 +1667,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
           >
             <td
               class="euiTableRowCell"
-              id="id"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1691,7 +1690,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="type"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1715,7 +1713,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="query_count"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1730,7 +1727,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="timestamp"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1758,7 +1754,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="latency"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1773,7 +1768,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="cpu"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1788,7 +1782,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="memory"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1803,7 +1796,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="indices"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1839,7 +1831,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
           >
             <td
               class="euiTableRowCell"
-              id="id"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1863,7 +1854,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="type"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1887,7 +1877,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="query_count"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1902,7 +1891,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="timestamp"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1926,7 +1914,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="latency"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1941,7 +1928,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="cpu"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1956,7 +1942,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="memory"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1971,7 +1956,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="indices"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1994,7 +1978,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
           >
             <td
               class="euiTableRowCell"
-              id="id"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2018,7 +2001,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="type"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2042,7 +2024,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="query_count"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2057,7 +2038,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="timestamp"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2081,7 +2061,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="latency"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2096,7 +2075,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="cpu"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2111,7 +2089,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="memory"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2126,7 +2103,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="indices"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2149,7 +2125,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
           >
             <td
               class="euiTableRowCell"
-              id="id"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2173,7 +2148,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="type"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2197,7 +2171,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="query_count"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2212,7 +2185,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="timestamp"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2240,7 +2212,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="latency"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2255,7 +2226,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="cpu"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2270,7 +2240,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="memory"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2285,7 +2254,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="indices"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2321,7 +2289,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
           >
             <td
               class="euiTableRowCell"
-              id="id"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2345,7 +2312,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="type"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2369,7 +2335,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="query_count"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2384,7 +2349,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="timestamp"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2412,7 +2376,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="latency"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2427,7 +2390,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="cpu"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2442,7 +2404,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="memory"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2457,7 +2418,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="indices"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2493,7 +2453,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
           >
             <td
               class="euiTableRowCell"
-              id="id"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2517,7 +2476,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="type"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2541,7 +2499,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="query_count"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2556,7 +2513,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="timestamp"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2584,7 +2540,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="latency"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2599,7 +2554,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="cpu"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2614,7 +2568,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="memory"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2629,7 +2582,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="indices"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2665,7 +2617,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
           >
             <td
               class="euiTableRowCell"
-              id="id"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2689,7 +2640,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="type"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2713,7 +2663,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="query_count"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2728,7 +2677,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="timestamp"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2756,7 +2704,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="latency"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2771,7 +2718,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="cpu"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2786,7 +2732,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="memory"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2801,7 +2746,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
-              id="indices"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"

--- a/public/pages/QueryInsights/__snapshots__/QueryInsights.test.tsx.snap
+++ b/public/pages/QueryInsights/__snapshots__/QueryInsights.test.tsx.snap
@@ -57,6 +57,59 @@ exports[`QueryInsights Component renders the table with the correct columns and 
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <div
+        class="euiPopover euiPopover--anchorDownLeft"
+        data-test-subj="column-visibility-popover"
+      >
+        <div
+          class="euiPopover__anchor"
+        >
+          <button
+            aria-label="Toggle column visibility"
+            data-test-subj="column-visibility-button"
+            style="display: inline-flex; align-items: center; gap: 8px; padding: 0px 12px; height: 40px; cursor: pointer; font-size: 14px; color: rgb(1, 125, 115); font-weight: 400; width: auto; min-width: 0; text-align: left; border: 1px solid #d3dae6; border-radius: 0; background: transparent; outline: none; box-shadow: none;"
+          >
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--medium euiIcon--customColor"
+              focusable="false"
+              height="16"
+              role="img"
+              style="color: rgb(1, 125, 115);"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M16 3v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v1Zm-1 0V2a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v1h14Zm0 1H1v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4ZM4.5 7a.5.5 0 0 1 0 1H2.496a.5.5 0 1 1 0-1H4.5Zm9 0a.5.5 0 1 1 0 1h-6a.5.5 0 0 1 0-1h6Zm-9 4a.5.5 0 1 1 0 1H2.496a.5.5 0 1 1 0-1H4.5Zm9 0a.5.5 0 1 1 0 1h-6a.5.5 0 1 1 0-1h6Z"
+              />
+            </svg>
+            <span>
+              Columns
+            </span>
+            <svg
+              aria-hidden="true"
+              class="euiIcon euiIcon--small euiIcon--customColor"
+              focusable="false"
+              height="16"
+              role="img"
+              style="color: rgb(1, 125, 115);"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                fill-rule="non-zero"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="euiFlexItem euiFlexItem--flexGrowZero"
+    >
+      <div
         class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiSuperDatePicker__flexWrapper"
       >
         <div
@@ -1451,81 +1504,6 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                 </span>
               </button>
             </th>
-            <th
-              aria-live="polite"
-              aria-sort="none"
-              class="euiTableHeaderCell"
-              data-test-subj="tableHeaderCell_search_type_8"
-              role="columnheader"
-              scope="col"
-            >
-              <button
-                class="euiTableHeaderButton"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
-              >
-                <span
-                  class="euiTableCellContent"
-                >
-                  <span
-                    class="euiTableCellContent__text"
-                    title="Search Type"
-                  >
-                    Search Type
-                  </span>
-                </span>
-              </button>
-            </th>
-            <th
-              aria-live="polite"
-              aria-sort="none"
-              class="euiTableHeaderCell"
-              data-test-subj="tableHeaderCell_node_id_9"
-              role="columnheader"
-              scope="col"
-            >
-              <button
-                class="euiTableHeaderButton"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
-              >
-                <span
-                  class="euiTableCellContent"
-                >
-                  <span
-                    class="euiTableCellContent__text"
-                    title="Coordinator Node ID"
-                  >
-                    Coordinator Node ID
-                  </span>
-                </span>
-              </button>
-            </th>
-            <th
-              aria-live="polite"
-              aria-sort="none"
-              class="euiTableHeaderCell"
-              data-test-subj="tableHeaderCell_total_shards_10"
-              role="columnheader"
-              scope="col"
-            >
-              <button
-                class="euiTableHeaderButton"
-                data-test-subj="tableHeaderSortButton"
-                type="button"
-              >
-                <span
-                  class="euiTableCellContent"
-                >
-                  <span
-                    class="euiTableCellContent__text"
-                    title="Total Shards"
-                  >
-                    Total Shards
-                  </span>
-                </span>
-              </button>
-            </th>
           </tr>
         </thead>
         <tbody>
@@ -1534,6 +1512,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
           >
             <td
               class="euiTableRowCell"
+              id="id"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1557,6 +1536,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="type"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1580,6 +1560,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="query_count"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1594,6 +1575,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="timestamp"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1617,6 +1599,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="latency"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1631,6 +1614,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="cpu"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1645,6 +1629,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="memory"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1659,6 +1644,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="indices"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1675,66 +1661,13 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                 </span>
               </div>
             </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Search Type
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  query then fetch
-                </span>
-              </div>
-            </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Coordinator Node ID
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  UYKFun8PSAeJvkkt9cWf0w
-                </span>
-              </div>
-            </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Total Shards
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  1
-                </span>
-              </div>
-            </td>
           </tr>
           <tr
             class="euiTableRow"
           >
             <td
               class="euiTableRowCell"
+              id="id"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1758,6 +1691,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="type"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1781,6 +1715,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="query_count"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1795,6 +1730,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="timestamp"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1805,19 +1741,24 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                 class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
               >
                 <span
-                  class=""
+                  class="euiBadge euiBadge--hollow euiBadge--iconLeft"
+                  title="Aggregated"
                 >
-                  <button
-                    class="euiLink euiLink--primary"
-                    type="button"
+                  <span
+                    class="euiBadge__content"
                   >
-                    -
-                  </button>
+                    <span
+                      class="euiBadge__text"
+                    >
+                      Aggregated
+                    </span>
+                  </span>
                 </span>
               </div>
             </td>
             <td
               class="euiTableRowCell"
+              id="latency"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1832,6 +1773,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="cpu"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1846,6 +1788,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="memory"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1860,6 +1803,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="indices"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1872,61 +1816,20 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                 <span
                   class=""
                 >
-                  -
-                </span>
-              </div>
-            </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Search Type
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  -
-                </span>
-              </div>
-            </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Coordinator Node ID
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  -
-                </span>
-              </div>
-            </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Total Shards
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  -
+                  <span
+                    class="euiBadge euiBadge--hollow euiBadge--iconLeft"
+                    title="Aggregated"
+                  >
+                    <span
+                      class="euiBadge__content"
+                    >
+                      <span
+                        class="euiBadge__text"
+                      >
+                        Aggregated
+                      </span>
+                    </span>
+                  </span>
                 </span>
               </div>
             </td>
@@ -1936,6 +1839,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
           >
             <td
               class="euiTableRowCell"
+              id="id"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1959,6 +1863,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="type"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1982,6 +1887,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="query_count"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -1996,6 +1902,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="timestamp"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2019,6 +1926,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="latency"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2033,6 +1941,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="cpu"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2047,6 +1956,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="memory"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2061,6 +1971,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="indices"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2077,66 +1988,13 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                 </span>
               </div>
             </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Search Type
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  query then fetch
-                </span>
-              </div>
-            </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Coordinator Node ID
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  UYKFun8PSAeJvkkt9cWf0w
-                </span>
-              </div>
-            </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Total Shards
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  1
-                </span>
-              </div>
-            </td>
           </tr>
           <tr
             class="euiTableRow"
           >
             <td
               class="euiTableRowCell"
+              id="id"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2160,6 +2018,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="type"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2183,6 +2042,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="query_count"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2197,6 +2057,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="timestamp"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2220,6 +2081,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="latency"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2234,6 +2096,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="cpu"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2248,6 +2111,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="memory"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2262,6 +2126,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="indices"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2278,66 +2143,13 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                 </span>
               </div>
             </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Search Type
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  query then fetch
-                </span>
-              </div>
-            </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Coordinator Node ID
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  KINGun8PSAeJvkkt9cWf0w
-                </span>
-              </div>
-            </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Total Shards
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  1
-                </span>
-              </div>
-            </td>
           </tr>
           <tr
             class="euiTableRow"
           >
             <td
               class="euiTableRowCell"
+              id="id"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2361,6 +2173,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="type"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2384,6 +2197,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="query_count"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2398,6 +2212,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="timestamp"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2408,19 +2223,24 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                 class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
               >
                 <span
-                  class=""
+                  class="euiBadge euiBadge--hollow euiBadge--iconLeft"
+                  title="Aggregated"
                 >
-                  <button
-                    class="euiLink euiLink--primary"
-                    type="button"
+                  <span
+                    class="euiBadge__content"
                   >
-                    -
-                  </button>
+                    <span
+                      class="euiBadge__text"
+                    >
+                      Aggregated
+                    </span>
+                  </span>
                 </span>
               </div>
             </td>
             <td
               class="euiTableRowCell"
+              id="latency"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2435,6 +2255,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="cpu"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2449,6 +2270,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="memory"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2463,6 +2285,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="indices"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2475,61 +2298,20 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                 <span
                   class=""
                 >
-                  -
-                </span>
-              </div>
-            </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Search Type
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  -
-                </span>
-              </div>
-            </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Coordinator Node ID
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  -
-                </span>
-              </div>
-            </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Total Shards
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  -
+                  <span
+                    class="euiBadge euiBadge--hollow euiBadge--iconLeft"
+                    title="Aggregated"
+                  >
+                    <span
+                      class="euiBadge__content"
+                    >
+                      <span
+                        class="euiBadge__text"
+                      >
+                        Aggregated
+                      </span>
+                    </span>
+                  </span>
                 </span>
               </div>
             </td>
@@ -2539,6 +2321,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
           >
             <td
               class="euiTableRowCell"
+              id="id"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2562,6 +2345,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="type"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2585,6 +2369,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="query_count"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2599,6 +2384,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="timestamp"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2609,19 +2395,24 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                 class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
               >
                 <span
-                  class=""
+                  class="euiBadge euiBadge--hollow euiBadge--iconLeft"
+                  title="Aggregated"
                 >
-                  <button
-                    class="euiLink euiLink--primary"
-                    type="button"
+                  <span
+                    class="euiBadge__content"
                   >
-                    -
-                  </button>
+                    <span
+                      class="euiBadge__text"
+                    >
+                      Aggregated
+                    </span>
+                  </span>
                 </span>
               </div>
             </td>
             <td
               class="euiTableRowCell"
+              id="latency"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2636,6 +2427,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="cpu"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2650,6 +2442,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="memory"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2664,6 +2457,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="indices"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2676,61 +2470,20 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                 <span
                   class=""
                 >
-                  -
-                </span>
-              </div>
-            </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Search Type
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  -
-                </span>
-              </div>
-            </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Coordinator Node ID
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  -
-                </span>
-              </div>
-            </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Total Shards
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  -
+                  <span
+                    class="euiBadge euiBadge--hollow euiBadge--iconLeft"
+                    title="Aggregated"
+                  >
+                    <span
+                      class="euiBadge__content"
+                    >
+                      <span
+                        class="euiBadge__text"
+                      >
+                        Aggregated
+                      </span>
+                    </span>
+                  </span>
                 </span>
               </div>
             </td>
@@ -2740,6 +2493,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
           >
             <td
               class="euiTableRowCell"
+              id="id"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2763,6 +2517,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="type"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2786,6 +2541,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="query_count"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2800,6 +2556,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="timestamp"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2810,19 +2567,24 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                 class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
               >
                 <span
-                  class=""
+                  class="euiBadge euiBadge--hollow euiBadge--iconLeft"
+                  title="Aggregated"
                 >
-                  <button
-                    class="euiLink euiLink--primary"
-                    type="button"
+                  <span
+                    class="euiBadge__content"
                   >
-                    -
-                  </button>
+                    <span
+                      class="euiBadge__text"
+                    >
+                      Aggregated
+                    </span>
+                  </span>
                 </span>
               </div>
             </td>
             <td
               class="euiTableRowCell"
+              id="latency"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2837,6 +2599,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="cpu"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2851,6 +2614,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="memory"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2865,6 +2629,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="indices"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2877,61 +2642,20 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                 <span
                   class=""
                 >
-                  -
-                </span>
-              </div>
-            </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Search Type
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  -
-                </span>
-              </div>
-            </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Coordinator Node ID
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  -
-                </span>
-              </div>
-            </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Total Shards
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  -
+                  <span
+                    class="euiBadge euiBadge--hollow euiBadge--iconLeft"
+                    title="Aggregated"
+                  >
+                    <span
+                      class="euiBadge__content"
+                    >
+                      <span
+                        class="euiBadge__text"
+                      >
+                        Aggregated
+                      </span>
+                    </span>
+                  </span>
                 </span>
               </div>
             </td>
@@ -2941,6 +2665,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
           >
             <td
               class="euiTableRowCell"
+              id="id"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2964,6 +2689,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="type"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -2987,6 +2713,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="query_count"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -3001,6 +2728,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="timestamp"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -3011,19 +2739,24 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                 class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
               >
                 <span
-                  class=""
+                  class="euiBadge euiBadge--hollow euiBadge--iconLeft"
+                  title="Aggregated"
                 >
-                  <button
-                    class="euiLink euiLink--primary"
-                    type="button"
+                  <span
+                    class="euiBadge__content"
                   >
-                    -
-                  </button>
+                    <span
+                      class="euiBadge__text"
+                    >
+                      Aggregated
+                    </span>
+                  </span>
                 </span>
               </div>
             </td>
             <td
               class="euiTableRowCell"
+              id="latency"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -3038,6 +2771,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="cpu"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -3052,6 +2786,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="memory"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -3066,6 +2801,7 @@ exports[`QueryInsights Component renders the table with the correct columns and 
             </td>
             <td
               class="euiTableRowCell"
+              id="indices"
             >
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
@@ -3078,61 +2814,20 @@ exports[`QueryInsights Component renders the table with the correct columns and 
                 <span
                   class=""
                 >
-                  -
-                </span>
-              </div>
-            </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Search Type
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  -
-                </span>
-              </div>
-            </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Coordinator Node ID
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  -
-                </span>
-              </div>
-            </td>
-            <td
-              class="euiTableRowCell"
-            >
-              <div
-                class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
-              >
-                Total Shards
-              </div>
-              <div
-                class="euiTableCellContent euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
-              >
-                <span
-                  class=""
-                >
-                  -
+                  <span
+                    class="euiBadge euiBadge--hollow euiBadge--iconLeft"
+                    title="Aggregated"
+                  >
+                    <span
+                      class="euiBadge__content"
+                    >
+                      <span
+                        class="euiBadge__text"
+                      >
+                        Aggregated
+                      </span>
+                    </span>
+                  </span>
                 </span>
               </div>
             </td>

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -55,6 +55,6 @@ module.exports = {
     '^.+\\.(js|tsx?)$': '<rootDir>/../../src/dev/jest/babel_transform.js',
   },
   transformIgnorePatterns: [
-    '[/\\\\]node_modules(?![\\/\\\\](monaco-editor|react-monaco-editor|react-ace))[/\\\\].+\\.(js|ts|tsx)$',
+    '[/\\\\]node_modules(?![\\/\\\\](monaco-editor|react-monaco-editor|react-ace|query-string|decode-uri-component|split-on-first|filter-obj))[/\\\\].+\\.(js|ts|tsx)$',
   ],
 };


### PR DESCRIPTION
### Description
Implement a reusable column visibility system allowing users to show/hide table columns via a popover UI. Preferences persist in localStorage across sessions.

- Add useColumnVisibility hook for state management and persistence
- Add ColumnVisibilityPopover shared component
- Integrate into QueryInsights (TopN) and InflightQueries (Live) pages
- Add unit tests for hook and component
- Add integration tests for both pages

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
