### PR TITLE
Bump js-yaml to 4.3.0 to address CVE-2026-59869

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "form-data": "4.0.6",
     "sha.js": "^2.4.12",
     "min-document": "^2.19.1",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.0",
     "yaml": "^2.8.3",
     "minimatch": "^3.1.3",
     "lodash": "^4.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2547,10 +2547,10 @@ jest-util@30.4.1:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
-  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
+js-yaml@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
### Description

Bumps the `js-yaml` resolution from `4.2.0` to `4.3.0` to address **CVE-2026-59869**.

**Vulnerability:** js-yaml is affected by an inefficient-algorithmic-complexity issue (CWE-407, CVSS 3.1 = 7.5 High): parsing a document where a chain of mappings uses merge keys — each mapping merging the previous — causes **quadratic CPU time**, a denial-of-service vector. Affected ranges are `3.0.0–<3.15.0` and `4.0.0–<4.3.0`; fixed in **4.3.0** (and 3.15.0).

**Fix:** raise the `resolutions` floor to `^4.3.0` and update the lockfile to the patched release. js-yaml is a transitive dependency here (not imported directly), so pinning via `resolutions` forces the patched version across the whole tree.

This continues the pattern of the earlier js-yaml bump in #564 (which moved 4.1.1 → 4.2.0 for a different CVE); 4.3.0 is the next patched release in the 4.x line. Same single sub-dependency (`argparse ^2.0.1`), so the dependency tree is otherwise unchanged.

**Notes**
- `resolutions`-only change: the OSD monorepo `single_version_dependencies` check reads only `dependencies`/`devDependencies`, so this does not introduce a version-range conflict with root OSD (which pins `js-yaml ^4.1.1`; 4.3.0 satisfies it).
- Lockfile integrity hash verified against the registry tarball for js-yaml 4.3.0.

### Issues Resolved

Addresses CVE-2026-59869 (js-yaml quadratic-complexity DoS).

### Check List
- [x] All tests pass
- [x] No functional change — dependency version bump only
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
