### PR TITLE
Add flag to hide remote repository registration in configuration page

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -115,10 +115,17 @@ export const VALIDATION_LIMITS = {
 
 export interface ConfigSchema {
   wlm: { enabled: boolean };
+  // Controls whether users can register new S3 repositories from the remote exporter UI
+  remoteRepositoryRegistration: { enabled: boolean };
 }
 
 const DEFAULT_CONFIG: ConfigSchema = {
   wlm: { enabled: true },
+  remoteRepositoryRegistration: { enabled: true },
 };
 
 export const WLM_CONFIG: Readonly<ConfigSchema['wlm']> = Object.freeze({ ...DEFAULT_CONFIG.wlm });
+
+export const REMOTE_REPOSITORY_REGISTRATION_CONFIG: Readonly<
+  ConfigSchema['remoteRepositoryRegistration']
+> = Object.freeze({ ...DEFAULT_CONFIG.remoteRepositoryRegistration });

--- a/public/pages/Configuration/Configuration.test.tsx
+++ b/public/pages/Configuration/Configuration.test.tsx
@@ -10,6 +10,7 @@ import { MemoryRouter } from 'react-router-dom';
 import Configuration from './Configuration';
 import { DataSourceContext } from '../TopNQueries/TopNQueries';
 import { TIME_UNITS_TEXT, EXPORTER_TYPE } from '../../../common/constants';
+import * as constants from '../../../common/constants';
 import {
   validateTopNSize,
   validateWindowSize,
@@ -515,10 +516,43 @@ describe('Configuration Component', () => {
       await waitFor(() => {
         expect(screen.getByText('Register new')).toBeInTheDocument();
       });
+      // When registration is enabled the help text mentions registering a new repository.
+      expect(
+        screen.getByText('Select an existing repository or register a new one.')
+      ).toBeInTheDocument();
       fireEvent.click(screen.getByText('Register new'));
       await waitFor(() => {
         expect(screen.getByText('Register S3 repository')).toBeInTheDocument();
       });
+    });
+
+    it('should hide Register new when repository registration is disabled', async () => {
+      // Self-contained: flip the flag off, then restore it at the end so no shared mock is needed.
+      const flag = jest.replaceProperty(constants, 'REMOTE_REPOSITORY_REGISTRATION_CONFIG', {
+        enabled: false,
+      });
+      mockCoreStart.http.get.mockImplementation((url: string) => {
+        if (url === '/api/cat/plugins') {
+          return Promise.resolve({ ok: true, response: [{ component: 'repository-s3' }] });
+        }
+        if (url === '/api/snapshot/repositories') {
+          return Promise.resolve({ ok: true, response: { 'my-repo': { type: 's3' } } });
+        }
+        return Promise.resolve({ ok: true, response: {} });
+      });
+      renderConfiguration();
+      fireEvent.click(getRemoteToggle());
+      // The repository selector still renders (users can pick an existing repository)...
+      await waitFor(() => {
+        expect(screen.getByText('exporter.remote.repository')).toBeInTheDocument();
+      });
+      // ...but the registration entry point is gone, and the help text drops the "register" wording.
+      expect(screen.queryByText('Register new')).not.toBeInTheDocument();
+      expect(screen.getByText('Select an existing repository.')).toBeInTheDocument();
+      expect(
+        screen.queryByText('Select an existing repository or register a new one.')
+      ).not.toBeInTheDocument();
+      flag.restore();
     });
 
     it('should hide fields when toggle is turned off after being on', async () => {

--- a/public/pages/Configuration/Configuration.tsx
+++ b/public/pages/Configuration/Configuration.tsx
@@ -46,6 +46,7 @@ import {
   GROUP_BY_OPTIONS,
   EXPORTER_TYPES_LIST,
   EXPORTER_TYPE,
+  REMOTE_REPOSITORY_REGISTRATION_CONFIG,
 } from '../../../common/constants';
 import { QueryInsightsDataSourceMenu } from '../../components/DataSourcePicker';
 import { QueryInsightsDashboardsPluginStartDependencies } from '../../types';
@@ -749,7 +750,11 @@ const Configuration = ({
                     <EuiFlexItem>
                       <EuiFormRow
                         label="exporter.remote.repository"
-                        helpText="Select an existing repository or register a new one."
+                        helpText={
+                          REMOTE_REPOSITORY_REGISTRATION_CONFIG.enabled
+                            ? 'Select an existing repository or register a new one.'
+                            : 'Select an existing repository.'
+                        }
                         style={formRowPadding}
                         isInvalid={remoteEnabled && remoteRepository.trim() === ''}
                         error={
@@ -778,15 +783,17 @@ const Configuration = ({
                               data-test-subj="remote-exporter-repository"
                             />
                           </EuiFlexItem>
-                          <EuiFlexItem grow={false}>
-                            <EuiButton
-                              size="s"
-                              onClick={() => setIsRepoFlyoutOpen(true)}
-                              data-test-subj="register-repo-button"
-                            >
-                              Register new
-                            </EuiButton>
-                          </EuiFlexItem>
+                          {REMOTE_REPOSITORY_REGISTRATION_CONFIG.enabled && (
+                            <EuiFlexItem grow={false}>
+                              <EuiButton
+                                size="s"
+                                onClick={() => setIsRepoFlyoutOpen(true)}
+                                data-test-subj="register-repo-button"
+                              >
+                                Register new
+                              </EuiButton>
+                            </EuiFlexItem>
+                          )}
                         </EuiFlexGroup>
                       </EuiFormRow>
                     </EuiFlexItem>
@@ -878,7 +885,7 @@ const Configuration = ({
           </EuiFlexGroup>
         </EuiBottomBar>
       ) : null}
-      {isRepoFlyoutOpen && (
+      {REMOTE_REPOSITORY_REGISTRATION_CONFIG.enabled && isRepoFlyoutOpen && (
         <RegisterRepositoryFlyout
           core={core}
           dataSourceId={dataSource?.id}


### PR DESCRIPTION
### Description

Added a flag `remoteRepositoryRegistration.enabled` to control if users are allowed to register a new s3 repository from the remote exporter configuration UI. The default is enabled, but when it's disabled, the register new button is hidden and the flyout to register a new repository is gone as shown below. 

<img width="1499" height="726" alt="Screenshot 2026-07-22 at 5 41 04 PM" src="https://github.com/user-attachments/assets/68637b71-dc0f-41e5-b808-507aa212f9f0" />

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
